### PR TITLE
Add read_line() function for reading stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ distinguish from normal comments.
 
 ## Standard Library
 
+Added `read_line()` for reading a single line of text from stdin.
+
 Added `Dict::remove()`.
 
 ## CLI

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -842,6 +842,21 @@ public fun println(_: String): Unit {
   __BUILT_IN_IMPLEMENTATION
 }
 
+/// Read a single line of text from stdin.
+///
+/// Returns `Ok` with the line (without trailing newline) on success,
+/// or `Err` with an error message on failure.
+///
+/// ```
+/// match read_line() {
+///   Ok(line) => println("You entered: " + line)
+///   Err(e) => println("Error: " + e)
+/// }
+/// ```
+public fun read_line(): Result<String, String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
 /// Execute the given string as a shell command, and return stdout
 /// concatenated with stderr.
 ///

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2585,6 +2585,40 @@ fn eval_built_in_call(
                 env.push_value(Value::unit());
             }
         }
+        BuiltInFunctionKind::PreludeReadLine => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                0,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let mut line = String::new();
+            let v = match std::io::stdin().read_line(&mut line) {
+                Ok(_) => {
+                    // Remove trailing newline if present
+                    if line.ends_with('\n') {
+                        line.pop();
+                        if line.ends_with('\r') {
+                            line.pop();
+                        }
+                    }
+                    Value::ok(Value::new(Value_::String(line)))
+                }
+                Err(e) => {
+                    let s = Value::new(Value_::String(format!("{e}")));
+                    Value::err(s)
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(v);
+            }
+        }
         BuiltInFunctionKind::PreludeShell => {
             if env.enforce_sandbox {
                 let mut saved_values = vec![];

--- a/src/values.rs
+++ b/src/values.rs
@@ -366,6 +366,7 @@ pub(crate) enum BuiltInFunctionKind {
     PreludeGetEnv,
     PreludePrint,
     PreludePrintln,
+    PreludeReadLine,
     PreludeShell,
     // TODO: It's a little confusing that we have both shell() and
     // shell_arguments(), these should go in separate namespaces once
@@ -408,6 +409,7 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::PreludeStringRepr
             | BuiltInFunctionKind::PreludePrint
             | BuiltInFunctionKind::PreludePrintln
+            | BuiltInFunctionKind::PreludeReadLine
             | BuiltInFunctionKind::PreludeSourceDirectory
             | BuiltInFunctionKind::PreludeShellArguments
             | BuiltInFunctionKind::PreludeGetEnv => PathBuf::from("__prelude.gdn"),
@@ -447,6 +449,7 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::PreludeStringRepr => "string_repr",
             BuiltInFunctionKind::PreludePrint => "print",
             BuiltInFunctionKind::PreludePrintln => "println",
+            BuiltInFunctionKind::PreludeReadLine => "read_line",
             BuiltInFunctionKind::PreludeSourceDirectory => "source_directory",
             BuiltInFunctionKind::PreludeShellArguments => "shell_arguments",
             BuiltInFunctionKind::FsSetWorkingDirectory => "set_working_directory",


### PR DESCRIPTION
## Summary
This PR adds a new `read_line()` function to the standard library that allows reading a single line of text from stdin, returning a `Result<String, String>` to handle both success and error cases.

## Changes
- **Standard Library**: Added `read_line()` function that reads a single line from stdin and returns `Ok(line)` on success or `Err(error_message)` on failure
- **Prelude Definition**: Added function signature and documentation in `__prelude.gdn` with usage examples
- **Implementation**: Added `PreludeReadLine` variant to `BuiltInFunctionKind` enum and implemented the evaluation logic in `eval.rs`
- **Trailing Newline Handling**: The implementation properly strips trailing newlines (`\n`) and carriage returns (`\r`) from the input line before returning

## Implementation Details
- The function takes no arguments and reads from standard input using `std::io::stdin().read_line()`
- Handles both Unix (`\n`) and Windows (`\r\n`) line endings by removing them from the returned string
- Returns a `Result` type, allowing callers to handle I/O errors gracefully
- Respects the `expr_value_is_used` flag to avoid unnecessary value pushing when the result is unused

https://claude.ai/code/session_01LErWMBYSbSF1zGX9eSdJEM