### PR TITLE
Format TypeName struct initialization for Float type

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -379,7 +379,9 @@ fn built_in_types() -> FxHashMap<TypeName, TypeDefAndMethods> {
         },
     );
     types.insert(
-        TypeName { text: "Float".into() },
+        TypeName {
+            text: "Float".into(),
+        },
         TypeDefAndMethods {
             def: TypeDef::BuiltIn(BuiltInType::Float, None),
             methods: FxHashMap::default(),


### PR DESCRIPTION
This PR reformats the `TypeName` struct initialization for the "Float" built-in type to improve code readability and consistency.

## Summary
Applied formatting changes to the `TypeName` struct initialization in the `built_in_types()` function to use multi-line formatting, making the code more consistent with potential style guidelines or other similar struct initializations in the codebase.

## Key Changes
- Reformatted the `TypeName { text: "Float".into() }` initialization from single-line to multi-line format
- The struct field is now on its own line for improved readability

## Implementation Details
This is a purely stylistic change with no functional impact. The behavior of the code remains identical; only the formatting of the struct initialization has been adjusted.

https://claude.ai/code/session_019TNGtgb2qyX6bt3LQD7Q45