### PR TITLE
Refactor Parentheses expression to use struct instead of tuple

### DIFF
--- a/src/checks/same_literal_returns.rs
+++ b/src/checks/same_literal_returns.rs
@@ -92,7 +92,7 @@ fn expr_as_constant(expr: &Expression) -> Option<LiteralValue> {
                 None
             }
         }
-        Expression_::Parentheses(_, inner, _) => expr_as_constant(inner),
+        Expression_::Parentheses(paren) => expr_as_constant(&paren.expr),
         _ => None,
     }
 }

--- a/src/checks/self_assign_compare.rs
+++ b/src/checks/self_assign_compare.rs
@@ -17,7 +17,7 @@ fn expr_key(expr: &Expression) -> Option<String> {
         Expression_::Variable(sym) => Some(sym.name.text.clone()),
         Expression_::IntLiteral(n) => Some(format!("int:{}", n)),
         Expression_::StringLiteral(s) => Some(format!("str:{}", s)),
-        Expression_::Parentheses(_, inner, _) => expr_key(inner),
+        Expression_::Parentheses(paren) => expr_key(&paren.expr),
         _ => None,
     }
 }

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1098,8 +1098,8 @@ impl TypeCheckVisitor<'_> {
                 self.verify_expr(&Type::bool(), expr, type_bindings, expected_return_ty);
                 Type::unit()
             }
