### PR TITLE
Fix npm build failure for website

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ site-build:
     cp website/*.mp4 website/dist
 
     mkdir -p website/dist/static
-    cd website/static && npm run build
+    cd website/static && npm install && npm run build
     cp website/static/*.css website/dist/static
 
     mkdir -p website/dist/static/fonts


### PR DESCRIPTION
The site-build command was failing because it ran npm build without first installing dependencies. Added npm install before npm run build in the justfile to ensure node_modules exists before building.