### PR TITLE
Fix error handling and improve type error messages

### DIFF
--- a/src/checks/hints.rs
+++ b/src/checks/hints.rs
@@ -127,7 +127,7 @@ impl Visitor for HintVisitor<'_> {
                             }
                         }
 
-                        if matches!(b, BuiltInType::Fun) {
+                        if matches!(b, BuiltInType::Fun) && type_hint.args.len() == 2 {
                             let first_arg = &type_hint.args[0];
                             if first_arg.sym.name.text != "Tuple" {
                                 self.diagnostics.push(Diagnostic {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1858,10 +1858,13 @@ fn eval_for_in(
                     RestoreValues(vec![iteree_current_elem.clone()]),
                     EvalError::Exception(ExceptionInfo {
                         position: iteree_pos.clone(),
-                        message: ErrorMessage(vec![Text(format!(
-                            "Incorrect type for variable: {}",
-                            "x"
-                        ))]),
+                        message: format_type_error(
+                            &TypeName {
+                                text: "Tuple".into(),
+                            },
+                            &iteree_current_elem,
+                            env,
+                        ),
                     }),
                 ));
             }
@@ -2033,14 +2036,18 @@ fn eval_let(
                 }
             }
             _ => {
+                let message = format_type_error(
+                    &TypeName {
+                        text: "Tuple".into(),
+                    },
+                    &expr_value,
+                    env,
+                );
                 return Err((
                     RestoreValues(vec![expr_value]),
                     EvalError::Exception(ExceptionInfo {
                         position: init_value_pos.clone(),
-                        message: ErrorMessage(vec![Text(format!(
-                            "Incorrect type for variable: {}",
-                            "x"
-                        ))]),
+                        message,
                     }),
                 ));
             }
@@ -2853,8 +2860,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -2912,7 +2919,10 @@ fn eval_built_in_call(
             )?;
 
             let v = match std::fs::canonicalize(position.path.as_ref()) {
-                Ok(abspath) => Value::some(Value::path(abspath.display().to_string())),
+                Ok(abspath) => match abspath.parent() {
+                    Some(dir) => Value::some(Value::path(dir.display().to_string())),
+                    None => Value::none(),
+                },
                 Err(_) => Value::none(),
             };
 
@@ -3019,8 +3029,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3097,8 +3107,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3159,8 +3169,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3220,8 +3230,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3281,8 +3291,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3299,8 +3309,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -3366,8 +3376,8 @@ fn eval_built_in_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -4661,7 +4671,7 @@ fn eval_built_in_method_call(
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
-                            position: arg_positions[0].clone(),
+                            position: receiver_pos.clone(),
                             message: format_type_error(
                                 &TypeName {
                                     text: "Dict".into(),
@@ -4754,7 +4764,7 @@ fn eval_built_in_method_call(
                     if expr_value_is_used {
                         // TODO: check that the new value has the same
                         // type as the existing dict values.
-                        let value_type = Type::from_value(&arg_values[0]);
+                        let value_type = Type::from_value(&arg_values[1]);
 
                         env.push_value(Value::new(Value_::Dict { items, value_type }));
                     }
@@ -4971,7 +4981,7 @@ fn eval_built_in_method_call(
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
-                            position: arg_positions[0].clone(),
+                            position: receiver_pos.clone(),
                             message: format_type_error(
                                 &TypeName {
                                     text: "List".into(),
@@ -5015,8 +5025,8 @@ fn eval_built_in_method_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {
@@ -5068,8 +5078,8 @@ fn eval_built_in_method_call(
                     let mut saved_values = vec![];
                     for value in arg_values.iter().rev() {
                         saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
                     }
+                    saved_values.push(receiver_value.clone());
                     return Err((
                         RestoreValues(saved_values),
                         EvalError::Exception(ExceptionInfo {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1584,7 +1584,7 @@ fn parse_struct(
         (fields, close_brace.position)
     };
 
-    let position = Position::merge_token(&struct_token, &close_brace_pos);
+    let position = Position::merge_token(&first_token, &close_brace_pos);
 
     ToplevelItem::Struct(StructInfo {
         pos: position,

--- a/src/test_files/runtime/source_directory.gdn
+++ b/src/test_files/runtime/source_directory.gdn
@@ -3,5 +3,5 @@
 }
 
 // args: run
-// expected stdout: Some("source_directory.gdn")
+// expected stdout: Some("runtime")
 


### PR DESCRIPTION
This PR addresses several bugs and improvements in error handling and type checking throughout the evaluator and parser.

## Summary
Multiple fixes to error handling logic, type error message formatting, and position tracking in error reporting. Additionally, fixes a bug in the `source_directory` built-in function to return the parent directory instead of the full path.

## Key Changes

- **Improved type error messages**: Replaced generic "Incorrect type for variable" messages with calls to `format_type_error()` in `eval_for_in()` and `eval_let()` for better error diagnostics
- **Fixed saved values ordering**: Corrected the order of pushing values to `saved_values` vectors in multiple error handling paths - receiver value should be pushed after all argument values to maintain proper restoration order
- **Fixed `source_directory` function**: Changed to return the parent directory of a canonicalized path instead of the full path, matching expected behavior
- **Fixed error position tracking**: Updated error positions in dict and list method calls to use `receiver_pos` instead of `arg_positions[0]` for more accurate error reporting
- **Fixed type inference bug**: Changed `Type::from_value(&arg_values[0])` to `&arg_values[1]` in dict value type checking to use the correct argument
- **Fixed struct position tracking**: Changed struct position calculation to use `first_token` instead of `struct_token` for more accurate source location
- **Added bounds check**: Added length check for `type_hint.args` before accessing elements in hint visitor to prevent potential panics
- **Updated test expectations**: Updated `source_directory.gdn` test to expect "runtime" directory instead of filename

## Implementation Details
The saved values ordering fix is particularly important as it ensures that when errors occur during method calls, the values are restored in the correct order for proper cleanup. The type error message improvements provide users with more detailed information about type mismatches.

https://claude.ai/code/session_01Njhmj9nTBsW5sGgLGLTxkd