### PR TITLE
Add warning for loops that unconditionally break on first iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Checks
 
+Added a warning when a loop unconditionally breaks on the first
+iteration, so it can only execute once.
+
 Added a warning when all code paths in a function return the same
 literal value.
 

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -6,6 +6,7 @@ mod same_literal_returns;
 mod self_assign_compare;
 mod struct_fields;
 pub mod type_checker;
+mod unconditional_break;
 mod unnecessary_return;
 mod unreachable;
 mod unused_defs;
@@ -25,6 +26,7 @@ use loops::check_loops;
 use recursion_variable::check_recursion_variables;
 use same_literal_returns::check_same_literal_returns;
 use self_assign_compare::check_self_assign_compare;
+use unconditional_break::check_unconditional_break;
 use unnecessary_return::check_unnecessary_return;
 use unreachable::check_unreachable;
 use unused_defs::check_unused_defs;
@@ -79,6 +81,7 @@ pub(crate) fn check_toplevel_items_in_env(
     diagnostics.extend(check_recursion_variables(items));
     diagnostics.extend(check_unnecessary_return(items));
     diagnostics.extend(check_self_assign_compare(items));
+    diagnostics.extend(check_unconditional_break(items));
 
     diagnostics
 }

--- a/src/checks/unconditional_break.rs
+++ b/src/checks/unconditional_break.rs
@@ -1,0 +1,98 @@
+//! Check for loops that unconditionally break on every iteration,
+//! making the loop body execute at most once.
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::parser::ast::{Block, Expression, Expression_, FunInfo, LetDestination, ToplevelItem};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::visitor::Visitor;
+use crate::{msgcode, msgtext};
+
+struct UnconditionalBreakVisitor {
+    diagnostics: Vec<Diagnostic>,
+}
+
+/// Check whether a block will always reach a `break` statement,
+/// regardless of which branch is taken.
+fn block_always_breaks(block: &Block) -> bool {
+    for expr in &block.exprs {
+        if expr_always_breaks(expr) {
+            return true;
+        }
+    }
+    false
+}
+
+fn expr_always_breaks(expr: &Expression) -> bool {
+    match &expr.expr_ {
+        Expression_::Break => true,
+        Expression_::If(_, then_block, Some(else_block)) => {
+            block_always_breaks(then_block) && block_always_breaks(else_block)
+        }
+        Expression_::Match(_, cases) if !cases.is_empty() => {
+            cases.iter().all(|(_, block)| block_always_breaks(block))
+        }
+        _ => false,
+    }
+}
+
+impl Visitor for UnconditionalBreakVisitor {
+    fn visit_expr_while(&mut self, cond: &Expression, body: &Block) {
+        self.visit_expr(cond);
+
+        if block_always_breaks(body) {
+            self.diagnostics.push(Diagnostic {
+                message: ErrorMessage(vec![
+                    msgtext!("This loop always "),
+                    msgcode!("break"),
+                    msgtext!("s on the first iteration, so it can only execute once."),
+                ]),
+                position: body.open_brace.clone(),
+                notes: vec![],
+                severity: Severity::Warning,
+                fixes: vec![],
+            });
+        }
+
+        self.visit_block(body);
+    }
+
+    fn visit_expr_for_in(&mut self, _: &LetDestination, expr: &Expression, body: &Block) {
+        self.visit_expr(expr);
+
+        if block_always_breaks(body) {
+            self.diagnostics.push(Diagnostic {
+                message: ErrorMessage(vec![
+                    msgtext!("This loop always "),
+                    msgcode!("break"),
+                    msgtext!("s on the first iteration, so it can only execute once."),
+                ]),
+                position: body.open_brace.clone(),
+                notes: vec![],
+                severity: Severity::Warning,
+                fixes: vec![],
+            });
+        }
+
+        self.visit_block(body);
+    }
+
+    fn visit_expr_fun_literal(&mut self, fun_info: &FunInfo) {
+        // A break inside a closure belongs to the closure, not the
+        // outer loop. Continue visiting but don't consider closures
+        // as part of the loop body analysis (block_always_breaks
+        // won't recurse into closures since it only looks at
+        // if/match branches).
+        self.visit_fun_info(fun_info);
+    }
+}
+
+pub(crate) fn check_unconditional_break(items: &[ToplevelItem]) -> Vec<Diagnostic> {
+    let mut visitor = UnconditionalBreakVisitor {
+        diagnostics: vec![],
+    };
+
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics
+}

