### PR TITLE
Add check-snippets subcommand for validating Garden code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ simplified to `foo()`), with an autofix.
 Added :load to evaluate all definitions in a file and switch to that
 namespace.
 
+Added a `check-snippets` subcommand that checks every Garden code
+block in a markdown file for syntax and semantic errors, equivalent
+to calling `reflect::check_snippet` on each block.
+
 ## Standard Library
 
 Added `random::choose()`.

--- a/src/check_snippets.rs
+++ b/src/check_snippets.rs
@@ -1,0 +1,89 @@
+//! Check Garden code blocks in markdown files for syntax and
+//! semantic errors, equivalent to calling `reflect::check_snippet`
+//! on each block.
+
+use std::io::IsTerminal;
+use std::path::Path;
+
+use crate::checks::check_toplevel_items;
+use crate::diagnostics::{format_diagnostic, Severity};
+use crate::env::Env;
+use crate::parser::ast::IdGenerator;
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::diagnostics::MessagePart::*;
+use crate::parser::vfs::Vfs;
+use crate::parser::{parse_toplevel_items_from_span, ParseError};
+use crate::run_code_blocks::extract_code_blocks;
+
+pub(crate) fn check_snippets(path: &Path, src: &str) {
+    let use_color = std::io::stdout().is_terminal();
+
+    let blocks = extract_code_blocks(src);
+
+    let mut id_gen = IdGenerator::default();
+    let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
+    let env = Env::new(id_gen.clone(), vfs);
+
+    let mut had_error = false;
+    let mut first = true;
+
+    for block in &blocks {
+        let (items, parse_errors) = parse_toplevel_items_from_span(
+            &vfs_path,
+            src,
+            &mut id_gen,
+            block.start_offset,
+            block.end_offset,
+        );
+
+        for err in parse_errors {
+            had_error = true;
+            let (message, position) = match err {
+                ParseError::Invalid {
+                    message, position, ..
+                } => (message, position),
+                ParseError::Incomplete { message, position } => (message, position),
+            };
+
+            let message_str = if use_color {
+                message.as_styled_string()
+            } else {
+                message.as_string()
+            };
+            let formatted = format_diagnostic(
+                &ErrorMessage(vec![Text(message_str)]),
+                &position,
+                &env.project_root,
+                Severity::Error,
+                &[],
+                &env.vfs,
+            );
+            println!("{}{}", if first { "" } else { "\n" }, formatted);
+            first = false;
+        }
+
+        for diagnostic in check_toplevel_items(&vfs_path, &items, &env) {
+            had_error = true;
+
+            let message_str = if use_color {
+                diagnostic.message.as_styled_string()
+            } else {
+                diagnostic.message.as_string()
+            };
+            let formatted = format_diagnostic(
+                &ErrorMessage(vec![Text(message_str)]),
+                &diagnostic.position,
+                &env.project_root,
+                diagnostic.severity,
+                &diagnostic.notes,
+                &env.vfs,
+            );
+            println!("{}{}", if first { "" } else { "\n" }, formatted);
+            first = false;
+        }
+    }
+
+    if had_error {
+        std::process::exit(1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@
 #![allow(clippy::cmp_owned)]
 
 mod caret_finder;
+mod check_snippets;
 mod checks;
 mod cli_session;
 mod colors;
@@ -212,6 +213,10 @@ enum CliCommands {
     },
     /// Run Garden code blocks in markdown and .gdn files.
     RunCodeBlocks { paths: Vec<PathBuf> },
+    /// Check all Garden code blocks in a markdown file for syntax
+    /// and semantic errors, as if `reflect::check_snippet` had been
+    /// called on each block.
+    CheckSnippets { path: PathBuf },
     /// Show the type of the expression at the position given.
     ShowType {
         path: PathBuf,
@@ -277,6 +282,11 @@ fn main() {
         }
         CliCommands::RunCodeBlocks { paths } => {
             run_code_blocks::run_code_blocks(&paths, interrupted);
+        }
+        CliCommands::CheckSnippets { path } => {
+            let abs_path = to_abs_path(&path);
+            let src = read_utf8_or_die(&abs_path);
+            check_snippets::check_snippets(&abs_path, &src);
         }
         CliCommands::JsonExample => {
             println!("{}", json_session::sample_request_as_json());
@@ -835,6 +845,11 @@ mod tests {
     #[test]
     fn test_golden_run_code_blocks() -> TestResult<()> {
         run_golden_tests("run_code_blocks")
+    }
+
+    #[test]
+    fn test_golden_check_snippets() -> TestResult<()> {
+        run_golden_tests("check_snippets")
     }
 
     #[test]

--- a/src/run_code_blocks.rs
+++ b/src/run_code_blocks.rs
@@ -20,13 +20,13 @@ use crate::BAD_CLI_REQUEST_EXIT_CODE;
 
 /// A code block extracted from markdown.
 #[derive(Debug)]
-struct CodeBlock {
+pub(crate) struct CodeBlock {
     /// The byte offset where the code block content starts in the
     /// markdown source.
-    start_offset: usize,
+    pub(crate) start_offset: usize,
     /// The byte offset where the code block content ends in the
     /// markdown source.
-    end_offset: usize,
+    pub(crate) end_offset: usize,
 }
 
 /// Result of evaluating an expression in a code block.
@@ -47,7 +47,7 @@ enum CheckResult {
 }
 
 /// Extract code blocks from markdown source.
-fn extract_code_blocks(markdown: &str) -> Vec<CodeBlock> {
+pub(crate) fn extract_code_blocks(markdown: &str) -> Vec<CodeBlock> {
     let parser = Parser::new(markdown).into_offset_iter();
     let mut blocks = vec![];
     let mut in_code_block = false;

--- a/src/test_files/check_snippets/clean.md
+++ b/src/test_files/check_snippets/clean.md
@@ -1,0 +1,12 @@
+# Clean snippets
+
+```garden
+1 + 1
+```
+
+```python
+ignored
+```
+
+// args: check-snippets
+// expected exit status: 0

--- a/src/test_files/check_snippets/multiple_blocks.md
+++ b/src/test_files/check_snippets/multiple_blocks.md
@@ -1,0 +1,35 @@
+# Multiple blocks
+
+A clean block:
+
+```garden
+1 + 1
+```
+
+A bad block:
+
+```garden
+println(missing)
+```
+
+Another bad block:
+
+```garden
+let x = unknown
+```
+
+// args: check-snippets
+// expected exit status: 1
+// expected stdout:
+// Error: Unbound symbol: `missing`
+// --| src/test_files/check_snippets/multiple_blocks.md:12:9
+// 11| ```garden
+// 12| println(missing)
+// 13| ```     ^^^^^^^
+// 
+// Error: Unbound symbol: `unknown`
+// --| src/test_files/check_snippets/multiple_blocks.md:18:9
+// 17| ```garden
+// 18| let x = unknown
+// 19| ```     ^^^^^^^
+

--- a/src/test_files/check_snippets/syntax_error.md
+++ b/src/test_files/check_snippets/syntax_error.md
@@ -1,0 +1,15 @@
+# Syntax error
+
+```garden
+let x =
+```
+
+// args: check-snippets
+// expected exit status: 1
+// expected stdout:
+// Error: Expected an expression after this.
+// --| src/test_files/check_snippets/syntax_error.md:4:7
+//  3| ```garden
+//  4| let x =
+//  5| ```   ^
+

--- a/src/test_files/check_snippets/unbound.md
+++ b/src/test_files/check_snippets/unbound.md
@@ -1,0 +1,15 @@
+# Unbound symbol
+
+```garden
+println(undefined_var)
+```
+
+// args: check-snippets
+// expected exit status: 1
+// expected stdout:
+// Error: Unbound symbol: `undefined_var`
+// --| src/test_files/check_snippets/unbound.md:4:9
+//  3| ```garden
+//  4| println(undefined_var)
+//  5| ```     ^^^^^^^^^^^^^
+

--- a/src/test_files/check_snippets/warning.md
+++ b/src/test_files/check_snippets/warning.md
@@ -1,0 +1,21 @@
+# Warning
+
+```garden
+fun foo(x: Int): Int {
+  let unused = 99
+  x
+}
+foo(1)
+```
+
+// args: check-snippets
+// expected exit status: 1
+// expected stdout:
+// Warning: `unused` is unused.
+// --| src/test_files/check_snippets/warning.md:5:7
+//  3| ```garden
+//  4| fun foo(x: Int): Int {
+//  5|   let unused = 99
+//  6|   x   ^^^^^^
+//  7| }
+


### PR DESCRIPTION
## Summary
This PR adds a new `check-snippets` subcommand that validates all Garden code blocks in markdown files for syntax and semantic errors, providing a way to ensure code examples in documentation are correct.

## Key Changes
- **New `check_snippets` module** (`src/check_snippets.rs`): Implements the core functionality to extract and validate Garden code blocks from markdown files, reporting parse errors and semantic diagnostics with proper formatting and color support
- **New CLI subcommand**: Added `CheckSnippets` variant to `CliCommands` enum that accepts a markdown file path and invokes the validation logic
- **Extracted code block utilities**: Made `CodeBlock` struct and `extract_code_blocks()` function public in `run_code_blocks.rs` to allow reuse by the new check-snippets functionality
- **Test coverage**: Added four golden test files covering clean snippets, syntax errors, unbound symbols, and multiple error blocks
- **Documentation**: Updated CHANGELOG.md to document the new feature

## Implementation Details
- The checker reuses existing infrastructure: `parse_toplevel_items_from_span()` for parsing, `check_toplevel_items()` for semantic analysis, and `format_diagnostic()` for error formatting
- Supports colored output when writing to a terminal, with fallback to plain text
- Exits with status code 1 if any errors are found, 0 if all blocks are valid
- Only validates Garden code blocks (ignores other language blocks like Python)
- Properly handles multiple code blocks in a single file with formatted error output

https://claude.ai/code/session_01LzcbcpTWycxJpRq5wkgYtq