### PR TITLE
Add --ignore-warnings flag to garden check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ simplified to `foo()`), with an autofix.
 Added :load to evaluate all definitions in a file and switch to that
 namespace.
 
+`garden check` now accepts `--ignore-warnings` to suppress warnings
+and only display errors.
+
 ## Standard Library
 
 Added `random::choose()`.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -18,7 +18,7 @@ use crate::parser::vfs::{to_project_relative, Vfs, VfsId};
 use crate::parser::KEYWORDS;
 use crate::VfsPathBuf;
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Severity {
     Warning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,9 @@ enum CliCommands {
         /// Only valid with --fix.
         #[clap(long, action)]
         stdout: bool,
+        /// Only show errors, suppressing warnings.
+        #[clap(long, action)]
+        ignore_warnings: bool,
     },
     /// Run Garden code blocks in markdown and .gdn files.
     RunCodeBlocks { paths: Vec<PathBuf> },
@@ -289,12 +292,21 @@ fn main() {
             override_path,
             fix,
             stdout,
+            ignore_warnings,
         } => {
             let abs_path = to_abs_path(&path);
             let mut src = read_utf8_or_die(&abs_path);
             src = remove_testing_footer(&src);
             let src_path = to_abs_path(&override_path.unwrap_or(path.clone()));
-            syntax_check::check(&src_path, &src, json, fix, stdout, &abs_path)
+            syntax_check::check(
+                &src_path,
+                &src,
+                json,
+                fix,
+                stdout,
+                ignore_warnings,
+                &abs_path,
+            )
         }
         CliCommands::Test {
             paths,

--- a/src/syntax_check.rs
+++ b/src/syntax_check.rs
@@ -58,6 +58,7 @@ pub(crate) fn check(
     json: bool,
     fix: bool,
     stdout: bool,
+    ignore_warnings: bool,
     original_path: &Path,
 ) {
     let use_color = std::io::stdout().is_terminal() && !json && !fix;
@@ -149,6 +150,10 @@ pub(crate) fn check(
                 notes,
             });
         }
+    }
+
+    if ignore_warnings {
+        diagnostics.retain(|d| d.severity != Severity::Warning);
     }
 
     if fix {


### PR DESCRIPTION
## Summary
Added a new `--ignore-warnings` flag to the `garden check` command that allows users to suppress warnings and only display errors in the output.

## Key Changes
- Added `ignore_warnings` boolean flag to the `Check` CLI command variant
- Updated `syntax_check::check()` function signature to accept the `ignore_warnings` parameter
- Implemented filtering logic to remove warnings from diagnostics when the flag is enabled
- Added `PartialEq` and `Eq` derives to the `Severity` enum to support equality comparisons
- Updated CHANGELOG.md to document the new feature

## Implementation Details
The filtering is applied after all diagnostics are collected but before fixes are applied. When `--ignore-warnings` is set, the diagnostics vector is filtered to retain only errors (removing all warnings). This approach keeps the implementation clean and maintains the existing fix application logic.

https://claude.ai/code/session_01QkZHa1fZ7vVT26wfS2Pn83