### PR TITLE
Style stdout output differently from evaluated values

### DIFF
--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -135,18 +135,20 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
       }
 
       if (!hasError) {
-        let output = "";
+        snippetDiv.innerHTML = "";
+
         if (stdoutParts.length > 0) {
-          output = stdoutParts.join("");
+          const stdoutDiv = document.createElement("div");
+          stdoutDiv.className = "output-stdout";
+          stdoutDiv.textContent = stdoutParts.join("");
+          snippetDiv.appendChild(stdoutDiv);
         }
         if (valueParts.length > 0) {
-          if (output.length > 0) {
-            output += "\n";
-          }
-          output += valueParts.join("\n");
+          const valueDiv = document.createElement("div");
+          valueDiv.className = "output-value";
+          valueDiv.textContent = valueParts.join("\n");
+          snippetDiv.appendChild(valueDiv);
         }
-
-        snippetDiv.innerHTML = output;
       }
     })
     .catch((error: unknown) => {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -284,6 +284,15 @@ textarea {
   border-top: 3px solid #00000030;
 }
 
+.output-stdout {
+  color: #666;
+  white-space: pre;
+}
+
+.output-value {
+  white-space: pre;
+}
+
 .snippet {
   border: 3px solid #00000030;
   border-radius: 5px;


### PR DESCRIPTION
Wrap stdout output and evaluated values in separate div elements with distinct CSS classes. Stdout is now displayed in a gray color (#666) to visually distinguish it from evaluated values which remain in the default text color.