### PR TITLE
Hide header on scroll down, reveal on scroll up

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -227,6 +227,11 @@ header {
   right: 0;
   z-index: 100;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.4);
+  transition: transform 0.3s ease;
+}
+
+header.header-hidden {
+  transform: translateY(-100%);
 }
 
 header a {

--- a/website/template.html
+++ b/website/template.html
@@ -31,5 +31,20 @@
     </footer>
 
     <script type="module" src="/static/playground.js"></script>
+    <script>
+      (function () {
+        var lastScrollY = window.scrollY;
+        var header = document.querySelector("header");
+        window.addEventListener("scroll", function () {
+          var currentScrollY = window.scrollY;
+          if (currentScrollY > lastScrollY && currentScrollY > 60) {
+            header.classList.add("header-hidden");
+          } else {
+            header.classList.remove("header-hidden");
+          }
+          lastScrollY = currentScrollY;
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- The fixed header wastes vertical space when users are reading content
- Header now auto-hides when scrolling down and reappears when scrolling up
- Uses a CSS `transform: translateY(-100%)` with a 0.3s ease transition for smooth animation
- Scroll detection ignores the first 60px so the header stays visible at the top of the page

## Test plan
- [ ] Open any page on the website and scroll down — header should slide out of view
- [ ] Scroll back up — header should slide back into view
- [ ] Refresh page at top — header should be visible immediately
- [ ] Test on mobile viewport widths to ensure responsive behavior is preserved

https://claude.ai/code/session_01R5fn9FzwMAomYvf5aNSmCR