### PR TITLE
Add "Did you mean?" suggestions for unbound symbol errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Added a warning for unnecessary `let` bindings where a variable is
 bound and immediately returned (e.g. `let x = foo() x` can be
 simplified to `foo()`), with an autofix.
 
+Unbound symbol errors now suggest the most similar name in scope
+("Did you mean ...?") and offer an autofix to replace the typo.
+
 ## Commands
 
 Added :load to evaluate all definitions in a file and switch to that

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1511,23 +1511,46 @@ impl TypeCheckVisitor<'_> {
                 internal_reason: "Unbound variable".to_owned(),
                 inferred_type: None,
             };
+
+            if sym.name.text != "__BUILT_IN_IMPLEMENTATION" {
+                let local_names = self.bindings.all_bindings();
+                let ns = self
+                    .env
+                    .get_namespace(&self.path.path)
+                    .expect("Should have a namespace for this path");
+                let ns = ns.borrow();
+
+                let mut available_names: Vec<&SymbolName> =
+                    local_names.iter().map(|(name, _)| name).collect();
+                available_names.extend(ns.values.keys());
+
+                let mut fixes = vec![];
+                let mut message_parts =
+                    vec![msgtext!("Unbound symbol: "), msgcode!("{}", sym.name)];
+                if let Some(similar) = most_similar(&available_names, &sym.name) {
+                    fixes.push(Autofix {
+                        description: format!("Use `{}` here.", similar),
+                        position: sym.position.clone(),
+                        new_text: similar.text.clone(),
+                    });
+                    message_parts.push(msgtext!(". Did you mean "));
+                    message_parts.push(msgcode!("{}", similar));
+                    message_parts.push(msgtext!("?"));
+                }
+
+                self.diagnostics.push(Diagnostic {
+                    notes: vec![],
+                    fixes,
+                    severity: Severity::Error,
+                    message: ErrorMessage(message_parts),
+                    position: sym.position.clone(),
+                });
+            }
+
             // Treat this variable as locally bound in the
             // rest of the scope, to prevent cascading
             // errors.
             self.set_binding(sym, ty.clone());
-
-            if sym.name.text != "__BUILT_IN_IMPLEMENTATION" {
-                self.diagnostics.push(Diagnostic {
-                    notes: vec![],
-                    fixes: vec![],
-                    severity: Severity::Error,
-                    message: ErrorMessage(vec![
-                        msgtext!("Unbound symbol: "),
-                        msgcode!("{}", sym.name),
-                    ]),
-                    position: sym.position.clone(),
-                });
-            }
 
             return ty;
         };

--- a/src/test_files/check/dict_literal_types.gdn
+++ b/src/test_files/check/dict_literal_types.gdn
@@ -27,7 +27,7 @@ Dict["x" => 1, "y" => ""]
 //  6|      ^^^^^^^
 //  7| // Bad: undefined value.
 // 
-// Error: Unbound symbol: `no_such2`
+// Error: Unbound symbol: `no_such2`. Did you mean `no_such`?
 // --| src/test_files/check/dict_literal_types.gdn:8:15
 //  7| // Bad: undefined value.
 //  8| Dict["foo" => no_such2]
@@ -46,3 +46,6 @@ Dict["x" => 1, "y" => ""]
 // 17| // Bad: mixed value types.
 // 18| Dict["x" => 1, "y" => ""]
 // 19|                       ^^
+
+// expected stderr:
+// 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check_fix/unbound_name.gdn
+++ b/src/test_files/check_fix/unbound_name.gdn
@@ -1,0 +1,17 @@
+fun greet(): Unit {
+  println("Hello")
+}
+
+{
+  gret()
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// fun greet(): Unit {
+//   println("Hello")
+// }
+// 
+// {
+//   greet()
+// }


### PR DESCRIPTION
## Summary
Enhanced unbound symbol error messages to suggest the most similar name in scope and provide an autofix to correct the typo.

## Key Changes
- **Improved error diagnostics**: When an unbound symbol is encountered, the type checker now searches for the most similar name among available local and namespace bindings
- **Suggestion messages**: Error messages now include "Did you mean ...?" when a similar name is found
- **Autofix support**: Added automatic fixes that replace the typo with the suggested name, allowing users to fix the issue with `--fix`
- **Test coverage**: Added `unbound_name.gdn` test file demonstrating the autofix functionality
- **Updated test expectations**: Modified `dict_literal_types.gdn` to reflect the new error message format with suggestions

## Implementation Details
- The error handling logic was refactored to collect available names (both local bindings and namespace values) before generating the diagnostic
- Uses a `most_similar()` function to find the closest matching name using string similarity
- The autofix is only generated when a similar name is found, keeping the diagnostic clean when no suggestions are available
- Moved the `set_binding()` call to after the diagnostic is reported, maintaining the original behavior of treating unbound variables as locally bound to prevent cascading errors

https://claude.ai/code/session_01Ud5o1jcBhkypBQqruPBsKX