### PR TITLE
Fix playground output styling to match snippets

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -123,7 +123,8 @@ pre > code {
 
 pre,
 code,
-.snippet-output {
+.snippet-output,
+#playground-output {
   font-family: monospace;
 }
 


### PR DESCRIPTION
The playground output wasn't using a monospace font while code snippets were. This makes the output consistent by adding #playground-output to the existing monospace font-family selector.