### PR TITLE
Add command name autocompletion for REPL input

### DIFF
--- a/src/syntax_highlighter.rs
+++ b/src/syntax_highlighter.rs
@@ -8,7 +8,9 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
 use rustyline::Helper;
+use strum::IntoEnumIterator;
 
+use crate::commands::Command;
 use crate::parser::lex::{lex, STRING_RE, SYMBOL_RE};
 use crate::parser::KEYWORDS;
 use crate::Vfs;
@@ -24,6 +26,27 @@ impl GardenHighlighter {
 
 impl Completer for GardenHighlighter {
     type Candidate = String;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        let line_to_cursor = &line[..pos];
+
+        // Only complete command names: input starts with ':' and no space yet.
+        if !line_to_cursor.starts_with(':') || line_to_cursor.contains(' ') {
+            return Ok((pos, vec![]));
+        }
+
+        let candidates: Vec<String> = Command::iter()
+            .map(|cmd| cmd.to_string())
+            .filter(|name| name.starts_with(line_to_cursor))
+            .collect();
+
+        Ok((0, candidates))
+    }
 }
 
 impl Hinter for GardenHighlighter {


### PR DESCRIPTION
## Summary
Implement autocompletion for command names in the REPL by adding a `complete` method to the `GardenHighlighter` struct. This allows users to type a colon (`:`) followed by partial command names and receive matching suggestions.

## Changes
- Added `strum::IntoEnumIterator` import to enable iteration over `Command` enum variants
- Added `crate::commands::Command` import to access available commands
- Implemented the `complete` method in the `Completer` trait for `GardenHighlighter`:
  - Filters completions to only trigger when input starts with `:` and contains no spaces
  - Iterates through all available commands and converts them to strings
  - Returns matching command names that start with the user's input
  - Returns completion position as 0 to replace the entire prefix

## Implementation Details
The completion logic is intentionally simple and focused: it only completes command names at the start of input (lines beginning with `:`). Once a space is detected, no completions are offered, preventing interference with argument completion logic that may be added later.

https://claude.ai/code/session_01QqkADxSRNfk38Zt3jewQ6Q