### PR TITLE
Document inline code execution feature in Garden CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ generally include a new test file.
 # Running Garden Programs
 - ./target/debug/garden check yourfile.gdn: Check the test program named yourfile.gdn
 - ./target/debug/garden run yourfile.gdn: Run the code in yourfile.gdn.
+- ./target/debug/garden run -c 'println("Hello")': Run a code snippet directly without a file.
 - ./target/debug/garden test yourfile.gdn: Run unit tests in yourfile.gdn.
 
 To generate target/debug/garden use `cargo build`. This separation


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md documentation to include information about the `-c` flag for running Garden code snippets directly from the command line without requiring a file.

## Changes
- Added documentation for the `garden run -c` command that allows executing inline code snippets
- Example provided: `./target/debug/garden run -c 'println("Hello")'`
- This feature enables quick testing and experimentation with Garden code without creating temporary files

## Details
This documentation update reflects an existing or newly implemented capability in the Garden CLI that allows developers to run single-line or short code snippets directly via the command line interface, similar to how many scripting languages (Python, Ruby, etc.) support the `-c` flag for inline code execution.