### PR TITLE
Add path parameter to reflect::check_snippet for import resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ namespace.
 
 Added `random::choose()`.
 
+`reflect::check_snippet` now takes a `Path` argument, used as the
+location of the file that the snippet represents when resolving
+relative imports.
+
 Fixed an issue with `Dict::set()` where the output values had an
 incorrect type at runtime.
 

--- a/src/__reflect.gdn
+++ b/src/__reflect.gdn
@@ -2,13 +2,15 @@
 import "__prelude.gdn" as prelude
 import "__fs.gdn" as fs
 
-/// Check the syntax of `src`.
-public fun check_snippet(src: String): Result<Unit, List<String>> {
+/// Check the syntax of `src`. `path` is treated as the location of
+/// the file that the snippet represents, which is used to resolve
+/// relative imports.
+public fun check_snippet(src: String, path: Path): Result<Unit, List<String>> {
   __BUILT_IN_IMPLEMENTATION
 }
 
 test check_snippet_good {
-  match check_snippet("fun foo() {}") {
+  match check_snippet("fun foo() {}", Path{ p: "__snippet.gdn" }) {
     Ok(_) => {}
     Err(_) => {
       assert(False)
@@ -17,7 +19,7 @@ test check_snippet_good {
 }
 
 test check_snippet_bad_syntax {
-  match check_snippet("fun foo(") {
+  match check_snippet("fun foo(", Path{ p: "__snippet.gdn" }) {
     Ok(_) => {
       assert(False)
     }
@@ -26,7 +28,7 @@ test check_snippet_bad_syntax {
 }
 
 test check_snippet_bad_name {
-  match check_snippet("fun foo() { bar() }") {
+  match check_snippet("fun foo() { bar() }", Path{ p: "__snippet.gdn" }) {
     Ok(_) => {
       assert(False)
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3412,7 +3412,7 @@ fn eval_built_in_call(
                 },
                 receiver_value,
                 receiver_pos,
-                1,
+                2,
                 arg_positions,
                 arg_values,
             )?;
@@ -3422,9 +3422,23 @@ fn eval_built_in_call(
                 saved_values.push(value.clone());
             }
 
-            let snippet = check_string(&arg_values[0], &arg_positions[0], saved_values, env)?;
+            let snippet =
+                check_string(&arg_values[0], &arg_positions[0], saved_values.clone(), env)?;
 
-            let v = check_snippet(snippet, env);
+            let path_s = match unwrap_path(&arg_values[1], env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: arg_positions[1].clone(),
+                            message: msg,
+                        }),
+                    ));
+                }
+            };
+
+            let v = check_snippet(snippet, PathBuf::from(path_s), env);
             if expr_value_is_used {
                 env.push_value(v);
             }
@@ -3873,9 +3887,7 @@ fn eval_built_in_call(
     Ok(())
 }
 
-fn check_snippet(src: &str, env: &Env) -> Value {
-    let path = PathBuf::from("__snippet.gdn");
-
+fn check_snippet(src: &str, path: PathBuf, env: &Env) -> Value {
     let mut check_env = env
         .initial_state
         .as_ref()

--- a/src/test_files/go_to_def/namespace_fun.gdn
+++ b/src/test_files/go_to_def/namespace_fun.gdn
@@ -5,4 +5,5 @@ reflect::lex("abc")
 
 // args: definition-position
 // expected stdout:
-// {"start_offset":728,"end_offset":731,"line_number":38,"end_line_number":38,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}
+// {"start_offset":950,"end_offset":953,"line_number":40,"end_line_number":40,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}
+

--- a/src/test_files/json_session/doc_namespace.json
+++ b/src/test_files/json_session/doc_namespace.json
@@ -32,7 +32,7 @@
 // {
 //   "kind": {
 //     "run_command": {
-//       "message": "Split `src` into individual lexed tokens, along with their offsets\nin the original string.\n\n// Defined in __reflect.gdn:39\nfn lex(src: String): List<(Int, String)> { ... }",
+//       "message": "Split `src` into individual lexed tokens, along with their offsets\nin the original string.\n\n// Defined in __reflect.gdn:41\nfn lex(src: String): List<(Int, String)> { ... }",
 //       "stack_frame_name": "__user.gdn"
 //     }
 //   },

--- a/src/test_files/runtime/check_snippet.gdn
+++ b/src/test_files/runtime/check_snippet.gdn
@@ -1,7 +1,7 @@
 import "__reflect.gdn" as reflect
 
 {
-  dbg(reflect::check_snippet("True"))
+  dbg(reflect::check_snippet("True", Path{ p: "__snippet.gdn" }))
 }
 
 // args: run

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -234,7 +234,12 @@ fun render_markdown_code(snippet: Snippet): String {
 }
 
 fun check_source(src: String, path: Option<Path>): Unit {
-  match reflect::check_snippet(src) {
+  let snippet_path = match path {
+    Some(p) => p
+    None => Path{ p: "__snippet.gdn" }
+  }
+
+  match reflect::check_snippet(src, snippet_path) {
     Ok(_) => {}
     Err(messages) => {
       let path_desc = match path {


### PR DESCRIPTION
## Summary
Updated `reflect::check_snippet()` to accept a `Path` parameter that specifies the location of the file the snippet represents. This enables proper resolution of relative imports when checking snippet syntax.

## Key Changes
- Modified `check_snippet()` signature to accept a `path: Path` parameter in addition to the source string
- Updated the built-in implementation to extract and validate the path argument before passing it to the internal `check_snippet()` function
- Changed internal `check_snippet()` function to accept a `PathBuf` instead of hardcoding `"__snippet.gdn"`
- Updated all call sites to provide an appropriate path:
  - `website/markdown.gdn`: Uses provided path or defaults to `"__snippet.gdn"`
  - Test files: Updated to pass `Path{ p: "__snippet.gdn" }` as the second argument
- Updated documentation and changelog to reflect the new parameter

## Implementation Details
- The path parameter is validated using `unwrap_path()` with proper error handling that restores saved values on failure
- The path is converted to a `PathBuf` and passed through to the internal checking logic
- All existing tests updated to maintain compatibility with the new signature
- Line number offsets in test expectations adjusted due to the signature change

https://claude.ai/code/session_01MjfvUJvs3Wi5UrNygjZf2g