### PR TITLE
Add helpful message about fixable issues in syntax check output

### DIFF
--- a/src/syntax_check.rs
+++ b/src/syntax_check.rs
@@ -187,6 +187,14 @@ pub(crate) fn check(
     }
 
     if !diagnostics.is_empty() {
+        if !json && !all_fixes.is_empty() {
+            let num_fixable = all_fixes.len();
+            eprintln!(
+                "\n{} {} can be fixed automatically (use `--fix`).",
+                num_fixable,
+                if num_fixable == 1 { "issue" } else { "issues" }
+            );
+        }
         std::process::exit(1);
     }
 }

--- a/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
+++ b/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
@@ -24,3 +24,6 @@ fun add_one(i: Int): Int {
 //  7|   ^^^^^^^^
 //  8|   // Should be parsed as a call, not an if followed by a tuple (5).
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/bound_but_unused.gdn
+++ b/src/test_files/check/bound_but_unused.gdn
@@ -8,3 +8,6 @@ public fun foo(x: Int) {}
 // 1| public fun foo(x: Int) {}
 // 2|                ^
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/let_shadow_lambda.gdn
+++ b/src/test_files/check/let_shadow_lambda.gdn
@@ -22,3 +22,6 @@
 //  4|         ^
 //  5|     let f = fun() {
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/type_error_if_without_else.gdn
+++ b/src/test_files/check/type_error_if_without_else.gdn
@@ -34,3 +34,6 @@ public fun foo(b: Bool): Int {
 //  | ^^^^^
 // 5| }
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/unused_import.gdn
+++ b/src/test_files/check/unused_import.gdn
@@ -8,3 +8,6 @@ import "__fs.gdn" as fs
 // 1| import "__fs.gdn" as fs
 // 2|                      ^^
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/unused_literal.gdn
+++ b/src/test_files/check/unused_literal.gdn
@@ -44,3 +44,6 @@ public fun example() {
 //  6|   ^^^^^^
 //  7|   let x = 10
 
+// expected stderr:
+// 4 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/unused_shadowed_var.gdn
+++ b/src/test_files/check/unused_shadowed_var.gdn
@@ -27,3 +27,6 @@ public fun f(): Int {
 //  7|       ^
 //  8|   let x = 1
 
+// expected stderr:
+// 2 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/unused_type_param.gdn
+++ b/src/test_files/check/unused_type_param.gdn
@@ -11,3 +11,6 @@ public method w_is_unused<T, U, V, W, _X>(this: List<T>, _x: U, _y: Int) {
 // 2|   let _v: V = throw("abc")         ^
 // 3| }
 
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).
+


### PR DESCRIPTION
## Summary
This PR adds a user-friendly message to the syntax checker that informs users when there are automatically fixable issues, along with instructions on how to fix them using the `--fix` flag.

## Changes
- **src/syntax_check.rs**: Added a new informational message that displays when diagnostics are found and fixable issues exist. The message:
  - Only shows in non-JSON output mode (respects `--json` flag)
  - Displays the count of fixable issues with proper singular/plural grammar
  - Provides clear guidance to use the `--fix` flag
  - Prints to stderr before exiting with code 1

- **Test files**: Updated 8 test files to include expected stderr output that validates the new message is displayed correctly:
  - `ambiguity_fun_call_or_tuple.gdn` (1 fixable issue)
  - `bound_but_unused.gdn` (1 fixable issue)
  - `let_shadow_lambda.gdn` (1 fixable issue)
  - `type_error_if_without_else.gdn` (1 fixable issue)
  - `unused_import.gdn` (1 fixable issue)
  - `unused_literal.gdn` (4 fixable issues)
  - `unused_shadowed_var.gdn` (2 fixable issues)
  - `unused_type_param.gdn` (1 fixable issue)

## Implementation Details
The message is only shown when:
- There are diagnostics to report
- The output is not in JSON format (to avoid breaking JSON parsing)
- There are fixable issues available (`all_fixes` is not empty)

The implementation uses proper English grammar with singular "issue" vs plural "issues" based on the count.

https://claude.ai/code/session_0143125vegjCkfibVNvBH1Za