### PR TITLE
Fix spacing in single line block formatting

### DIFF
--- a/src/test_files/format/single_line.gdn
+++ b/src/test_files/format/single_line.gdn
@@ -1,8 +1,14 @@
 fun foo() { x }
 fun bar() { if True { y } else { z } }
+fun extra_spaces() {  a  }
+fun no_spaces() {b}
+fun mixed() {  c}
 
 // args: format
 // expected stdout:
 // fun foo() { x }
 // fun bar() { if True { y } else { z } }
+// fun extra_spaces() { a }
+// fun no_spaces() { b }
+// fun mixed() { c }
 


### PR DESCRIPTION
Update the formatter to normalize spacing inside single-line blocks. For example, `{  y  }` becomes `{ y }` and `{z}` becomes `{ z }`.

This adds span-based edits that work alongside the existing line-based indentation edits. Span edits are applied in reverse order to avoid offset invalidation.