### PR TITLE
Add helpful error for string concatenation with + operator

### DIFF
--- a/src/parser/diagnostics.rs
+++ b/src/parser/diagnostics.rs
@@ -1,9 +1,14 @@
+use std::io::IsTerminal as _;
+
 use crate::diagnostics::with_syntax_highlighting;
 
 #[derive(Debug, Clone)]
 pub(crate) enum MessagePart {
     Text(String),
     Code(String),
+    /// A clickable hyperlink. In terminals that support OSC 8, this
+    /// renders as a clickable link.
+    Link { url: String, text: String },
 }
 
 /// A macro that wraps Text(format!("foo")) to make it easier to write
@@ -24,6 +29,18 @@ macro_rules! msgcode {
     };
 }
 
+/// A macro that creates a clickable hyperlink in error messages.
+/// Usage: msglink!("https://example.com", "click here")
+#[macro_export]
+macro_rules! msglink {
+    ($url:expr, $text:expr) => {
+        $crate::parser::diagnostics::MessagePart::Link {
+            url: $url.to_owned(),
+            text: $text.to_owned(),
+        }
+    };
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ErrorMessage(pub(crate) Vec<MessagePart>);
 
@@ -34,6 +51,10 @@ impl ErrorMessage {
             match message_part {
                 MessagePart::Text(t) => s.push_str(t),
                 MessagePart::Code(c) => s.push_str(&format!("`{c}`")),
+                MessagePart::Link { url, text } => {
+                    // In plain text, show "text (url)"
+                    s.push_str(&format!("{text} ({url})"));
+                }
             }
         }
 
@@ -41,11 +62,21 @@ impl ErrorMessage {
     }
 
     pub(crate) fn as_styled_string(&self) -> String {
+        let use_osc8 = std::io::stdout().is_terminal();
+
         let mut s = String::new();
         for message_part in &self.0 {
             match message_part {
                 MessagePart::Text(t) => s.push_str(t),
                 MessagePart::Code(c) => s.push_str(&with_syntax_highlighting(c, true)),
+                MessagePart::Link { url, text } => {
+                    if use_osc8 {
+                        // OSC 8 hyperlink: \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\
+                        s.push_str(&format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"));
+                    } else {
+                        s.push_str(&format!("{text} ({url})"));
+                    }
+                }
             }
         }
 

--- a/src/test_files/check/string_concat_with_plus.gdn
+++ b/src/test_files/check/string_concat_with_plus.gdn
@@ -1,0 +1,18 @@
+public fun foo() {
+  "a" + "b"
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Cannot use `+` to concatenate strings. In Garden, `+` is only for integers.
+// 
+// Use the `^` operator for string concatenation. See: operator:^ (https://www.garden-lang.org/operator:%5E.html)
+// -| src/test_files/check/string_concat_with_plus.gdn:2:3
+// 1| public fun foo() {
+// 2|   "a" + "b"
+// 3| } ^^^^^^^^^
+
+// expected stderr: 
+1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check_fix/string_concat_operator.gdn
+++ b/src/test_files/check_fix/string_concat_operator.gdn
@@ -1,0 +1,10 @@
+fun hello() {
+  "a" + "b"
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// fun hello() {
+//   "a" ^ "b"
+// }
+


### PR DESCRIPTION
## Summary
Added a helpful error message when users attempt to concatenate strings using the `+` operator instead of the `^` operator in Garden. The error includes a quickfix to automatically replace `+` with `^`.

## Changes
- **Type checker enhancement**: Added special handling in the `infer_binary_op` method to detect when both operands of a `+` operation are strings
- **Error messaging**: When string concatenation with `+` is detected, the type checker now emits an error that:
  - Explains that `+` is only for integers
  - Directs users to use `^` for string concatenation
  - Includes a link to the documentation
  - Provides an automatic quickfix to replace the operator
- **Test coverage**: Added `string_concat_with_plus.gdn` test file to verify the error message and exit behavior
- **Documentation**: Updated CHANGELOG.md to document this new feature

## Implementation Details
- The check only triggers when both operands are confirmed to be strings (using `is_subtype` checks)
- Error types from previous errors are excluded from triggering this check to avoid cascading errors
- The operator position is calculated based on the positions of the left and right operands
- The quickfix provides the replacement text with proper spacing: ` ^ `

https://claude.ai/code/session_01XH1pV15m6ZdoHFVVrXXtcK