### PR TITLE
Fix type inference for unannotated function return types

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1546,7 +1546,30 @@ impl TypeCheckVisitor<'_> {
             self.save_enum_variant_id(sym, value.clone());
         }
 
-        Type::from_value(&value)
+        let ty = Type::from_value(&value);
+
+        // from_fun_info uses NoValue as the return type for unannotated
+        // non-empty functions so closures are assignable to any function type
+        // at runtime. For type inference, use Any to indicate an unknown
+        // return type, consistent with how visit_fun_info handles unannotated
+        // functions.
+        match (fun_info, ty) {
+            (
+                Some(fi),
+                Type::Fun {
+                    type_params,
+                    params,
+                    return_,
+                    name_sym,
+                },
+            ) if fi.return_hint.is_none() && return_.is_no_value() => Type::Fun {
+                type_params,
+                params,
+                return_: Box::new(Type::Any),
+                name_sym,
+            },
+            (_, ty) => ty,
+        }
     }
 
     fn infer_binary_op(

--- a/src/test_files/hover/unannotated_fun_return.gdn
+++ b/src/test_files/hover/unannotated_fun_return.gdn
@@ -1,0 +1,9 @@
+fun fizzbuzz() {
+  let _x = 1
+}
+
+fizzbuzz()
+//^
+
+// args: show-type
+// expected stdout: Fun<(), Any>


### PR DESCRIPTION
## Summary
This change fixes type inference for unannotated functions to use `Any` as the return type instead of `NoValue`, ensuring consistency between runtime behavior and type checking.

## Key Changes
- Modified `visit_enum_variant` in `type_checker.rs` to detect when a function has no return type annotation and `from_value` returns `NoValue`, and replace it with `Any` to indicate an unknown return type
- Added test case `unannotated_fun_return.gdn` to verify that unannotated functions are correctly inferred as `Fun<(), Any>`

## Implementation Details
The fix addresses an inconsistency where `from_fun_info` uses `NoValue` as the return type for unannotated non-empty functions (to allow runtime assignability), but this doesn't match type inference expectations. The change checks if:
1. Function info exists and has no return type hint
2. The inferred type is a function with `NoValue` as the return type

When both conditions are met, the return type is replaced with `Any` to properly indicate an unknown return type during type inference, consistent with how `visit_fun_info` handles unannotated functions.

https://claude.ai/code/session_013jvT5PC5VXgtJv3YJdRxZL