### PR TITLE
Add autofix suggestion for method calls mistaken as field access

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1166,29 +1166,71 @@ impl TypeCheckVisitor<'_> {
                         None => vec![],
                     };
 
+                    let methods = self
+                        .env
+                        .types
+                        .get(&recv_ty_name)
+                        .cloned()
+                        .map(|tdm| tdm.methods)
+                        .unwrap_or_default();
+
+                    let mut fixes = vec![];
+                    let suggest = if methods.contains_key(&field_sym.name) {
+                        fixes.push(Autofix {
+                            description: format!("Use `{}()` here.", field_sym.name),
+                            position: field_sym.position.clone(),
+                            new_text: format!("{}()", field_sym.name),
+                        });
+
+                        format!(" Did you mean `{}()`?", field_sym.name)
+                    } else {
+                        "".to_owned()
+                    };
+
                     self.diagnostics.push(Diagnostic {
                         notes,
-                        fixes: vec![],
+                        fixes,
                         severity: Severity::Error,
                         message: ErrorMessage(vec![
                             msgtext!("Struct "),
                             msgcode!("{}", recv_ty_name),
                             msgtext!(" has no field "),
                             msgcode!("{}", field_sym.name),
-                            msgtext!("."),
+                            msgtext!(".{}", suggest),
                         ]),
                         position: field_sym.position.clone(),
                     });
 
                     Type::error("No struct field with this name")
                 } else {
+                    let methods = self
+                        .env
+                        .types
+                        .get(&recv_ty_name)
+                        .cloned()
+                        .map(|tdm| tdm.methods)
+                        .unwrap_or_default();
+
+                    let mut fixes = vec![];
+                    let suggest = if methods.contains_key(&field_sym.name) {
+                        fixes.push(Autofix {
+                            description: format!("Use `{}()` here.", field_sym.name),
+                            position: field_sym.position.clone(),
+                            new_text: format!("{}()", field_sym.name),
+                        });
+
+                        format!(" Did you mean `{}()`?", field_sym.name)
+                    } else {
+                        "".to_owned()
+                    };
+
                     self.diagnostics.push(Diagnostic {
                         notes: vec![],
-                        fixes: vec![],
+                        fixes,
                         severity: Severity::Error,
                         message: ErrorMessage(vec![
                             msgcode!("{}", recv_ty_name),
-                            msgtext!(" is not a struct."),
+                            msgtext!(" is not a struct.{}", suggest),
                         ]),
                         position: field_sym.position.clone(),
                     });
@@ -1197,13 +1239,34 @@ impl TypeCheckVisitor<'_> {
                 }
             }
             _ => {
+                let methods = self
+                    .env
+                    .types
+                    .get(&recv_ty_name)
+                    .cloned()
+                    .map(|tdm| tdm.methods)
+                    .unwrap_or_default();
+
+                let mut fixes = vec![];
+                let suggest = if methods.contains_key(&field_sym.name) {
+                    fixes.push(Autofix {
+                        description: format!("Use `{}()` here.", field_sym.name),
+                        position: field_sym.position.clone(),
+                        new_text: format!("{}()", field_sym.name),
+                    });
+
+                    format!(" Did you mean `{}()`?", field_sym.name)
+                } else {
+                    "".to_owned()
+                };
+
                 self.diagnostics.push(Diagnostic {
                     notes: vec![],
-                    fixes: vec![],
+                    fixes,
                     severity: Severity::Error,
                     message: ErrorMessage(vec![
                         msgcode!("{}", recv_ty_name),
-                        msgtext!(" is not a struct."),
+                        msgtext!(" is not a struct.{}", suggest),
                     ]),
                     position: field_sym.position.clone(),
                 });

--- a/src/test_files/check_fix/list_len_method.gdn
+++ b/src/test_files/check_fix/list_len_method.gdn
@@ -1,0 +1,11 @@
+{
+  let items = [1, 2, 3]
+  items.len
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// {
+//   let items = [1, 2, 3]
+//   items.len()
+// }


### PR DESCRIPTION
## Summary
This PR adds an autofix suggestion when a user attempts to access a field that doesn't exist but matches a method name on the type. For example, accessing `items.len` will now suggest `items.len()` with an automatic fix.

## Key Changes
- Enhanced error diagnostics in `type_checker.rs` to detect when a field access name matches an available method on the type
- When a mismatch is detected, the error message now includes a helpful suggestion: "Did you mean `method_name()`?"
- Added an `Autofix` that automatically converts the field access to a method call (e.g., `items.len` → `items.len()`)
- Applied this improvement to two error paths in the type checker (struct field access and general field access)
- Added test case `list_len_method.gdn` demonstrating the autofix in action
- Updated CHANGELOG.md to document the new feature

## Implementation Details
- The fix retrieves available methods from the type environment and checks if the accessed name matches any method
- Only generates the suggestion and autofix when a matching method is found
- The autofix includes both a description and the corrected code text for IDE integration

https://claude.ai/code/session_014eWiDph7M3enBMha1hczaQ