### PR TITLE
Skip source validation for exception markers in markdown

### DIFF
--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -258,7 +258,11 @@ fun render_markdown_garden_code(snippet: Snippet): String {
     for line in snippet.content.lines() {
       match line.split_once("//->") {
         Some((_before, after)) => {
-          check_source(after, snippet.file)
+          // `*exception*` is a special marker indicating that the
+          // expression should throw an exception, not Garden source.
+          if after.trim() != "*exception*" {
+            check_source(after, snippet.file)
+          }
         }
         None => {}
       }


### PR DESCRIPTION
## Summary
Updated markdown code snippet rendering to recognize and handle a special `*exception*` marker that indicates an expression should throw an exception rather than produce Garden source code.

## Changes
- Added conditional check to skip source validation when the `*exception*` marker is encountered
- Added clarifying comments explaining the purpose of the special marker
- Allows documentation examples to properly document exception-throwing code without validation errors

## Implementation Details
The change wraps the `check_source()` call with a condition that trims the extracted content and compares it against the `*exception*` marker. When this marker is present, source validation is skipped, enabling documentation of code that intentionally throws exceptions.

https://claude.ai/code/session_018LuWbxrchzW9RQgNKYF9pi