### PR TITLE
Improve error message for unused `main` functions

### DIFF
--- a/src/checks/unused_defs.rs
+++ b/src/checks/unused_defs.rs
@@ -46,11 +46,25 @@ pub(crate) fn check_unused_defs(items: &[ToplevelItem], summary: &TCSummary) -> 
 
         // Report unreachable functions that have no callers at all.
         if !all_called_defs.contains(&item_id) {
-            diagnostics.push(Diagnostic {
-                message: ErrorMessage(vec![
+            let message = if symbol.name.text == "main" {
+                ErrorMessage(vec![
+                    msgcode!("{}", symbol.name),
+                    msgtext!(" is never called. Garden does not treat "),
+                    msgcode!("main"),
+                    msgtext!(" functions specially. To run code, write expressions directly in the file (e.g., "),
+                    msgcode!("println(\"Hello\")"),
+                    msgtext!("), or call "),
+                    msgcode!("main()"),
+                    msgtext!(" from a top-level block."),
+                ])
+            } else {
+                ErrorMessage(vec![
                     msgcode!("{}", symbol.name),
                     msgtext!(" is never called."),
-                ]),
+                ])
+            };
+            diagnostics.push(Diagnostic {
+                message,
                 position: symbol.position.clone(),
                 notes: vec![],
                 severity: Severity::Warning,
@@ -88,11 +102,25 @@ pub(crate) fn check_unused_defs(items: &[ToplevelItem], summary: &TCSummary) -> 
                     .filter_map(|def_id| *def_id)
                     .collect();
                 if reachable_from_item_ids.is_disjoint(&already_covered_ids) {
-                    diagnostics.push(Diagnostic {
-                        message: ErrorMessage(vec![
+                    let message = if symbol.name.text == "main" {
+                        ErrorMessage(vec![
+                            msgcode!("{}", &symbol.name),
+                            msgtext!(" is never called. Garden does not treat "),
+                            msgcode!("main"),
+                            msgtext!(" functions specially. To run code, write expressions directly in the file (e.g., "),
+                            msgcode!("println(\"Hello\")"),
+                            msgtext!("), or call "),
+                            msgcode!("main()"),
+                            msgtext!(" from a top-level block."),
+                        ])
+                    } else {
+                        ErrorMessage(vec![
                             msgcode!("{}", &symbol.name),
                             msgtext!(" is never called."),
-                        ]),
+                        ])
+                    };
+                    diagnostics.push(Diagnostic {
+                        message,
                         position: symbol.position.clone(),
                         notes: vec![],
                         severity: Severity::Warning,

--- a/src/test_files/check/unused_main.gdn
+++ b/src/test_files/check/unused_main.gdn
@@ -1,0 +1,14 @@
+fun main() {
+  println("Hello World")
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: `main` is never called. Garden does not treat `main` functions specially. To run code, write expressions directly in the file (e.g., `println("Hello")`), or call `main()` from a top-level block.
+// -| src/test_files/check/unused_main.gdn:1:5
+// 1| fun main() {
+//  |     ^^^^
+// 2|   println("Hello World")
+// 3| }
+


### PR DESCRIPTION
## Summary
This PR improves the diagnostic message shown when a `main` function is defined but never called, clarifying that Garden does not treat `main` functions specially and providing guidance on how to run code.

## Changes
- **Enhanced error messages**: When an unused `main` function is detected, the diagnostic now includes a detailed explanation that Garden doesn't automatically execute `main` functions, along with examples of how to run code instead (writing expressions directly in the file or calling `main()` from a top-level block)
- **Applied to two locations**: Updated both the unreachable function check and the unused definition check in `unused_defs.rs` to provide consistent messaging
- **Added test case**: Created `unused_main.gdn` test file to verify the new error message is displayed correctly

## Implementation Details
The change conditionally generates different `ErrorMessage` variants based on whether the unused function is named `main`. The generic "is never called" message is used for other functions, while `main` functions receive the more informative message with actionable guidance.