### PR TITLE
Add float literal syntax support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ completion, quickfixes and basic formatting. You can start it with
 
 ## Syntax
 
+Added float literal syntax, e.g. `1.5` or `-3.14`.
+
 Documentation is now written with triple slashes, e.g. `///`, to
 distinguish from normal comments.
 

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -975,6 +975,7 @@ impl TypeCheckVisitor<'_> {
                 Type::no_value()
             }
             Expression_::IntLiteral(_) => Type::int(),
+            Expression_::FloatLiteral(_) => Type::error("Float type not yet implemented"),
             Expression_::StringLiteral(_) => Type::string(),
             Expression_::ListLiteral(items) => {
                 let item_tys = items

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -625,6 +625,7 @@ pub(crate) fn run_command<T: Write>(
                     | Value_::Closure(_, _, _)
                     | Value_::BuiltInFunction(_, _, _) => true,
                     Value_::Integer(_) => false,
+                    Value_::Float(_) => false,
                     Value_::String(_) => false,
                     Value_::List { .. } => false,
                     Value_::Tuple { .. } => false,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5664,6 +5664,12 @@ fn eval_expr(
                 env.push_value(Value::new(Value_::Integer(*i)));
             }
         }
+        Expression_::FloatLiteral(f) => {
+            *expr_state = ExpressionState::EvaluatedAllSubexpressions;
+            if expr_value_is_used {
+                env.push_value(Value::new(Value_::Float(f.into_inner())));
+            }
+        }
         Expression_::StringLiteral(s) => {
             *expr_state = ExpressionState::EvaluatedAllSubexpressions;
             if expr_value_is_used {

--- a/src/format.rs
+++ b/src/format.rs
@@ -428,6 +428,7 @@ impl Visitor for IndentationVisitor {
                     self.visit_expr_fun_literal(fun_info);
                 }
                 Expression_::IntLiteral(_) => {}
+                Expression_::FloatLiteral(_) => {}
                 Expression_::StringLiteral(_) => {}
                 Expression_::DotAccess(recv, field_sym) => {
                     self.visit_symbol(field_sym);

--- a/src/garden_type.rs
+++ b/src/garden_type.rs
@@ -265,6 +265,7 @@ impl Type {
     pub(crate) fn from_value(value: &Value) -> Self {
         match value.as_ref() {
             Value_::Integer(_) => Type::int(),
+            Value_::Float(_) => Type::error("Float type not yet implemented"),
             Value_::Fun { runtime_type, .. } => runtime_type.clone(),
             Value_::Closure(_, _, runtime_type) => runtime_type.clone(),
             Value_::BuiltInFunction(_, _, Some(runtime_type)) => runtime_type.clone(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ use position::Position;
 use ast::*;
 use diagnostics::ErrorMessage;
 use diagnostics::MessagePart::*;
-use lex::{lex, lex_between, Token, TokenStream, INTEGER_RE, SYMBOL_RE};
+use lex::{lex, lex_between, Token, TokenStream, FLOAT_RE, INTEGER_RE, SYMBOL_RE};
 use rustc_hash::FxHashMap;
 use vfs::VfsPathBuf;
 
@@ -190,6 +190,43 @@ fn parse_integer(
         Expression::new(
             token.position,
             Expression_::IntLiteral(11223344),
+            id_gen.next(),
+        )
+    }
+}
+
+fn parse_float(
+    tokens: &mut TokenStream,
+    id_gen: &mut IdGenerator,
+    diagnostics: &mut Vec<ParseError>,
+) -> Expression {
+    let token = require_a_token(tokens, diagnostics, "float literal");
+
+    if FLOAT_RE.is_match(token.text) {
+        let text = token.text.replace('_', "");
+        let f: f64 = text.parse().unwrap();
+        Expression::new(
+            token.position,
+            Expression_::FloatLiteral(f.into()),
+            id_gen.next(),
+        )
+    } else {
+        diagnostics.push(ParseError::Invalid {
+            position: token.position.clone(),
+            message: ErrorMessage(vec![
+                msgcode!("{}", token.text),
+                msgtext!(" is not a valid float literal. Float literals look like "),
+                msgcode!("1.5"),
+                msgtext!("."),
+            ]),
+            notes: vec![],
+        });
+
+        // Choose an arbitrary value that's hopefully unlikely to
+        // occur in real code.
+        Expression::new(
+            token.position,
+            Expression_::FloatLiteral(1122.3344.into()),
             id_gen.next(),
         )
     }
@@ -752,6 +789,10 @@ fn parse_simple_expression(
                 Expression_::StringLiteral(unescaped),
                 id_gen.next(),
             );
+        }
+
+        if FLOAT_RE.is_match(token.text) {
+            return parse_float(tokens, id_gen, diagnostics);
         }
 
         if INTEGER_RE.is_match(token.text) {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,5 +1,6 @@
 //! Syntax tree definitions for Garden.
 
+use ordered_float::OrderedFloat;
 use rustc_hash::FxHashMap;
 
 use std::fmt::Display;
@@ -447,6 +448,10 @@ pub(crate) enum Expression_ {
     /// 123
     /// ```
     IntLiteral(i64),
+    /// ```garden
+    /// 1.5
+    /// ```
+    FloatLiteral(OrderedFloat<f64>),
     /// ```garden
     /// "foo"
     /// ```

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -199,6 +199,9 @@ pub(crate) trait Visitor {
             Expression_::IntLiteral(_) => {
                 // TODO: custom method for this variant
             }
+            Expression_::FloatLiteral(_) => {
+                // TODO: custom method for this variant
+            }
             Expression_::StringLiteral(_) => {
                 // TODO: custom method for this variant
             }

--- a/src/test_files/parser/float_literal.gdn
+++ b/src/test_files/parser/float_literal.gdn
@@ -1,0 +1,21 @@
+let x = 1.5
+
+// args: dump-ast
+// expected stdout:
+// Let(
+//     Symbol(
+//         Symbol"x",
+//     ),
+//     None,
+//     Expression {
+//         position: Position { ... },
+//         expr_: FloatLiteral(
+//             OrderedFloat(
+//                 1.5,
+//             ),
+//         ),
+//         value_is_used: true,
+//         id: SyntaxId(1),
+//     },
+// )
+

--- a/src/values.rs
+++ b/src/values.rs
@@ -47,6 +47,8 @@ impl Value {
 pub(crate) enum Value_ {
     /// An integer value.
     Integer(i64),
+    /// A floating-point value.
+    Float(f64),
     /// A reference to a user-defined function, along with its return
     /// type.
     Fun {
@@ -344,6 +346,7 @@ pub(crate) fn type_representation(value: &Value) -> TypeName {
     TypeName {
         text: match value.as_ref() {
             Value_::Integer(_) => "Int",
+            Value_::Float(_) => "Float",
             Value_::Fun { .. } => "Fun",
             Value_::Closure(_, _, _) => "Fun",
             Value_::BuiltInFunction(_, _, _) => "Fun",
@@ -485,6 +488,7 @@ impl Value {
     pub(crate) fn display(&self, env: &Env) -> String {
         match self.as_ref() {
             Value_::Integer(i) => format!("{i}"),
+            Value_::Float(f) => format!("{f}"),
             Value_::Fun { name_sym, .. } => format!("{}", name_sym.name),
             Value_::Closure(..) => "(closure)".to_owned(),
             Value_::BuiltInFunction(kind, _, _) => format!("{kind}"),


### PR DESCRIPTION
This PR adds support for floating-point literal syntax to the Garden language, allowing developers to write float values like `1.5` or `-3.14`.

## Summary
Float literals are now recognized and parsed as a distinct expression type, with proper lexing, parsing, evaluation, and type checking infrastructure in place.

## Key Changes

- **Lexer**: Added `FLOAT_RE` regex pattern to match float literals (e.g., `1.5`, `-3.14`) and integrated float matching before integer matching to correctly parse decimals
- **Parser**: 
  - Implemented `parse_float()` function to parse float tokens and generate `FloatLiteral` AST nodes
  - Added `FloatLiteral` variant to `Expression_` enum using `OrderedFloat<f64>`
  - Updated `parse_simple_expression()` to check for floats before integers
- **Evaluator**: Added float evaluation logic in `eval_expr()` to push `Value_::Float` onto the environment stack
- **Values**: 
  - Added `Float(f64)` variant to `Value_` enum
  - Updated `type_representation()` and `display()` functions to handle float values
- **Type System**: Added float type checking (currently returns error as Float type is not yet fully implemented)
- **Visitor Pattern**: Added float literal visitor stub for future custom handling
- **Formatting & Commands**: Updated pattern matching to handle the new `Float` value variant
- **Tests**: Added `float_literal.gdn` test file demonstrating float literal parsing

## Implementation Details

- Float regex pattern: `^-?[0-9][0-9_]*\.[0-9][0-9_]*` (supports underscores for readability, e.g., `1_000.5`)
- Float matching occurs before integer matching in the lexer to prevent `1.5` from being tokenized as `1`, `.`, `5`
- Uses `OrderedFloat` wrapper for proper f64 handling in the AST
- Type checking currently returns an error placeholder as the Float type system is not yet fully implemented

https://claude.ai/code/session_01NTtUtbx2KjfD2PxbX3PSHa