### PR TITLE
Fix parser panic on malformed tuple literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Added a warning for unnecessary `let` bindings where a variable is
 bound and immediately returned (e.g. `let x = foo() x` can be
 simplified to `foo()`), with an autofix.
 
+## Parsing
+
+Fixed a parser panic on malformed tuple literals such as `(,{` where
+the parser failed to make forward progress after recovering from an
+invalid element.
+
 ## Commands
 
 Added :load to evaluate all definitions in a file and switch to that

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -266,10 +266,12 @@ fn parse_tuple_literal_or_parentheses(
 
             let start_idx = tokens.idx;
             exprs.push(parse_expression(tokens, id_gen, diagnostics));
-            assert!(
-                tokens.idx > start_idx,
-                "The parser should always make forward progress."
-            );
+            if tokens.idx == start_idx {
+                // `parse_expression` could not consume any tokens and
+                // has already emitted a diagnostic. Stop collecting
+                // tuple elements to avoid an infinite loop.
+                break;
+            }
         }
 
         let close_paren = require_token(tokens, diagnostics, ")");

--- a/src/test_files/parser/tuple_no_progress.gdn
+++ b/src/test_files/parser/tuple_no_progress.gdn
@@ -1,0 +1,47 @@
+(,{
+
+// args: dump-ast
+// expected stdout:
+// TupleLiteral(
+//     [
+//         Expression {
+//             position: Position { ... },
+//             expr_: Invalid,
+//             value_is_used: true,
+//             id: SyntaxId(0),
+//         },
+//         Expression {
+//             position: Position { ... },
+//             expr_: Invalid,
+//             value_is_used: true,
+//             id: SyntaxId(1),
+//         },
+//     ],
+// )
+// Block(
+//     Block {
+//         open_brace: Position { ... },
+//         exprs: [],
+//         close_brace: Position { ... },
+//     },
+// )
+
+// expected stderr:
+// Error: Parse error: Expected an expression after this.
+// --| src/test_files/parser/tuple_no_progress.gdn:1:1
+//  1| (,{
+//   | ^
+//  2| 
+//  3| // args: dump-ast
+// Error: Parse error: Expected an expression after this.
+// --| src/test_files/parser/tuple_no_progress.gdn:1:2
+//  1| (,{
+//  2|  ^
+//  3| // args: dump-ast
+// Error: Parse error: Expected `)` after this.
+// --| src/test_files/parser/tuple_no_progress.gdn:1:2
+//  1| (,{
+//  2|  ^
+//  3| // args: dump-ast
+// Parse error (incomplete input): Expected `}`, but got EOF.
+


### PR DESCRIPTION
## Summary
Fixed a parser panic that occurred when parsing malformed tuple literals where the parser failed to make forward progress after recovering from an invalid element.

## Changes
- **Parser recovery logic**: Changed the assertion in `parse_tuple_literal_or_parentheses` to a conditional check that breaks the parsing loop when `parse_expression` fails to consume any tokens, preventing infinite loops during error recovery
- **Test case**: Added `tuple_no_progress.gdn` test file to verify the parser correctly handles malformed input like `(,{` and emits appropriate diagnostics without panicking
- **Documentation**: Updated CHANGELOG.md to document the fix

## Implementation Details
The issue occurred because when `parse_expression` encountered an error and couldn't consume any tokens, the parser would remain at the same position and attempt to parse the next tuple element infinitely. The fix detects this condition and breaks out of the loop, allowing the parser to continue gracefully with error recovery already handled by the diagnostic system.

https://claude.ai/code/session_01Smbrb7sx8HkXRUkSXNLfme