### PR TITLE
Improve go-to-definition to point to function name symbol

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1889,7 +1889,11 @@ impl TypeCheckVisitor<'_> {
                 match values.get(&sym.name) {
                     Some(value) => {
                         if let Some(fun_info) = value.fun_info() {
-                            self.id_to_def_pos.insert(sym.id, fun_info.pos.clone());
+                            let pos = match &fun_info.name_sym {
+                                Some(name_sym) => name_sym.position.clone(),
+                                None => fun_info.pos.clone(),
+                            };
+                            self.id_to_def_pos.insert(sym.id, pos);
                         }
 
                         if !ns_info.exported_syms.contains(&sym.name) {

--- a/src/test_files/go_to_def/namespace_fun.gdn
+++ b/src/test_files/go_to_def/namespace_fun.gdn
@@ -5,5 +5,5 @@ reflect::lex("abc")
 
 // args: definition-position
 // expected stdout:
-// {"start_offset":618,"end_offset":797,"line_number":36,"end_line_number":40,"column":0,"end_column":1,"path":"GDN_TEST_ROOT/__reflect.gdn"}
+// {"start_offset":728,"end_offset":731,"line_number":38,"end_line_number":38,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}
 


### PR DESCRIPTION
## Summary
This change improves the "go to definition" feature to point directly to the function name symbol when available, rather than the entire function definition. This provides a more precise navigation experience for users.

## Key Changes
- **Type checker**: Modified the definition position tracking in `type_checker.rs` to prefer the function name symbol's position (`name_sym.position`) over the full function definition position (`fun_info.pos`) when the name symbol is available
- **Test update**: Updated the expected output in `namespace_fun.gdn` test to reflect the new, more precise definition position that points to the function name rather than the function body

## Implementation Details
The change adds a fallback mechanism: if a function has a `name_sym` (name symbol), its position is used for go-to-definition; otherwise, the original function position is used. This ensures backward compatibility while providing better precision when symbol information is available.

Minor formatting cleanup was also applied to `env.rs` for consistency.

https://claude.ai/code/session_011TCbMJ2VJWnUKmFXNuPFo6