### PR TITLE
Migrate from lsp-types to gen-lsp-types library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,12 +83,6 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -154,7 +148,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -237,7 +231,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -306,15 +300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,12 +316,12 @@ dependencies = [
  "clap",
  "ctrlc",
  "escargot",
+ "gen-lsp-types",
  "goldentests",
  "humantime",
  "itertools",
  "lazy_static",
  "line-numbers",
- "lsp-types",
  "normalize-path",
  "ordered-float",
  "owo-colors",
@@ -351,6 +336,17 @@ dependencies = [
  "strsim 0.10.0",
  "strum",
  "strum_macros",
+ "url",
+]
+
+[[package]]
+name = "gen-lsp-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4552cb20fa322e0ebc35c2bbbe3eed8ace907bbcedc92aace7a325c9064b80b"
+dependencies = [
+ "serde",
+ "serde_json",
  "url",
 ]
 
@@ -603,19 +599,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "lsp-types"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
-dependencies = [
- "bitflags 1.3.2",
- "fluent-uri",
- "serde",
- "serde_json",
- "serde_repr",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,7 +619,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -648,7 +631,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -749,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -762,7 +745,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -890,7 +873,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -903,7 +886,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -922,7 +905,7 @@ version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -939,51 +922,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "serde"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
 
 [[package]]
-name = "serde"
-version = "1.0.202"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.63",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1064,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1081,7 +1059,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1136,14 +1114,15 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1410,7 +1389,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
@@ -1438,7 +1417,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1459,7 +1438,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1479,7 +1458,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1513,5 +1492,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ humantime = "2.1.0"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 line-numbers = "0.4.0"
-lsp-types = "0.97.0"
+gen-lsp-types = { version = "0.5.0", features = ["url"] }
 ordered-float = "3.7.0"
 url = "2.5.0"
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
-use lsp_types::{CompletionItem, CompletionItemKind, InsertTextFormat};
+use gen_lsp_types::{CompletionItem, CompletionItemKind, InsertTextFormat};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::checks::type_checker::check_types;
@@ -114,7 +114,7 @@ fn get_namespace_values(
         let ty = Type::from_value(value);
         items.push(CompletionItem {
             label: name.text.clone(),
-            kind: Some(CompletionItemKind::VARIABLE),
+            kind: Some(CompletionItemKind::Variable),
             detail: Some(format!(": {}", ty)),
             ..Default::default()
         });
@@ -133,7 +133,7 @@ fn get_local_variables(bindings: &[(SymbolName, Type)], prefix: &str) -> Vec<Com
 
         items.push(CompletionItem {
             label: name.text.clone(),
-            kind: Some(CompletionItemKind::VARIABLE),
+            kind: Some(CompletionItemKind::Variable),
             detail: Some(format!(": {}", ty)),
             ..Default::default()
         });
@@ -196,10 +196,10 @@ fn get_methods(env: &Env, recv_ty: &Type, prefix: &str) -> Vec<CompletionItem> {
 
         items.push(CompletionItem {
             label,
-            kind: Some(CompletionItemKind::METHOD),
+            kind: Some(CompletionItemKind::Method),
             detail: Some(detail),
             insert_text: Some(insert_text),
-            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            insert_text_format: Some(InsertTextFormat::Snippet),
             ..Default::default()
         });
     }
@@ -212,7 +212,7 @@ fn get_methods(env: &Env, recv_ty: &Type, prefix: &str) -> Vec<CompletionItem> {
 
             items.push(CompletionItem {
                 label: field.sym.name.text.clone(),
-                kind: Some(CompletionItemKind::FIELD),
+                kind: Some(CompletionItemKind::Field),
                 detail: Some(format!(": {}", field.hint.as_src())),
                 ..Default::default()
             });
@@ -282,10 +282,10 @@ fn get_namespace_functions(
 
         items.push(CompletionItem {
             label,
-            kind: Some(CompletionItemKind::FUNCTION),
+            kind: Some(CompletionItemKind::Function),
             detail: Some(detail),
             insert_text: Some(insert_text),
-            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            insert_text_format: Some(InsertTextFormat::Snippet),
             ..Default::default()
         });
     }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,14 +1,12 @@
 //! LSP (Language Server Protocol) support for Garden.
 
-use lsp_types::request::{
-    CodeActionRequest, Completion, Formatting, GotoDefinition, Initialize, Request, Shutdown,
-};
-use lsp_types::{
-    CodeAction, CodeActionKind, CodeActionOptions, CodeActionParams, CodeActionProviderCapability,
-    CodeActionResponse, CompletionItem, CompletionOptions, CompletionParams, Diagnostic,
-    DiagnosticSeverity, DocumentFormattingParams, GotoDefinitionParams, InitializeParams,
-    InitializeResult, Location, Position, PublishDiagnosticsParams, Range, ServerCapabilities,
-    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri, WorkspaceEdit,
+use gen_lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOptions, CodeActionParams, CodeActionProvider,
+    CodeActionResponse, CompletionItem, CompletionOptions, CompletionParams, DefinitionParams,
+    DefinitionProvider, Diagnostic, DiagnosticSeverity, DocumentFormattingParams,
+    DocumentFormattingProvider, InitializeParams, InitializeResult, Location, Position,
+    PublishDiagnosticsParams, Range, ServerCapabilities, ServerInfo, TextDocumentSync,
+    TextDocumentSyncKind, TextEdit, Uri, WorkspaceEdit,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -139,11 +137,10 @@ fn write_message<T: Serialize>(message: &T) -> io::Result<()> {
 
 /// Convert a file path to an LSP URI.
 fn path_to_uri(path: &PathBuf) -> Uri {
-    let url = Url::from_file_path(path).unwrap_or_else(|_| {
+    Url::from_file_path(path).unwrap_or_else(|_| {
         // Fallback to file:// scheme with display
         Url::parse(&format!("file://{}", path.display())).unwrap()
-    });
-    url.as_str().parse().unwrap()
+    })
 }
 
 /// Convert a Garden position to an LSP range.
@@ -182,7 +179,7 @@ fn get_diagnostics(src: &str, path: &PathBuf) -> Vec<Diagnostic> {
 
         diagnostics.push(Diagnostic {
             range: garden_pos_to_lsp_range(&position),
-            severity: Some(DiagnosticSeverity::ERROR),
+            severity: Some(DiagnosticSeverity::Error),
             message,
             ..Default::default()
         });
@@ -203,8 +200,8 @@ fn get_diagnostics(src: &str, path: &PathBuf) -> Vec<Diagnostic> {
         } in raw_diagnostics
         {
             let lsp_severity = match severity {
-                Severity::Error => DiagnosticSeverity::ERROR,
-                Severity::Warning => DiagnosticSeverity::WARNING,
+                Severity::Error => DiagnosticSeverity::Error,
+                Severity::Warning => DiagnosticSeverity::Warning,
             };
 
             diagnostics.push(Diagnostic {
@@ -280,15 +277,15 @@ fn handle_initialize(
 ) -> JsonRpcResponse<InitializeResult> {
     let result = InitializeResult {
         capabilities: ServerCapabilities {
-            definition_provider: Some(lsp_types::OneOf::Left(true)),
+            definition_provider: Some(DefinitionProvider::Bool(true)),
             completion_provider: Some(CompletionOptions {
                 trigger_characters: Some(vec![".".to_owned(), "::".to_owned()]),
                 ..Default::default()
             }),
-            text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
-            document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
-            code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
-                code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+            text_document_sync: Some(TextDocumentSync::Kind(TextDocumentSyncKind::Full)),
+            document_formatting_provider: Some(DocumentFormattingProvider::Bool(true)),
+            code_action_provider: Some(CodeActionProvider::CodeActionOptions(CodeActionOptions {
+                code_action_kinds: Some(vec![CodeActionKind::QuickFix]),
                 ..Default::default()
             })),
             ..Default::default()
@@ -356,7 +353,7 @@ fn handle_did_open(params: &serde_json::Value, documents: &mut DocumentStore) ->
 
     // Get diagnostics and send them
     let diagnostics = get_diagnostics(text, &path);
-    send_diagnostics(url.as_str().parse().unwrap(), diagnostics)
+    send_diagnostics(url, diagnostics)
 }
 
 /// Handle textDocument/didChange notification.
@@ -398,7 +395,7 @@ fn handle_did_change(params: &serde_json::Value, documents: &mut DocumentStore) 
 
     // Get diagnostics and send them
     let diagnostics = get_diagnostics(text, &path);
-    send_diagnostics(url.as_str().parse().unwrap(), diagnostics)
+    send_diagnostics(url, diagnostics)
 }
 
 /// Handle a textDocument/completion request.
@@ -407,16 +404,11 @@ fn handle_completion(
     params: CompletionParams,
     documents: &DocumentStore,
 ) -> JsonRpcResponse<Vec<CompletionItem>> {
-    let uri = &params.text_document_position.text_document.uri;
-    let position = params.text_document_position.position;
+    let uri = &params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
 
     // Convert file:// URI to path
-    let url = match Url::parse(uri.as_str()) {
-        Ok(u) => u,
-        Err(_) => return JsonRpcResponse::new(id, vec![]),
-    };
-
-    let path = match url.to_file_path() {
+    let path = match uri.to_file_path() {
         Ok(p) => p,
         Err(_) => return JsonRpcResponse::new(id, vec![]),
     };
@@ -442,19 +434,14 @@ fn handle_completion(
 /// Handle a textDocument/definition request.
 fn handle_definition(
     id: serde_json::Value,
-    params: GotoDefinitionParams,
+    params: DefinitionParams,
     documents: &DocumentStore,
 ) -> JsonRpcResponse<Option<Location>> {
     let uri = &params.text_document_position_params.text_document.uri;
     let position = params.text_document_position_params.position;
 
     // Convert file:// URI to path
-    let url = match Url::parse(uri.as_str()) {
-        Ok(u) => u,
-        Err(_) => return JsonRpcResponse::new(id, None),
-    };
-
-    let path = match url.to_file_path() {
+    let path = match uri.to_file_path() {
         Ok(p) => p,
         Err(_) => return JsonRpcResponse::new(id, None),
     };
@@ -495,12 +482,7 @@ fn handle_formatting(
     let uri = &params.text_document.uri;
 
     // Convert file:// URI to path
-    let url = match Url::parse(uri.as_str()) {
-        Ok(u) => u,
-        Err(_) => return JsonRpcResponse::new(id, vec![]),
-    };
-
-    let path = match url.to_file_path() {
+    let path = match uri.to_file_path() {
         Ok(p) => p,
         Err(_) => return JsonRpcResponse::new(id, vec![]),
     };
@@ -546,16 +528,11 @@ fn handle_code_action(
     id: serde_json::Value,
     params: CodeActionParams,
     documents: &DocumentStore,
-) -> JsonRpcResponse<CodeActionResponse> {
+) -> JsonRpcResponse<Vec<CodeActionResponse>> {
     let uri = &params.text_document.uri;
 
     // Convert file:// URI to path
-    let url = match Url::parse(uri.as_str()) {
-        Ok(u) => u,
-        Err(_) => return JsonRpcResponse::new(id, vec![]),
-    };
-
-    let path = match url.to_file_path() {
+    let path = match uri.to_file_path() {
         Ok(p) => p,
         Err(_) => return JsonRpcResponse::new(id, vec![]),
     };
@@ -572,7 +549,7 @@ fn handle_code_action(
     let fixes = get_fixes(&src, &path);
 
     // Convert fixes to code actions
-    let mut actions: CodeActionResponse = vec![];
+    let mut actions: Vec<CodeActionResponse> = vec![];
     for fix in fixes {
         let range = garden_pos_to_lsp_range(&fix.position);
 
@@ -586,9 +563,6 @@ fn handle_code_action(
             new_text: fix.new_text,
         };
 
-        // lsp_types::Uri has interior mutability, but this is the
-        // standard way to construct WorkspaceEdit.
-        #[allow(clippy::mutable_key_type)]
         let mut changes = std::collections::HashMap::new();
         changes.insert(uri.clone(), vec![text_edit]);
 
@@ -599,12 +573,12 @@ fn handle_code_action(
 
         let action = CodeAction {
             title: fix.description,
-            kind: Some(CodeActionKind::QUICKFIX),
+            kind: Some(CodeActionKind::QuickFix),
             edit: Some(workspace_edit),
             ..Default::default()
         };
 
-        actions.push(lsp_types::CodeActionOrCommand::CodeAction(action));
+        actions.push(CodeActionResponse::CodeAction(action));
     }
 
     JsonRpcResponse::new(id, actions)
@@ -687,7 +661,7 @@ pub(crate) fn run_lsp() {
         };
 
         match parsed.method.as_deref() {
-            Some(method) if method == Initialize::METHOD => {
+            Some("initialize") => {
                 if let Some(id) = parsed.id {
                     let params: InitializeParams = match message
                         .get("params")
@@ -708,7 +682,7 @@ pub(crate) fn run_lsp() {
             Some("initialized") => {
                 // This is a notification, no response needed
             }
-            Some(method) if method == Completion::METHOD => {
+            Some("textDocument/completion") => {
                 if let Some(id) = parsed.id {
                     let params: CompletionParams = match message
                         .get("params")
@@ -726,9 +700,9 @@ pub(crate) fn run_lsp() {
                     }
                 }
             }
-            Some(method) if method == GotoDefinition::METHOD => {
+            Some("textDocument/definition") => {
                 if let Some(id) = parsed.id {
-                    let params: GotoDefinitionParams = match message
+                    let params: DefinitionParams = match message
                         .get("params")
                         .and_then(|p| serde_json::from_value(p.clone()).ok())
                     {
@@ -744,7 +718,7 @@ pub(crate) fn run_lsp() {
                     }
                 }
             }
-            Some(method) if method == Formatting::METHOD => {
+            Some("textDocument/formatting") => {
                 if let Some(id) = parsed.id {
                     let params: DocumentFormattingParams = match message
                         .get("params")
@@ -762,7 +736,7 @@ pub(crate) fn run_lsp() {
                     }
                 }
             }
-            Some(method) if method == CodeActionRequest::METHOD => {
+            Some("textDocument/codeAction") => {
                 if let Some(id) = parsed.id {
                     let params: CodeActionParams = match message
                         .get("params")
@@ -792,7 +766,7 @@ pub(crate) fn run_lsp() {
                     eprintln!("Error handling didChange: {e}");
                 }
             }
-            Some(method) if method == Shutdown::METHOD => {
+            Some("shutdown") => {
                 if let Some(id) = parsed.id {
                     let response = handle_shutdown(id);
                     if let Err(e) = write_message(&response) {


### PR DESCRIPTION
## Summary
This PR migrates the LSP (Language Server Protocol) implementation from the `lsp-types` crate to the `gen-lsp-types` crate, which provides a generated and more up-to-date LSP type definitions.

## Key Changes

- **Dependency Update**: Replaced `lsp-types = "0.97.0"` with `gen-lsp-types = { version = "0.5.0", features = ["url"] }` in Cargo.toml
- **Import Updates**: Updated all LSP type imports in `src/lsp.rs` and `src/completions.rs` to use `gen_lsp_types` instead of `lsp_types`
- **Type Name Changes**: Updated enum variant names to match the new library's conventions:
  - `DiagnosticSeverity::ERROR` → `DiagnosticSeverity::Error`
  - `DiagnosticSeverity::WARNING` → `DiagnosticSeverity::Warning`
  - `TextDocumentSyncKind::FULL` → `TextDocumentSyncKind::Full`
  - `CodeActionKind::QUICKFIX` → `CodeActionKind::QuickFix`
  - `CompletionItemKind::VARIABLE` → `CompletionItemKind::Variable`
  - `CompletionItemKind::METHOD` → `CompletionItemKind::Method`
  - `CompletionItemKind::FIELD` → `CompletionItemKind::Field`
  - `CompletionItemKind::FUNCTION` → `CompletionItemKind::Function`
  - `InsertTextFormat::SNIPPET` → `InsertTextFormat::Snippet`
- **Type Wrapper Changes**: Updated capability provider types:
  - `lsp_types::OneOf::Left(true)` → `DefinitionProvider::Bool(true)` and `DocumentFormattingProvider::Bool(true)`
  - `TextDocumentSyncCapability::Kind()` → `TextDocumentSync::Kind()`
  - `CodeActionProviderCapability::Options()` → `CodeActionProvider::CodeActionOptions()`
  - `CodeActionResponse` return type changed from enum to `Vec<CodeActionResponse>`
- **Parameter Structure Changes**: Updated completion and definition request parameter access:
  - `params.text_document_position.text_document` → `params.text_document_position_params.text_document`
- **URI Handling Simplification**: Removed redundant `Url::parse()` calls where `Uri` type already supports `to_file_path()` directly
- **Method Matching**: Replaced `Request::METHOD` constant matching with string literals (e.g., `"initialize"`, `"textDocument/completion"`)
- **Code Cleanup**: Removed unnecessary `#[allow(clippy::mutable_key_type)]` annotation and simplified URI conversion logic

## Notable Implementation Details

The migration maintains full backward compatibility in functionality while adopting the new library's API conventions. The `gen-lsp-types` library provides better type safety and more consistent naming patterns (PascalCase for enum variants instead of SCREAMING_SNAKE_CASE).

https://claude.ai/code/session_01M7FwP8PwqNtMKqvQuWBcK7