### PR TITLE
Add create_dir and delete_dir functions

### DIFF
--- a/src/__fs.gdn
+++ b/src/__fs.gdn
@@ -60,3 +60,36 @@ public fun working_directory(): Path {
 public fun set_working_directory(path: Path): Result<Unit, String> {
   __BUILTIN_IMPLEMENTATION
 }
+
+// Create a new directory at the specified path.
+//
+// If the directory already exists, an error is returned.
+//
+// ```
+// import "__fs.gdn" as fs
+// fs::create_dir(Path{ p: "/tmp/my_new_directory" })
+// ```
+public fun create_dir(path: Path): Result<Unit, String> {
+  __BUILTIN_IMPLEMENTATION
+}
+
+test create_dir {
+  create_dir(Path{ p: "/tmp/test_garden_create_dir" })
+}
+
+// Delete the directory at the specified path.
+//
+// The directory must be empty. If it contains files or subdirectories,
+// an error is returned.
+//
+// ```
+// import "__fs.gdn" as fs
+// fs::delete_dir(Path{ p: "/tmp/my_directory" })
+// ```
+public fun delete_dir(path: Path): Result<Unit, String> {
+  __BUILTIN_IMPLEMENTATION
+}
+
+test delete_dir {
+  delete_dir(Path{ p: "/tmp/test_garden_delete_dir" })
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3399,6 +3399,114 @@ fn eval_builtin_call(
                 env.push_value(Value::new(Value_::Integer(random_value)));
             }
         }
+        BuiltinFunctionKind::CreateDir => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(&arg_values[0], env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(receiver_pos.clone(), msg),
+                    ));
+                }
+            };
+
+            let path = PathBuf::from(path_s.clone());
+
+            let value = match std::fs::create_dir(&path) {
+                Ok(()) => Value::ok(Value::unit()),
+                Err(e) => {
+                    let s = Value::new(Value_::String(format!("{e} {path_s}")));
+                    Value::err(s)
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(value);
+            }
+        }
+        BuiltinFunctionKind::DeleteDir => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(&arg_values[0], env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(receiver_pos.clone(), msg),
+                    ));
+                }
+            };
+
+            let path = PathBuf::from(path_s.clone());
+
+            let value = match std::fs::remove_dir(&path) {
+                Ok(()) => Value::ok(Value::unit()),
+                Err(e) => {
+                    let s = Value::new(Value_::String(format!("{e} {path_s}")));
+                    Value::err(s)
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(value);
+            }
+        }
     }
 
     Ok(())

--- a/src/test_files/runtime/create_dir.gdn
+++ b/src/test_files/runtime/create_dir.gdn
@@ -1,0 +1,19 @@
+import "__fs.gdn" as fs
+
+{
+  let test_dir = Path{ p: "/tmp/test_garden_create_dir_runtime" }
+
+  // Create the directory
+  fs::create_dir(test_dir).or_throw()
+
+  // Verify it exists by listing the parent directory
+  let contents = fs::list_directory(Path{ p: "/tmp" }).or_throw()
+
+  // Clean up
+  fs::delete_dir(test_dir)
+
+  println("Directory created successfully")
+}
+
+// args: run
+// expected stdout: Directory created successfully

--- a/src/test_files/runtime/delete_dir.gdn
+++ b/src/test_files/runtime/delete_dir.gdn
@@ -1,0 +1,16 @@
+import "__fs.gdn" as fs
+
+{
+  let test_dir = Path{ p: "/tmp/test_garden_delete_dir_runtime" }
+
+  // Create a directory first
+  fs::create_dir(test_dir).or_throw()
+
+  // Delete the directory
+  fs::delete_dir(test_dir).or_throw()
+
+  println("Directory deleted successfully")
+}
+
+// args: run
+// expected stdout: Directory deleted successfully

--- a/src/values.rs
+++ b/src/values.rs
@@ -391,6 +391,8 @@ pub(crate) enum BuiltinFunctionKind {
     GetEnv,
     Keywords,
     RandomInt,
+    CreateDir,
+    DeleteDir,
 }
 
 impl BuiltinFunctionKind {
@@ -407,7 +409,9 @@ impl BuiltinFunctionKind {
             BuiltinFunctionKind::WriteFile
             | BuiltinFunctionKind::ListDirectory
             | BuiltinFunctionKind::WorkingDirectory
-            | BuiltinFunctionKind::SetWorkingDirectory => PathBuf::from("__fs.gdn"),
+            | BuiltinFunctionKind::SetWorkingDirectory
+            | BuiltinFunctionKind::CreateDir
+            | BuiltinFunctionKind::DeleteDir => PathBuf::from("__fs.gdn"),
             BuiltinFunctionKind::SourceForFun
             | BuiltinFunctionKind::SourceForMethod
             | BuiltinFunctionKind::SourceForType
@@ -453,6 +457,8 @@ impl Display for BuiltinFunctionKind {
             BuiltinFunctionKind::GetEnv => "get_env",
             BuiltinFunctionKind::Keywords => "keywords",
             BuiltinFunctionKind::RandomInt => "int",
+            BuiltinFunctionKind::CreateDir => "create_dir",
+            BuiltinFunctionKind::DeleteDir => "delete_dir",
         };
         write!(f, "{name}")
     }


### PR DESCRIPTION
Implemented two new built-in filesystem functions:
- create_dir: Creates a new directory at the specified path
- delete_dir: Deletes an empty directory at the specified path

Both functions return Result<Unit, String> and include:
- Sandbox enforcement for security
- Proper error handling with descriptive messages
- Runtime tests in src/test_files/runtime/
- Unit tests in src/__fs.gdn
- Documentation with usage examples

Changes:
- src/values.rs: Added CreateDir and DeleteDir enum variants
- src/eval.rs: Implemented execution logic for both functions
- src/__fs.gdn: Added public function signatures with tests
- src/test_files/runtime/: Added create_dir.gdn and delete_dir.gdn tests