### PR TITLE
Fix test summary not displaying in playground

### DIFF
--- a/src/sandboxed_playground.rs
+++ b/src/sandboxed_playground.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_sandboxed_playground(src: &str, path: &Path, interrupted: Arc<
     let responses = match eval_toplevel_items(&vfs_path, &items, &mut env, &session) {
         Ok(summary) => {
             let mut items = vec![];
-            if !summary.diagnostics.is_empty() {
+            if !summary.tests.is_empty() {
                 items.push(PlaygroundResponse {
                     error: None,
                     value: Some(describe_tests(&env, &summary)),


### PR DESCRIPTION
The playground backend was checking `summary.diagnostics` instead of `summary.tests` when deciding whether to include the test summary in the response. This caused test summaries to only appear when there were diagnostics, not when there were actual tests.

Changed the condition from `!summary.diagnostics.is_empty()` to `!summary.tests.is_empty()` so the test summary appears whenever tests are present in the code snippet.