### PR TITLE
Add spaces before type annotations

### DIFF
--- a/src/test_files/format/type_annotation_spacing.gdn
+++ b/src/test_files/format/type_annotation_spacing.gdn
@@ -1,0 +1,44 @@
+fun add_one(i:Int):Int {
+  i + 1
+}
+
+let x:String = "hello"
+let y:Int = 42
+
+struct Person {
+  name:String,
+  age:Int,
+}
+
+fun multi_param(a:Int, b:String, c:Bool):Unit {}
+
+let items:List<String> = []
+
+fun tuple_type(x:(Int, String)):Unit {}
+
+// Namespace separator should be preserved
+fs::list_directory(path)
+
+// args: format
+// expected stdout:
+// fun add_one(i: Int): Int {
+//   i + 1
+// }
+// 
+// let x: String = "hello"
+// let y: Int = 42
+// 
+// struct Person {
+//   name: String,
+//   age: Int,
+// }
+// 
+// fun multi_param(a: Int, b: String, c: Bool): Unit {}
+// 
+// let items: List<String> = []
+// 
+// fun tuple_type(x: (Int, String)): Unit {}
+// 
+// // Namespace separator should be preserved
+// fs::list_directory(path)
+


### PR DESCRIPTION
The formatter now ensures there's always a space after colons in type annotations, transforming `x:Int` to `x: Int`. This improves code readability and consistency.

Implementation details:
- Extended the format function to include a new phase for type annotation spacing
- Added fix_type_annotation_spacing function that tokenizes the source and finds colons followed by type names
- Type names are identified by starting with an uppercase letter
- Namespace separators (::) are explicitly excluded
- Existing correctly-formatted code is preserved unchanged