### PR TITLE
Warn about unused literal expressions in blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Garden now has an LSP server providing go-to-definition, code
 completion, quickfixes and basic formatting. You can start it with
 `garden lsp`.
 
+`garden check` now warns about unused literal values.
+
 ## Syntax
 
 Documentation is now written with triple slashes, e.g. `///`, to

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -5,6 +5,7 @@ mod struct_fields;
 pub mod type_checker;
 mod unreachable;
 mod unused_defs;
+mod unused_literals;
 mod unused_vars;
 
 use std::cell::RefCell;
@@ -24,6 +25,7 @@ use self::duplicates::check_duplicates;
 use self::hints::check_hints;
 use self::struct_fields::check_struct_fields;
 use self::type_checker::check_types;
+use self::unused_literals::check_unused_literals;
 use self::unused_vars::check_unused_variables;
 
 /// Check toplevel items in a fresh environment, without any
@@ -54,6 +56,7 @@ pub(crate) fn check_toplevel_items_in_env(
     let mut diagnostics = vec![];
 
     diagnostics.extend(check_unused_variables(items));
+    diagnostics.extend(check_unused_literals(items, env));
     diagnostics.extend(check_struct_fields(items, env));
     diagnostics.extend(check_hints(items, env));
 

--- a/src/checks/unused_literals.rs
+++ b/src/checks/unused_literals.rs
@@ -1,0 +1,101 @@
+use crate::diagnostics::{Autofix, Diagnostic, Severity};
+use crate::env::Env;
+use crate::parser::ast::{Expression, Expression_, ToplevelItem};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::diagnostics::MessagePart::*;
+use crate::parser::position::Position;
+use crate::parser::visitor::Visitor;
+
+pub(crate) fn check_unused_literals(items: &[ToplevelItem], env: &Env) -> Vec<Diagnostic> {
+    let mut visitor = UnusedLiteralVisitor::new(env);
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics()
+}
+
+struct UnusedLiteralVisitor<'a> {
+    unused_literals: Vec<Diagnostic>,
+    env: &'a Env,
+}
+
+impl<'a> UnusedLiteralVisitor<'a> {
+    fn new(env: &'a Env) -> UnusedLiteralVisitor<'a> {
+        UnusedLiteralVisitor {
+            unused_literals: vec![],
+            env,
+        }
+    }
+
+    fn diagnostics(mut self) -> Vec<Diagnostic> {
+        self.unused_literals.sort_by_key(|d| d.position.clone());
+        self.unused_literals
+    }
+
+    fn check_expression(&mut self, expr: &Expression) {
+        // Only check expressions whose values are not used
+        if expr.value_is_used {
+            return;
+        }
+
+        let is_literal = matches!(
+            &expr.expr_,
+            Expression_::IntLiteral(_)
+                | Expression_::StringLiteral(_)
+                | Expression_::ListLiteral(_)
+                | Expression_::DictLiteral(_)
+                | Expression_::TupleLiteral(_)
+                | Expression_::StructLiteral(_, _)
+        );
+
+        if is_literal {
+            let fix = Autofix {
+                description: "Remove unused value".to_owned(),
+                position: self.get_line_position(&expr.position),
+                new_text: String::new(),
+            };
+
+            self.unused_literals.push(Diagnostic {
+                notes: vec![],
+                severity: Severity::Warning,
+                message: ErrorMessage(vec![Text("Unused value.".to_owned())]),
+                position: expr.position.clone(),
+                fixes: vec![fix],
+            });
+        }
+    }
+
+    fn get_line_position(&self, position: &Position) -> Position {
+        let Some(src) = self.env.vfs.file_src(&position.vfs_path) else {
+            // If we can't get the source, just return the original position
+            return position.clone();
+        };
+
+        // Find the start of the line (including leading whitespace)
+        let line_start = src[..position.start_offset]
+            .rfind('\n')
+            .map(|pos| pos + 1)
+            .unwrap_or(0);
+
+        // Find the end of the line (including the newline if present)
+        let line_end = src[position.end_offset..]
+            .find('\n')
+            .map(|pos| position.end_offset + pos + 1)
+            .unwrap_or(src.len());
+
+        // Create a new position spanning the entire line
+        let mut line_position = position.clone();
+        line_position.start_offset = line_start;
+        line_position.end_offset = line_end;
+        line_position.column = 0;
+
+        line_position
+    }
+}
+
+impl<'a> Visitor for UnusedLiteralVisitor<'a> {
+    fn visit_expr(&mut self, expr: &Expression) {
+        self.check_expression(expr);
+        self.visit_expr_(&expr.expr_);
+    }
+}

--- a/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
+++ b/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
@@ -14,3 +14,13 @@ fun add_one(i: Int): Int {
 }
 
 // args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: Unused value.
+// --| src/test_files/check/ambiguity_fun_call_or_tuple.gdn:6:3
+//  4|   // Definitely a tuple, because there's whitespace before it.
+//  5|   let _y = x
+//  6|   (10, 11)
+//  7|   ^^^^^^^^
+//  8|   // Should be parsed as a call, not an if followed by a tuple (5).
+

--- a/src/test_files/check/type_error_if_without_else.gdn
+++ b/src/test_files/check/type_error_if_without_else.gdn
@@ -7,6 +7,14 @@ public fun foo(b: Bool): Int {
 // args: check
 // expected exit status: 1
 // expected stdout:
+// Warning: Unused value.
+// -| src/test_files/check/type_error_if_without_else.gdn:3:9
+// 1| public fun foo(b: Bool): Int {
+// 2|     if b {
+// 3|         123
+// 4|     }   ^^^
+// 5| }
+// 
 // Error: Expected `Unit`, but got `Int`.
 // -| src/test_files/check/type_error_if_without_else.gdn:3:9
 // 1| public fun foo(b: Bool): Int {

--- a/src/test_files/check/unused_literal.gdn
+++ b/src/test_files/check/unused_literal.gdn
@@ -1,0 +1,46 @@
+public fun example() {
+  42
+  "hello"
+  [1, 2, 3]
+  Dict[]
+
+  let x = 10
+  x
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: Unused value.
+// --| src/test_files/check/unused_literal.gdn:2:3
+//  1| public fun example() {
+//  2|   42
+//   |   ^^
+//  3|   "hello"
+//  4|   [1, 2, 3]
+// 
+// Warning: Unused value.
+// --| src/test_files/check/unused_literal.gdn:3:3
+//  1| public fun example() {
+//  2|   42
+//  3|   "hello"
+//   |   ^^^^^^^
+//  4|   [1, 2, 3]
+//  5|   Dict[]
+// 
+// Warning: Unused value.
+// --| src/test_files/check/unused_literal.gdn:4:3
+//  2|   42
+//  3|   "hello"
+//  4|   [1, 2, 3]
+//   |   ^^^^^^^^^
+//  5|   Dict[]
+// 
+// Warning: Unused value.
+// --| src/test_files/check/unused_literal.gdn:5:3
+//  3|   "hello"
+//  4|   [1, 2, 3]
+//  5|   Dict[]
+//  6|   ^^^^^^
+//  7|   let x = 10
+

--- a/src/test_files/check_fix/unused_value.gdn
+++ b/src/test_files/check_fix/unused_value.gdn
@@ -1,0 +1,11 @@
+public fun nums(): List<Int> {
+  [1, 2]
+  [3, 4]
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// public fun nums(): List<Int> {
+//   [3, 4]
+// }
+


### PR DESCRIPTION
The check command now warns when literal expressions (numbers, strings, lists, dicts, tuples, or struct literals) appear in blocks but their values are not used. This helps identify potentially unintended code where a literal is written but has no effect.

Includes golden test coverage for the new warning.