### PR TITLE
Improve error message for tuple field access syntax

### DIFF
--- a/src/test_files/parser/tuple_field_access.gdn
+++ b/src/test_files/parser/tuple_field_access.gdn
@@ -1,0 +1,105 @@
+fun foo(p) {
+    p.0
+    p.1
+}
+
+// args: dump-ast
+// expected stdout:
+// Fun(
+//     Symbol"foo",
+//     FunInfo {
+//         pos: Position { ... },
+//         doc_comment: None,
+//         name_sym: Some(
+//             Symbol"foo",
+//         ),
+//         item_id: Some(
+//             ToplevelItemId(
+//                 12,
+//             ),
+//         ),
+//         type_params: [],
+//         params: ParenthesizedParameters {
+//             open_paren: Position { ... },
+//             params: [
+//                 SymbolWithHint {
+//                     symbol: Symbol"p",
+//                     hint: None,
+//                 },
+//             ],
+//             close_paren: Position { ... },
+//         },
+//         return_hint: None,
+//         body: Block {
+//             open_brace: Position { ... },
+//             exprs: [
+//                 Expression {
+//                     position: Position { ... },
+//                     expr_: DotAccess(
+//                         Expression {
+//                             position: Position { ... },
+//                             expr_: Variable(
+//                                 Symbol"p",
+//                             ),
+//                             value_is_used: true,
+//                             id: SyntaxId(3),
+//                         },
+//                         Symbol"__placeholder",
+//                     ),
+//                     value_is_used: false,
+//                     id: SyntaxId(5),
+//                 },
+//                 Expression {
+//                     position: Position { ... },
+//                     expr_: IntLiteral(
+//                         0,
+//                     ),
+//                     value_is_used: false,
+//                     id: SyntaxId(6),
+//                 },
+//                 Expression {
+//                     position: Position { ... },
+//                     expr_: DotAccess(
+//                         Expression {
+//                             position: Position { ... },
+//                             expr_: Variable(
+//                                 Symbol"p",
+//                             ),
+//                             value_is_used: true,
+//                             id: SyntaxId(8),
+//                         },
+//                         Symbol"__placeholder",
+//                     ),
+//                     value_is_used: false,
+//                     id: SyntaxId(10),
+//                 },
+//                 Expression {
+//                     position: Position { ... },
+//                     expr_: IntLiteral(
+//                         1,
+//                     ),
+//                     value_is_used: true,
+//                     id: SyntaxId(11),
+//                 },
+//             ],
+//             close_brace: Position { ... },
+//         },
+//     },
+//     CurrentFile,
+// )
+
+// expected stderr:
+// Error: Parse error: Garden does not support tuple field access like `.0` or `.1`. Use destructuring instead, for example: `let (x, y) = value`.
+// ---| src/test_files/parser/tuple_field_access.gdn:2:6
+//   1| fun foo(p) {
+//   2|     p.0
+//    |      ^
+//   3|     p.1
+//   4| }
+// Error: Parse error: Garden does not support tuple field access like `.0` or `.1`. Use destructuring instead, for example: `let (x, y) = value`.
+// ---| src/test_files/parser/tuple_field_access.gdn:3:6
+//   1| fun foo(p) {
+//   2|     p.0
+//   3|     p.1
+//   4| }    ^
+


### PR DESCRIPTION
## Summary
Improved the parser error message when users attempt to use tuple-like field access syntax (e.g., `foo.0` or `foo.1`), which is not supported in Garden. The new error message now explicitly explains that destructuring should be used instead.

## Changes
- **Enhanced error detection**: Modified `parse_symbol()` in `src/parser.rs` to detect when a numeric literal is used after a dot operator
- **Better error messaging**: When tuple field access is attempted, users now see a helpful error message with a concrete example of how to use destructuring instead
- **Conditional messaging**: The improved error message only appears when parsing method/field names (contains "method" in description) to avoid false positives
- **Test coverage**: Added `src/test_files/parser/tuple_field_access.gdn` to verify the error message is displayed correctly for both `.0` and `.1` access patterns

## Implementation Details
The fix checks if the token after a dot matches `INTEGER_RE` and the description context contains "method". When both conditions are true, it displays the tuple-specific error message with formatted code examples. Otherwise, it falls back to the generic "Expected a {description} after this" message.