### PR TITLE
Add GitHub action for Docker image build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,43 @@
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: playground/Dockerfile
+          tags: wilfred/garden-playground:latest
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push Docker image
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: playground/Dockerfile
+          tags: wilfred/garden-playground:latest
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -19,17 +22,18 @@ jobs:
         with:
           context: .
           file: playground/Dockerfile
-          tags: wilfred/garden-playground:latest
+          tags: ghcr.io/wilfred/garden-playground:latest
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -37,7 +41,7 @@ jobs:
         with:
           context: .
           file: playground/Dockerfile
-          tags: wilfred/garden-playground:latest
+          tags: ghcr.io/wilfred/garden-playground:latest
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This action builds the playground Docker image on all pushes and PRs. When pushing to the main branch, it also uploads the image to Docker Hub.

The workflow uses Docker BuildKit with GitHub Actions cache for faster builds.