### PR TITLE
Add -c flag to run Garden code directly from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +340,7 @@ dependencies = [
  "normalize-path",
  "ordered-float",
  "owo-colors",
+ "predicates",
  "rand",
  "regex",
  "rustc-hash",
@@ -635,6 +645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "normalize-path"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,7 +715,10 @@ checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ path = "src/main.rs"
 assert_cmd = "2.0.14"
 escargot = "0.5"
 goldentests = "1.1.1"
+predicates = "3"
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
## Summary
This PR adds support for executing Garden code directly from the command line using a `-c` flag, without requiring a file. This is useful for quick testing and scripting scenarios.

## Key Changes
- Added `-c` flag to the `Run` command that accepts inline Garden code
- Made the file `path` argument optional (required only when `-c` is not provided)
- Implemented validation to ensure exactly one of `-c` or `path` is specified
- Added synthetic path `/<cli>` for code provided via `-c` flag
- Added `predicates` crate as a dev dependency for improved test assertions
- Added three new integration tests:
  - `test_run_with_c_flag`: Verifies `-c` flag executes code correctly
  - `test_run_c_flag_with_path_errors`: Ensures error when both `-c` and path are provided
  - `test_run_without_c_or_path_errors`: Ensures error when neither `-c` nor path are provided

## Implementation Details
- The `Run` command now uses `Option<String>` for the `-c` flag and `Option<PathBuf>` for the path
- Logic handles four cases: code only, file only, both (error), or neither (error)
- Uses `BAD_CLI_REQUEST_EXIT_CODE` for validation errors
- Tests use the `predicates` crate for more expressive assertion matching on stderr output