### PR TITLE
Reduce CodeMirror editor font size from 17px to 16px

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -379,7 +379,7 @@ ul ul {
 /* CodeMirror Integration */
 .cm-editor {
   font-family: monospace;
-  font-size: 17px;
+  font-size: 16px;
   line-height: 20px;
   border: none;
   outline: none;


### PR DESCRIPTION
## Summary
Adjusted the font size of the CodeMirror editor to improve visual consistency and readability.

## Changes
- Reduced `.cm-editor` font size from 17px to 16px while maintaining the 20px line-height

## Details
This change makes the editor font size more proportional to the line-height ratio, providing better visual balance in the code editing interface.

https://claude.ai/code/session_011FJsEJkPryWh8AopeW186d