--- a/src/test_files/check/break_without_loop.gdn
+++ b/src/test_files/check/break_without_loop.gdn
@@ -26,4 +26,13 @@ public fun foo() {
 //  8|         // Bad
 //  9|         fun() { break }
 // 10|     }           ^^^^^
+// 
+// Warning: This loop always `break`s on the first iteration, so it can only execute once.
+// --| src/test_files/check/break_without_loop.gdn:4:16
+//  2|     break
+//  3| 
+//  4|     while True {
+//   |                ^
+//  5|         // Good
+//  6|         break
 

--- a/src/test_files/check/unconditional_break.gdn
+++ b/src/test_files/check/unconditional_break.gdn
@@ -1,0 +1,62 @@
+// Bad: while loop with unconditional break.
+public fun while_break() {
+    while True {
+        break
+    }
+}
+
+// Bad: for loop with unconditional break.
+public fun for_break() {
+    for _x in [1, 2, 3] {
+        break
+    }
+}
+
+// Bad: break in all branches of if/else.
+public fun if_else_break() {
+    while True {
+        if True {
+            break
+        } else {
+            break
+        }
+    }
+}
+
+// Good: conditional break (no else).
+public fun conditional_break() {
+    while True {
+        if True {
+            break
+        }
+    }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: This loop always `break`s on the first iteration, so it can only execute once.
+// --| src/test_files/check/unconditional_break.gdn:3:16
+//  1| // Bad: while loop with unconditional break.
+//  2| public fun while_break() {
+//  3|     while True {
+//  4|         break  ^
+//  5|     }
+// 
+// Warning: This loop always `break`s on the first iteration, so it can only execute once.
+// --| src/test_files/check/unconditional_break.gdn:10:25
+//  8| // Bad: for loop with unconditional break.
+//  9| public fun for_break() {
+// 10|     for _x in [1, 2, 3] {
+// 11|         break           ^
+// 12|     }
+// 
+// Warning: This loop always `break`s on the first iteration, so it can only execute once.
+// --| src/test_files/check/unconditional_break.gdn:17:16
+// 15| // Bad: break in all branches of if/else.
+// 16| public fun if_else_break() {
+// 17|     while True {
+//   |                ^
+// 18|         if True {
+// 19|             break
+


### PR DESCRIPTION
## Summary
This PR adds a new static analysis check that warns when a loop unconditionally breaks on the first iteration, making the loop body execute at most once. This is typically a logic error or indicates code that could be simplified.

## Key Changes
- **New check module** (`src/checks/unconditional_break.rs`): Implements detection of unconditional breaks in `while` and `for` loops
  - Analyzes whether a block always reaches a `break` statement regardless of control flow
  - Handles nested conditionals: detects breaks in all branches of `if/else` and `match` expressions
  - Properly scopes break analysis to avoid false positives from breaks inside closures
  
- **Integration**: Registered the new check in `src/checks.rs` to run as part of the standard check pipeline

- **Test coverage** (`src/test_files/check/unconditional_break.gdn`): Comprehensive test cases covering:
  - Direct unconditional breaks in while loops
  - Direct unconditional breaks in for loops
  - Breaks in all branches of if/else statements
  - Conditional breaks (correctly not flagged as warnings)

- **Documentation**: Updated CHANGELOG.md to document the new warning

## Implementation Details
- The check uses a visitor pattern to traverse the AST
- `block_always_breaks()` recursively analyzes blocks to determine if they unconditionally break
- `expr_always_breaks()` handles different expression types:
  - Direct `break` statements
  - `if/else` expressions (both branches must break)
  - `match` expressions (all cases must break)
- Closures are visited but not analyzed for breaks, since breaks inside closures belong to the closure scope, not the outer loop

https://claude.ai/code/session_012Drr6WDxDCp9ad3733za7R