### PR TITLE
Add code completion for local variables

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -7,7 +7,7 @@ use crate::checks::type_checker::check_types;
 use crate::env::Env;
 use crate::eval::load_toplevel_items;
 use crate::garden_type::Type;
-use crate::parser::ast::{AstId, Expression_, IdGenerator};
+use crate::parser::ast::{AstId, Expression_, IdGenerator, SymbolName};
 use crate::parser::parse_toplevel_items;
 use crate::pos_to_id::{find_expr_of_id, find_item_at};
 use crate::types::TypeDef;
@@ -44,6 +44,18 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) {
                     &meth_sym.name.text
                 };
                 print_methods(&env, recv_ty, prefix);
+                return;
+            }
+            Expression_::Variable(sym) => {
+                let prefix = if sym.name.is_placeholder() {
+                    ""
+                } else {
+                    &sym.name.text
+                };
+                if let Some(bindings) = summary.id_to_bindings.get(expr_id) {
+                    print_local_variables(bindings, prefix);
+                }
+                return;
             }
             _ => {}
         }
@@ -56,6 +68,26 @@ struct CompletionItem {
     name: String,
     /// Extra information shown immediately after the completion item.
     suffix: String,
+}
+
+fn print_local_variables(bindings: &[(SymbolName, Type)], prefix: &str) {
+    let mut items: Vec<CompletionItem> = vec![];
+
+    for (name, ty) in bindings {
+        if !name.text.starts_with(prefix) {
+            continue;
+        }
+
+        items.push(CompletionItem {
+            name: name.text.clone(),
+            suffix: format!(": {}", ty),
+        });
+    }
+
+    items.sort();
+    for item in items {
+        println!("{}", serde_json::to_string(&item).unwrap());
+    }
 }
 
 fn print_methods(env: &Env, recv_ty: &Type, prefix: &str) {

--- a/src/test_files/complete/local_variable.gdn
+++ b/src/test_files/complete/local_variable.gdn
@@ -1,0 +1,12 @@
+fun example() {
+    let foo = 1
+    let foobar = "hello"
+    let bar = true
+    fo
+//   ^
+}
+
+// args: complete
+// expected stdout:
+// {"name":"foo","suffix":": Int"}
+// {"name":"foobar","suffix":": String"}

--- a/src/test_files/complete/local_variable_with_params.gdn
+++ b/src/test_files/complete/local_variable_with_params.gdn
@@ -1,0 +1,10 @@
+fun example(first_arg: Int, second_arg: String) {
+    let first_local = True
+    fir
+//    ^
+}
+
+// args: complete
+// expected stdout:
+// {"name":"first_arg","suffix":": Int"}
+// {"name":"first_local","suffix":": Bool"}


### PR DESCRIPTION
Track local bindings in the type checker summary and use them to provide completions for variable names. This includes function parameters and let-bound variables that are in scope.