### PR TITLE
Add documentation for writing static analysis checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,92 @@ ErrorMessage(vec![
 This markup ensures that code elements like variable names, types,
 and paths stand out clearly in error messages.
 
+# Writing Static Analysis Checks
+
+Garden's static analysis checks live in `src/checks/` and use the
+`Visitor` trait (`src/parser/visitor.rs`) to traverse the AST. The
+Visitor handles recursion automatically — you only override the
+methods for the AST nodes you care about.
+
+## Adding a New Check
+
+1. Create a new file in `src/checks/` with a struct that holds a
+   `Vec<Diagnostic>` and any state you need.
+2. Implement `Visitor` for your struct, overriding only the relevant
+   `visit_*` methods.
+3. Add a public entry point function that creates the visitor, walks
+   all toplevel items, and returns the diagnostics.
+4. Register the check in `src/checks.rs` by calling your function
+   from `check_toplevel_items_in_env()`.
+
+## Example: A Minimal Check
+
+```rust
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::parser::ast::ToplevelItem;
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::visitor::Visitor;
+use crate::{msgcode, msgtext};
+
+struct MyVisitor {
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl Visitor for MyVisitor {
+    fn visit_expr(&mut self, expr: &Expression) {
+        // Your logic here: inspect expr, push to self.diagnostics
+
+        // Call the default to continue recursing into child nodes.
+        self.visit_expr_(&expr.expr_);
+    }
+}
+
+pub(crate) fn check_my_thing(items: &[ToplevelItem]) -> Vec<Diagnostic> {
+    let mut visitor = MyVisitor {
+        diagnostics: vec![],
+    };
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics
+}
+```
+
+## Key Visitor Methods to Override
+
+- `visit_toplevel_item` — top-level definitions (functions, methods,
+  tests, enums, structs, imports)
+- `visit_fun_info` / `visit_method_info` — function and method bodies
+- `visit_expr` — all expressions (call `visit_expr_` at the end to
+  keep recursing)
+- `visit_expr_while` / `visit_expr_for_in` — loop constructs
+- `visit_expr_let` / `visit_expr_assign` — variable bindings and
+  assignments
+- `visit_expr_variable` — variable references
+- `visit_symbol` / `visit_type_symbol` — identifiers and type names
+- `visit_type_hint` — type annotations
+- `visit_block` — blocks of expressions
+
+Each `visit_*` method has a `_default` variant (e.g.
+`visit_fun_info_default`) that performs the standard recursive
+traversal. Call the `_default` method when you want to add logic
+before or after the default recursion:
+
+```rust
+fn visit_fun_info(&mut self, fun_info: &FunInfo) {
+    // Custom logic before recursion.
+    self.enter_scope();
+
+    // Use the _default method to recurse as normal.
+    self.visit_fun_info_default(fun_info);
+
+    // Custom logic after recursion.
+    self.leave_scope();
+}
+```
+
+See `src/checks/loops.rs` for a concise real example.
+
 # Checking Changes
 - cargo clippy: Check that your Rust code is correct
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation to `CLAUDE.md` explaining how to write static analysis checks in Garden using the `Visitor` trait pattern.

## Key Changes
- Added new "Writing Static Analysis Checks" section covering:
  - Overview of how Garden's static analysis checks are structured
  - Step-by-step guide for adding a new check
  - Complete minimal example implementation
  - Reference list of key `Visitor` methods to override
  - Pattern for using `_default` variants to customize recursion behavior
  - Pointer to `src/checks/loops.rs` as a real-world example

## Details
The documentation explains:
- Where checks live (`src/checks/`) and how they use the `Visitor` trait
- The automatic recursion handling provided by the `Visitor` pattern
- How to create a new check with a struct holding diagnostics and state
- The registration process in `src/checks.rs`
- Common visitor methods developers will need to override for different AST node types
- The pattern for adding custom logic before/after recursive traversal using `_default` methods

https://claude.ai/code/session_01CCaDSFRB1r7cvXUUBkQpk4