-            Expression_::Parentheses(_, expr, _) => {
-                self.infer_expr(expr, type_bindings, expected_return_ty)
+            Expression_::Parentheses(paren) => {
+                self.infer_expr(&paren.expr, type_bindings, expected_return_ty)
             }
             Expression_::Invalid => {
                 // We've already emitted a parse error, so use the

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6011,8 +6011,8 @@ fn eval_expr(
             *expr_state = ExpressionState::EvaluatedAllSubexpressions;
             eval_continue(env);
         }
-        Expression_::Parentheses(_, expr, _) => {
-            env.push_expr_to_eval(ExpressionState::NotEvaluated, expr.clone());
+        Expression_::Parentheses(paren) => {
+            env.push_expr_to_eval(ExpressionState::NotEvaluated, paren.expr.clone());
         }
         Expression_::Invalid => {
             return Err((RestoreValues(vec![]),

--- a/src/extract_variable.rs
+++ b/src/extract_variable.rs
@@ -38,7 +38,7 @@ pub(crate) fn extract_variable(
             // wrapped in Parentheses, we want to remove the
             // parentheses too when extracting.
             if let Some(expr) = find_expr_of_id(&items, *syntax_id) {
-                if let Expression_::Parentheses(_, _, _) = expr.expr_ {
+                if let Expression_::Parentheses(_) = expr.expr_ {
                     expr_id = Some(syntax_id);
                 }
             }
@@ -114,7 +114,7 @@ pub(crate) fn extract_variable(
         return Err("No expression found for the ID at the selected position.".to_owned());
     };
     let var_init_expr = match expr.expr_ {
-        Expression_::Parentheses(_, inner_expr, _) => inner_expr,
+        Expression_::Parentheses(paren) => paren.expr,
         _ => Rc::new(expr.clone()),
     };
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -440,8 +440,8 @@ impl Visitor for IndentationVisitor {
                 Expression_::Assert(expr) => {
                     self.visit_expr(expr);
                 }
-                Expression_::Parentheses(_, expr, _) => {
-                    self.visit_expr(expr);
+                Expression_::Parentheses(paren) => {
+                    self.visit_expr(&paren.expr);
                 }
                 Expression_::Invalid => {}
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -287,11 +287,11 @@ fn parse_tuple_literal_or_parentheses(
     let position = Position::merge(&open_paren.position, &close_paren.position);
     Expression::new(
         position,
-        Expression_::Parentheses(
-            open_paren.position.clone(),
-            Rc::new(expr),
-            close_paren.position.clone(),
-        ),
+        Expression_::Parentheses(ParenthesizedExpression {
+            open_paren: open_paren.position.clone(),
+            expr: Rc::new(expr),
+            close_paren: close_paren.position.clone(),
+        }),
         id_gen.next(),
     )
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -294,6 +294,13 @@ pub(crate) struct DictKeyValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParenthesizedExpression {
+    pub(crate) open_paren: Position,
+    pub(crate) expr: Rc<Expression>,
+    pub(crate) close_paren: Position,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParenthesizedArguments {
     pub(crate) open_paren: Position,
     pub(crate) arguments: Vec<ExpressionWithComma>,
@@ -435,7 +442,7 @@ pub(crate) enum Expression_ {
     /// (x)
     /// x * (y * z)
     /// ```
-    Parentheses(Position, Rc<Expression>, Position),
+    Parentheses(ParenthesizedExpression),
     /// We had a parse error in this position, so there's no
     /// expression.
     Invalid,

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -214,8 +214,8 @@ pub(crate) trait Visitor {
             Expression_::Assert(expr) => {
                 self.visit_expr(expr);
             }
-            Expression_::Parentheses(_, expr, _) => {
-                self.visit_expr(expr);
+            Expression_::Parentheses(paren) => {
+                self.visit_expr(&paren.expr);
             }
             Expression_::Invalid => {
                 // TODO: custom method for this variant

--- a/src/test_files/parser/accidental_rust_dbg.gdn
+++ b/src/test_files/parser/accidental_rust_dbg.gdn
@@ -38,16 +38,18 @@ fun foo() {
 //                 Expression {
 //                     position: Position { ... },
 //                     expr_: Parentheses(
-//                         Position { ... },
-//                         Expression {
-//                             position: Position { ... },
-//                             expr_: IntLiteral(
-//                                 1,
-//                             ),
-//                             value_is_used: true,
-//                             id: SyntaxId(3),
+//                         ParenthesizedExpression {
+//                             open_paren: Position { ... },
+//                             expr: Expression {
+//                                 position: Position { ... },
+//                                 expr_: IntLiteral(
+//                                     1,
+//                                 ),
+//                                 value_is_used: true,
+//                                 id: SyntaxId(3),
+//                             },
+//                             close_paren: Position { ... },
 //                         },
-//                         Position { ... },
 //                     ),
 //                     value_is_used: true,
 //                     id: SyntaxId(4),

--- a/src/test_files/parser/unfinished_match.gdn
+++ b/src/test_files/parser/unfinished_match.gdn
@@ -53,16 +53,18 @@ fun foo(src) {
 //                 Expression {
 //                     position: Position { ... },
 //                     expr_: Parentheses(
-//                         Position { ... },
-//                         Expression {
-//                             position: Position { ... },
-//                             expr_: StringLiteral(
-//                                 "",
-//                             ),
-//                             value_is_used: true,
-//                             id: SyntaxId(5),
+//                         ParenthesizedExpression {
+//                             open_paren: Position { ... },
+//                             expr: Expression {
+//                                 position: Position { ... },
+//                                 expr_: StringLiteral(
+//                                     "",
+//                                 ),
+//                                 value_is_used: true,
+//                                 id: SyntaxId(5),
+//                             },
+//                             close_paren: Position { ... },
 //                         },
-//                         Position { ... },
 //                     ),
 //                     value_is_used: true,
 //                     id: SyntaxId(6),


### PR DESCRIPTION
## Summary
This PR refactors the `Parentheses` variant of the `Expression_` enum to use a dedicated `ParenthesizedExpression` struct instead of a tuple of three elements. This improves code clarity and maintainability by using named fields instead of positional arguments.

## Key Changes
- **New struct**: Added `ParenthesizedExpression` struct with named fields (`open_paren`, `expr`, `close_paren`) in `src/parser/ast.rs`
- **AST update**: Changed `Expression_::Parentheses` from `Parentheses(Position, Rc<Expression>, Position)` to `Parentheses(ParenthesizedExpression)`
- **Parser update**: Updated `parse_tuple_literal_or_parentheses()` in `src/parser.rs` to construct the new struct
- **Visitor pattern**: Updated all pattern matching across the codebase to use the new struct fields:
  - `src/checks/type_checker.rs`
  - `src/eval.rs`
  - `src/extract_variable.rs`
  - `src/format.rs`
  - `src/parser/visitor.rs`
  - `src/checks/same_literal_returns.rs`
  - `src/checks/self_assign_compare.rs`
- **Test files**: Updated expected debug output in test files to reflect the new struct representation

## Implementation Details
The refactoring maintains all existing functionality while improving code readability. All pattern matches now use named field access (`paren.expr`, `paren.open_paren`, `paren.close_paren`) instead of positional tuple destructuring, making the code more self-documenting and less error-prone.

https://claude.ai/code/session_01N8Hjhg6evsmzdyT5CTe7XB