### PR TITLE
Add check for variables only used in recursive calls

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,6 +1,7 @@
 mod duplicates;
 mod hints;
 mod loops;
+mod recursion_variable;
 mod same_literal_returns;
 mod struct_fields;
 pub mod type_checker;
@@ -19,6 +20,7 @@ use crate::namespaces::NamespaceInfo;
 use crate::parser::ast::ToplevelItem;
 use crate::parser::vfs::VfsPathBuf;
 use loops::check_loops;
+use recursion_variable::check_recursion_variables;
 use same_literal_returns::check_same_literal_returns;
 use unreachable::check_unreachable;
 use unused_defs::check_unused_defs;
@@ -70,6 +72,7 @@ pub(crate) fn check_toplevel_items_in_env(
     diagnostics.extend(check_loops(items));
     diagnostics.extend(check_unreachable(items));
     diagnostics.extend(check_same_literal_returns(items));
+    diagnostics.extend(check_recursion_variables(items));
 
     diagnostics
 }

--- a/src/checks/recursion_variable.rs
+++ b/src/checks/recursion_variable.rs
@@ -1,0 +1,162 @@
+//! Check for variables that are only used in recursive calls.
+//!
+//! If a parameter is only passed to a recursive call and never used
+//! for any other computation, it's effectively unused.
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::parser::ast::{
+    Expression, Expression_, FunInfo, InternedSymbolId, Symbol, SymbolName, ToplevelItem,
+};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::position::Position;
+use crate::parser::visitor::Visitor;
+use crate::{msgcode, msgtext};
+
+struct ParamUsage {
+    interned_id: InternedSymbolId,
+    name: SymbolName,
+    position: Position,
+    used_outside_recursion: bool,
+    used_in_recursion: bool,
+}
+
+struct FunctionContext {
+    function_name: SymbolName,
+    params: Vec<ParamUsage>,
+}
+
+struct RecursionVariableVisitor {
+    diagnostics: Vec<Diagnostic>,
+    function_stack: Vec<FunctionContext>,
+    in_recursive_args: bool,
+}
+
+impl RecursionVariableVisitor {
+    fn is_current_function(&self, name: &SymbolName) -> bool {
+        self.function_stack
+            .last()
+            .is_some_and(|ctx| ctx.function_name == *name)
+    }
+
+    fn mark_param_usage(&mut self, sym: &Symbol) {
+        let in_recursion = self.in_recursive_args;
+        for ctx in self.function_stack.iter_mut().rev() {
+            for param in &mut ctx.params {
+                if param.interned_id == sym.interned_id {
+                    if in_recursion {
+                        param.used_in_recursion = true;
+                    } else {
+                        param.used_outside_recursion = true;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+impl Visitor for RecursionVariableVisitor {
+    fn visit_fun_info(&mut self, fun_info: &FunInfo) {
+        let Some(name_sym) = &fun_info.name_sym else {
+            // Closures don't have names, handled by visit_expr_fun_literal.
+            self.visit_fun_info_default(fun_info);
+            return;
+        };
+
+        let params: Vec<ParamUsage> = fun_info
+            .params
+            .params
+            .iter()
+            .filter(|p| !p.symbol.name.text.starts_with('_'))
+            .map(|p| ParamUsage {
+                interned_id: p.symbol.interned_id,
+                name: p.symbol.name.clone(),
+                position: p.symbol.position.clone(),
+                used_outside_recursion: false,
+                used_in_recursion: false,
+            })
+            .collect();
+
+        self.function_stack.push(FunctionContext {
+            function_name: name_sym.name.clone(),
+            params,
+        });
+
+        let prev_in_recursive_args = self.in_recursive_args;
+        self.in_recursive_args = false;
+
+        self.visit_block(&fun_info.body);
+
+        self.in_recursive_args = prev_in_recursive_args;
+        let ctx = self.function_stack.pop().unwrap();
+
+        for param in &ctx.params {
+            if param.used_in_recursion && !param.used_outside_recursion {
+                self.diagnostics.push(Diagnostic {
+                    message: ErrorMessage(vec![
+                        msgcode!("{}", param.name),
+                        msgtext!(" is only used in recursion, so is effectively unused."),
+                    ]),
+                    position: param.position.clone(),
+                    severity: Severity::Warning,
+                    notes: vec![],
+                    fixes: vec![],
+                });
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expression) {
+        if let Expression_::Call(recv, paren_args) = &expr.expr_ {
+            if let Expression_::Variable(var) = &recv.expr_ {
+                if self.is_current_function(&var.name) {
+                    // This is a recursive call. Visit arguments in
+                    // recursive mode.
+                    let prev = self.in_recursive_args;
+                    self.in_recursive_args = true;
+                    for arg in &paren_args.arguments {
+                        self.visit_expr(&arg.expr);
+                    }
+                    self.in_recursive_args = prev;
+                    return;
+                }
+            }
+        }
+
+        self.visit_expr_(&expr.expr_);
+    }
+
+    fn visit_expr_variable(&mut self, var: &Symbol) {
+        self.mark_param_usage(var);
+    }
+
+    fn visit_expr_fun_literal(&mut self, fun_info: &FunInfo) {
+        // Closures are a barrier: prevent recursive call matching
+        // inside the closure body. Variable references inside the
+        // closure count as "used outside recursion".
+        let prev = self.in_recursive_args;
+        self.in_recursive_args = false;
+
+        self.function_stack.push(FunctionContext {
+            function_name: SymbolName::from(""),
+            params: vec![],
+        });
+
+        self.visit_fun_info_default(fun_info);
+
+        self.function_stack.pop();
+        self.in_recursive_args = prev;
+    }
+}
+
+pub(crate) fn check_recursion_variables(items: &[ToplevelItem]) -> Vec<Diagnostic> {
+    let mut visitor = RecursionVariableVisitor {
+        diagnostics: vec![],
+        function_stack: vec![],
+        in_recursive_args: false,
+    };
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics
+}

--- a/src/test_files/check/recursion_variable.gdn
+++ b/src/test_files/check/recursion_variable.gdn
@@ -1,0 +1,39 @@
+// Should warn: y is only used in the recursive call.
+public fun foo(x: Int, y: Int): Int {
+    if (x == 0) {
+        return 0
+    }
+    foo(x - 1, y)
+}
+
+// Should not warn: y is used in a non-recursive context.
+public fun bar(x: Int, y: Int): Int {
+    if (x == 0) {
+        return y
+    }
+    bar(x - 1, y + 1)
+}
+
+// Should not warn: no recursion at all.
+public fun baz(x: Int, y: Int): Int {
+    x + y
+}
+
+// Should not warn: underscore-prefixed params are intentionally unused.
+public fun qux(x: Int, _y: Int): Int {
+    if (x == 0) {
+        return 0
+    }
+    qux(x - 1, _y)
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: `y` is only used in recursion, so is effectively unused.
+// --| src/test_files/check/recursion_variable.gdn:2:24
+//  1| // Should warn: y is only used in the recursive call.
+//  2| public fun foo(x: Int, y: Int): Int {
+//  3|     if (x == 0) {      ^
+//  4|         return 0
+


### PR DESCRIPTION
## Summary
This PR adds a new diagnostic check that warns when function parameters are only used in recursive calls and never used for any other computation, making them effectively unused.

## Key Changes
- **New check module** (`src/checks/recursion_variable.rs`): Implements `RecursionVariableVisitor` that traverses the AST to detect parameters that are passed to recursive calls but never used in other computations
- **Integration**: Registered the new check in `src/checks.rs` to run as part of the standard checking pipeline
- **Test file**: Added comprehensive test cases in `src/test_files/check/recursion_variable.gdn` covering:
  - Parameters only used in recursion (should warn)
  - Parameters used both in recursion and other contexts (should not warn)
  - Functions with no recursion (should not warn)
  - Underscore-prefixed parameters that are intentionally unused (should not warn)

## Implementation Details
- The visitor tracks function context with a stack to handle nested functions and closures
- Parameters are marked as "used in recursion" or "used outside recursion" based on whether they appear in recursive call arguments or elsewhere
- Closures act as a barrier to prevent recursive call matching inside their bodies, treating variable references as "used outside recursion"
- Parameters starting with underscore are filtered out as they follow the convention for intentionally unused variables
- Diagnostics are emitted as warnings with the parameter name and position information

https://claude.ai/code/session_01YH6HFwy6ef46dVvTGWyjKL