### PR TITLE
Refactor DictLiteral to use structured DictKeyValue type

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1007,12 +1007,12 @@ impl TypeCheckVisitor<'_> {
             }
             Expression_::DictLiteral(items) => {
                 let mut value_tys = vec![];
-                for (key_expr, _, value_expr) in items {
-                    self.verify_expr(&Type::string(), key_expr, type_bindings, expected_return_ty);
+                for kv in items {
+                    self.verify_expr(&Type::string(), &kv.key, type_bindings, expected_return_ty);
 
                     let inferred_value_ty =
-                        self.infer_expr(value_expr, type_bindings, expected_return_ty);
-                    value_tys.push((inferred_value_ty, value_expr.position.clone()));
+                        self.infer_expr(&kv.value, type_bindings, expected_return_ty);
+                    value_tys.push((inferred_value_ty, kv.value.position.clone()));
                 }
 
                 let value_ty = match unify_all(&value_tys) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5707,7 +5707,7 @@ fn eval_expr(
                 let mut items: FxHashMap<String, Value> = FxHashMap::default();
                 let mut value_type = Type::no_value();
 
-                for (key_expr, _arrow, _v) in item_exprs {
+                for kv in item_exprs {
                     // The evaluated value of key-value pair.
                     let value_value = env
                         .pop_value()
@@ -5723,7 +5723,7 @@ fn eval_expr(
 
                     let key_str = check_string(
                         &key_value,
-                        &key_expr.position,
+                        &kv.key.position,
                         // TODO: set saved_values properly here.
                         vec![],
                         env,
@@ -5741,9 +5741,9 @@ fn eval_expr(
                     outer_expr.clone(),
                 );
 
-                for (key_expr, _, value_expr) in item_exprs.iter() {
-                    env.push_expr_to_eval(ExpressionState::NotEvaluated, value_expr.clone());
-                    env.push_expr_to_eval(ExpressionState::NotEvaluated, key_expr.clone());
+                for kv in item_exprs.iter() {
+                    env.push_expr_to_eval(ExpressionState::NotEvaluated, kv.value.clone());
+                    env.push_expr_to_eval(ExpressionState::NotEvaluated, kv.key.clone());
                 }
             }
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -400,9 +400,9 @@ impl Visitor for IndentationVisitor {
                     }
                 }
                 Expression_::DictLiteral(pairs) => {
-                    for (key_expr, _arrow_pos, value_expr) in pairs {
-                        self.visit_expr(key_expr);
-                        self.visit_expr(value_expr);
+                    for pair in pairs {
+                        self.visit_expr(&pair.key);
+                        self.visit_expr(&pair.value);
                     }
                 }
                 Expression_::TupleLiteral(exprs) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -319,7 +319,7 @@ fn parse_dict_literal_items(
     tokens: &mut TokenStream,
     id_gen: &mut IdGenerator,
     diagnostics: &mut Vec<ParseError>,
-) -> Vec<(Rc<Expression>, Position, Rc<Expression>)> {
+) -> Vec<DictKeyValue> {
     let mut items = vec![];
     loop {
         if peeked_symbol_is(tokens, "]") {
@@ -336,7 +336,11 @@ fn parse_dict_literal_items(
         let arrow = require_token(tokens, diagnostics, "=>");
         let value_expr = parse_expression(tokens, id_gen, diagnostics);
         let value_expr_pos = value_expr.position.clone();
-        items.push((Rc::new(key_expr), arrow.position, Rc::new(value_expr)));
+        items.push(DictKeyValue {
+            key: Rc::new(key_expr),
+            arrow_pos: arrow.position,
+            value: Rc::new(value_expr),
+        });
 
         assert!(
             tokens.idx > start_idx,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -287,6 +287,13 @@ pub(crate) struct ExpressionWithComma {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DictKeyValue {
+    pub(crate) key: Rc<Expression>,
+    pub(crate) arrow_pos: Position,
+    pub(crate) value: Rc<Expression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParenthesizedArguments {
     pub(crate) open_paren: Position,
     pub(crate) arguments: Vec<ExpressionWithComma>,
@@ -372,7 +379,7 @@ pub(crate) enum Expression_ {
     /// ```garden
     /// Dict[x => 1, y ^ z => 2]
     /// ```
-    DictLiteral(Vec<(Rc<Expression>, Position, Rc<Expression>)>),
+    DictLiteral(Vec<DictKeyValue>),
     /// ```garden
     /// ()
     /// (x,)

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -158,9 +158,9 @@ pub(crate) trait Visitor {
                 }
             }
             Expression_::DictLiteral(pairs) => {
-                for (key_expr, _arrow_pos, value_expr) in pairs {
-                    self.visit_expr(key_expr);
-                    self.visit_expr(value_expr);
+                for pair in pairs {
+                    self.visit_expr(&pair.key);
+                    self.visit_expr(&pair.value);
                 }
             }
             Expression_::TupleLiteral(exprs) => {


### PR DESCRIPTION
## Summary
This PR refactors the dictionary literal representation in the AST from a tuple-based structure to a dedicated `DictKeyValue` struct, improving code clarity and maintainability.

## Key Changes
- **New AST Type**: Introduced `DictKeyValue` struct in `src/parser/ast.rs` with named fields (`key`, `arrow_pos`, `value`) to replace the previous tuple representation `(Rc<Expression>, Position, Rc<Expression>)`
- **Parser Update**: Modified `parse_dict_literal_items()` in `src/parser.rs` to construct `DictKeyValue` instances instead of tuples
- **Evaluation**: Updated `eval_expr()` in `src/eval.rs` to destructure `DictKeyValue` using named fields instead of tuple patterns
- **Type Checking**: Refactored type checker in `src/checks/type_checker.rs` to access dictionary key-value pairs via the new struct fields
- **Formatting & Visiting**: Updated visitor implementations in `src/format.rs` and `src/parser/visitor.rs` to work with the structured type

## Implementation Details
The refactoring maintains identical functionality while improving code readability by replacing cryptic tuple destructuring patterns like `for (key_expr, _, value_expr) in items` with clearer named field access like `for kv in items { kv.key, kv.value }`. The `arrow_pos` field is now explicitly named rather than being an unnamed tuple element, making the code's intent more obvious.

https://claude.ai/code/session_0117DPeCxc9yGSmqWf32j34D