### PR TITLE
Fix code completion with LSP in editor

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 
 use crate::checks::type_checker::check_types;
@@ -23,13 +23,25 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) {
     let ns = env.get_or_create_namespace(path);
     load_toplevel_items(&items, &mut env, ns.clone());
 
-    let ids_at_pos = find_item_at(&items, offset, offset);
+    // Check both offset and offset-1 to handle cursor positions at
+    // the end of expressions (e.g., right after a dot in "foo.").
+    let mut ids_at_pos = vec![];
+    if offset > 0 {
+        ids_at_pos.extend(find_item_at(&items, offset - 1, offset - 1));
+    }
+    ids_at_pos.extend(find_item_at(&items, offset, offset));
     let summary = check_types(&vfs_path, &items, &env, ns);
 
+    let mut seen_expr_ids = FxHashSet::default();
     for id in ids_at_pos.iter().rev() {
         let AstId::Expr(expr_id) = id else {
             continue;
         };
+        // Skip duplicate expression IDs that can occur when checking both
+        // offset and offset-1.
+        if !seen_expr_ids.insert(*expr_id) {
+            continue;
+        }
         let Some(expr) = find_expr_of_id(&items, *expr_id) else {
             break;
         };


### PR DESCRIPTION
When the user types "foo." and the cursor is right after the dot, completions weren't being shown. This was because the completion logic only checked for expressions at the exact cursor offset, but the DotAccess expression's position ends at the dot (exclusive end), so the cursor position wasn't "inside" it.

The fix follows the same pattern used in get_definition(): check both offset and offset-1 to find expressions at the cursor boundary. Also added deduplication to avoid returning duplicate completions when the same expression is found at both offsets.