### PR TITLE
Format multiline function call arguments with proper indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Added `Dict::remove()`.
 
 ## CLI
 
-Added a `format` subcommand that fixes indentation in Garden files.
+Added a `format` subcommand that fixes indentation in Garden files. The
+formatter now indents multiline function call arguments by one level.
 
 Added `--fix` to `garden check`.
 

--- a/src/test_files/format/multiline_function_call.gdn
+++ b/src/test_files/format/multiline_function_call.gdn
@@ -1,0 +1,60 @@
+// Before formatting - arguments not indented
+fun test_call() {
+foo(
+1,
+2,
+3
+)
+}
+
+// Before formatting - nested function call
+fun test_nested() {
+bar(
+baz(
+4,
+5
+),
+6
+)
+}
+
+// Before formatting - already indented more than needed
+fun test_already_indented() {
+qux(
+    10,
+      20,
+  30
+)
+}
+
+// args: format
+// expected stdout:
+// // Before formatting - arguments not indented
+// fun test_call() {
+//   foo(
+//     1,
+//     2,
+//     3
+//   )
+// }
+// 
+// // Before formatting - nested function call
+// fun test_nested() {
+//   bar(
+//     baz(
+//       4,
+//       5
+//     ),
+//     6
+//   )
+// }
+// 
+// // Before formatting - already indented more than needed
+// fun test_already_indented() {
+//   qux(
+//     10,
+//       20,
+//     30
+//   )
+// }
+


### PR DESCRIPTION
## Summary
Added support for formatting multiline function call arguments in Garden files. Arguments that span multiple lines are now indented one level deeper than the function call itself, and closing parentheses are aligned with the call expression.

## Changes
- **New formatter logic**: Added `fix_function_argument_indentation()` method to handle indentation of multiline function calls and method calls
- **Enhanced visitor**: Implemented custom `visit_expr_()` method to intercept `Call` and `MethodCall` expressions and apply special formatting rules
- **Indentation rules**:
  - Arguments on lines after the opening parenthesis are indented one level deeper than the call
  - Closing parenthesis is aligned with the opening call expression
  - Existing deeper indentation is preserved (formatter doesn't reduce indentation)
  - Nested function calls are properly indented relative to their parent
- **Test coverage**: Added comprehensive test file `multiline_function_call.gdn` covering:
  - Basic multiline function calls
  - Nested function calls
  - Already-indented arguments (preserves deeper indentation)

## Implementation Details
- Uses `processed_lines` tracking to avoid processing the same line twice
- Respects current depth context for nested expressions
- Only adjusts indentation when current indentation is less than target (non-destructive)
- Handles both regular function calls and method calls uniformly