### PR TITLE
Add check for self-assignment and self-comparison operations

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -3,6 +3,7 @@ mod hints;
 mod loops;
 mod recursion_variable;
 mod same_literal_returns;
+mod self_assign_compare;
 mod struct_fields;
 pub mod type_checker;
 mod unnecessary_return;
@@ -23,6 +24,7 @@ use crate::parser::vfs::VfsPathBuf;
 use loops::check_loops;
 use recursion_variable::check_recursion_variables;
 use same_literal_returns::check_same_literal_returns;
+use self_assign_compare::check_self_assign_compare;
 use unnecessary_return::check_unnecessary_return;
 use unreachable::check_unreachable;
 use unused_defs::check_unused_defs;
@@ -76,6 +78,7 @@ pub(crate) fn check_toplevel_items_in_env(
     diagnostics.extend(check_same_literal_returns(items));
     diagnostics.extend(check_recursion_variables(items));
     diagnostics.extend(check_unnecessary_return(items));
+    diagnostics.extend(check_self_assign_compare(items));
 
     diagnostics
 }

--- a/src/checks/self_assign_compare.rs
+++ b/src/checks/self_assign_compare.rs
@@ -1,0 +1,90 @@
+//! Check for self-assignment (`x = x`) and self-comparison (`x == x`).
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::parser::ast::{BinaryOperatorKind, Expression, Expression_, ToplevelItem};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::visitor::Visitor;
+use crate::{msgcode, msgtext};
+
+struct SelfAssignCompareVisitor {
+    diagnostics: Vec<Diagnostic>,
+}
+
+/// Extract a comparable key from an expression. Returns `None` for
+/// expressions that are too complex to compare syntactically.
+fn expr_key(expr: &Expression) -> Option<String> {
+    match &expr.expr_ {
+        Expression_::Variable(sym) => Some(sym.name.text.clone()),
+        Expression_::IntLiteral(n) => Some(format!("int:{}", n)),
+        Expression_::StringLiteral(s) => Some(format!("str:{}", s)),
+        Expression_::Parentheses(_, inner, _) => expr_key(inner),
+        _ => None,
+    }
+}
+
+fn is_comparison_op(op: &BinaryOperatorKind) -> bool {
+    matches!(
+        op,
+        BinaryOperatorKind::Equal
+            | BinaryOperatorKind::NotEqual
+            | BinaryOperatorKind::LessThan
+            | BinaryOperatorKind::LessThanOrEqual
+            | BinaryOperatorKind::GreaterThan
+            | BinaryOperatorKind::GreaterThanOrEqual
+    )
+}
+
+impl Visitor for SelfAssignCompareVisitor {
+    fn visit_expr(&mut self, expr: &Expression) {
+        match &expr.expr_ {
+            Expression_::Assign(sym, rhs) => {
+                if let Expression_::Variable(var) = &rhs.expr_ {
+                    if var.name.text == sym.name.text {
+                        self.diagnostics.push(Diagnostic {
+                            message: ErrorMessage(vec![
+                                msgcode!("{}", sym.name),
+                                msgtext!(" is assigned to itself."),
+                            ]),
+                            position: expr.position.clone(),
+                            notes: vec![],
+                            severity: Severity::Warning,
+                            fixes: vec![],
+                        });
+                    }
+                }
+            }
+            Expression_::BinaryOperator(lhs, op, rhs) => {
+                if is_comparison_op(op) {
+                    if let (Some(lhs_key), Some(rhs_key)) = (expr_key(lhs), expr_key(rhs)) {
+                        if lhs_key == rhs_key {
+                            self.diagnostics.push(Diagnostic {
+                                message: ErrorMessage(vec![
+                                    msgtext!("Both sides of "),
+                                    msgcode!("{}", op),
+                                    msgtext!(" are identical."),
+                                ]),
+                                position: expr.position.clone(),
+                                notes: vec![],
+                                severity: Severity::Warning,
+                                fixes: vec![],
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        self.visit_expr_(&expr.expr_);
+    }
+}
+
+pub(crate) fn check_self_assign_compare(items: &[ToplevelItem]) -> Vec<Diagnostic> {
+    let mut visitor = SelfAssignCompareVisitor {
+        diagnostics: vec![],
+    };
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics
+}

--- a/src/test_files/check/self_assign_compare.gdn
+++ b/src/test_files/check/self_assign_compare.gdn
@@ -1,0 +1,105 @@
+// Self-assignment: should warn.
+public fun assign_self(x: Int): Int {
+    x = x
+    x
+}
+
+// Self-comparison with ==: should warn.
+public fun compare_equal(x: Int): Bool {
+    x == x
+}
+
+// Self-comparison with !=: should warn.
+public fun compare_not_equal(x: Int): Bool {
+    x != x
+}
+
+// Self-comparison with <: should warn.
+public fun compare_less(x: Int): Bool {
+    x < x
+}
+
+// Self-comparison with integer literals: should warn.
+public fun compare_literals(): Bool {
+    1 == 1
+}
+
+// Normal assignment: should not warn.
+public fun assign_different(x: Int): Int {
+    let y = x
+    y
+}
+
+// Normal comparison: should not warn.
+public fun compare_different(x: Int, y: Int): Bool {
+    x == y
+}
+
+// Warning: Both sides of `==` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:9:5
+//  8| public fun compare_equal(x: Int): Bool {
+//  9|     x == x
+//  10|     ^^^^^^
+//  11| }
+//
+// Warning: Both sides of `!=` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:14:5
+// 13| public fun compare_not_equal(x: Int): Bool {
+// 14|     x != x
+//   |     ^^^^^^
+// 15| }
+//
+// Warning: Both sides of `<` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:19:5
+// 18| public fun compare_less(x: Int): Bool {
+// 19|     x < x
+//   |     ^^^^^
+// 20| }
+//
+// Warning: Both sides of `==` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:24:5
+// 23| public fun compare_literals(): Bool {
+// 24|     1 == 1
+//   |     ^^^^^^
+// 25| }
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: `x` is assigned to itself.
+// --| src/test_files/check/self_assign_compare.gdn:3:5
+//  1| // Self-assignment: should warn.
+//  2| public fun assign_self(x: Int): Int {
+//  3|     x = x
+//   |     ^^^^^
+//  4|     x
+//  5| }
+// 
+// Warning: Both sides of `==` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:9:5
+//  7| // Self-comparison with ==: should warn.
+//  8| public fun compare_equal(x: Int): Bool {
+//  9|     x == x
+// 10| }   ^^^^^^
+// 
+// Warning: Both sides of `!=` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:14:5
+// 12| // Self-comparison with !=: should warn.
+// 13| public fun compare_not_equal(x: Int): Bool {
+// 14|     x != x
+// 15| }   ^^^^^^
+// 
+// Warning: Both sides of `<` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:19:5
+// 17| // Self-comparison with <: should warn.
+// 18| public fun compare_less(x: Int): Bool {
+// 19|     x < x
+// 20| }   ^^^^^
+// 
+// Warning: Both sides of `==` are identical.
+// --| src/test_files/check/self_assign_compare.gdn:24:5
+// 22| // Self-comparison with integer literals: should warn.
+// 23| public fun compare_literals(): Bool {
+// 24|     1 == 1
+// 25| }   ^^^^^^
+


### PR DESCRIPTION
## Summary
This PR adds a new diagnostic check that detects and warns about self-assignment (`x = x`) and self-comparison operations (`x == x`, `x != x`, `x < x`, etc.), which are typically logic errors or redundant code.

## Key Changes
- **New check module** (`src/checks/self_assign_compare.rs`): Implements detection of self-assignment and self-comparison patterns
  - Detects self-assignment: warns when a variable is assigned to itself
  - Detects self-comparison: warns when both sides of comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) are identical
  - Supports comparison of variables, integer literals, string literals, and parenthesized expressions
  
- **Integration** (`src/checks.rs`): Registers the new check in the diagnostic pipeline

- **Test file** (`src/test_files/check/self_assign_compare.gdn`): Comprehensive test cases covering:
  - Self-assignment scenarios
  - Self-comparison with various operators
  - Literal comparisons
  - Negative cases (normal assignments and comparisons that should not warn)

## Implementation Details
- Uses a visitor pattern to traverse the AST and identify problematic expressions
- Implements `expr_key()` helper function to extract comparable keys from expressions, supporting variables, literals, and parenthesized expressions
- Generates appropriate warning messages with precise source location information
- Exit status is 1 when warnings are detected, as expected by the test suite

https://claude.ai/code/session_01EjArwjoLiEa7Sc9svNtaPH