### PR TITLE
Add extract function code action to LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ simplified to `foo()`), with an autofix.
 Added :load to evaluate all definitions in a file and switch to that
 namespace.
 
+## Tooling
+
+The LSP server now offers an "Extract function" code action when a
+non-empty selection covers a Garden expression.
+
 ## Standard Library
 
 Added `random::choose()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,6 @@ simplified to `foo()`), with an autofix.
 Added :load to evaluate all definitions in a file and switch to that
 namespace.
 
-## Tooling
-
-The LSP server now offers an "Extract function" code action when a
-non-empty selection covers a Garden expression.
-
 ## Standard Library
 
 Added `random::choose()`.

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -25,6 +25,7 @@ use crate::completions;
 use crate::diagnostics::{Autofix, Diagnostic as GardenDiagnostic, Severity};
 use crate::env::Env;
 use crate::eval::load_toplevel_items;
+use crate::extract_function::extract_function;
 use crate::highlight::highlight_occurrences;
 use crate::parser::ast::IdGenerator;
 use crate::parser::position::Position as GardenPosition;
@@ -349,7 +350,10 @@ fn handle_initialize(
             document_formatting_provider: Some(DocumentFormattingProvider::Bool(true)),
             document_highlight_provider: Some(DocumentHighlightProvider::Bool(true)),
             code_action_provider: Some(CodeActionProvider::CodeActionOptions(CodeActionOptions {
-                code_action_kinds: Some(vec![CodeActionKind::QuickFix]),
+                code_action_kinds: Some(vec![
+                    CodeActionKind::QuickFix,
+                    CodeActionKind::RefactorExtract,
+                ]),
                 ..Default::default()
             })),
             rename_provider: Some(RenameProvider::Bool(true)),
@@ -628,24 +632,9 @@ fn handle_formatting(
     // Format the document
     let formatted = crate::format::format(&src, &path);
 
-    // Calculate the range covering the entire document
-    let line_count = src.lines().count();
-    let last_line_length = src.lines().last().map_or(0, |l| l.len());
-
-    let range = Range {
-        start: Position {
-            line: 0,
-            character: 0,
-        },
-        end: Position {
-            line: line_count.saturating_sub(1) as u32,
-            character: last_line_length as u32,
-        },
-    };
-
     // Create a TextEdit that replaces the entire document
     let edit = TextEdit {
-        range,
+        range: whole_document_range(&src),
         new_text: formatted,
     };
 
@@ -710,6 +699,10 @@ fn handle_code_action(
         actions.push(CodeActionResponse::CodeAction(action));
     }
 
+    if let Some(action) = build_extract_function_action(&src, &path, uri, &params.range) {
+        actions.push(CodeActionResponse::CodeAction(action));
+    }
+
     JsonRpcResponse::new(id, actions)
 }
 
@@ -764,6 +757,68 @@ fn handle_rename(
     };
 
     JsonRpcResponse::new(id, Some(workspace_edit))
+}
+
+/// Build an "Extract function" code action for the selected range, if the
+/// selection covers a Garden expression.
+fn build_extract_function_action(
+    src: &str,
+    path: &Path,
+    uri: &Uri,
+    range: &Range,
+) -> Option<CodeAction> {
+    let start_offset = line_char_to_offset(
+        src,
+        range.start.line as usize,
+        range.start.character as usize,
+    );
+    let end_offset =
+        line_char_to_offset(src, range.end.line as usize, range.end.character as usize);
+
+    // Only offer extract function for non-empty selections.
+    if start_offset >= end_offset {
+        return None;
+    }
+
+    let new_src = extract_function(src, path, start_offset, end_offset, "extracted").ok()?;
+
+    let full_range = whole_document_range(src);
+    let text_edit = TextEdit {
+        range: full_range,
+        new_text: new_src,
+    };
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(uri.clone(), vec![text_edit]);
+
+    let workspace_edit = WorkspaceEdit {
+        changes: Some(changes),
+        ..Default::default()
+    };
+
+    Some(CodeAction {
+        title: "Extract function".to_owned(),
+        kind: Some(CodeActionKind::RefactorExtract),
+        edit: Some(workspace_edit),
+        ..Default::default()
+    })
+}
+
+/// A range that covers the entire source document.
+fn whole_document_range(src: &str) -> Range {
+    let line_count = src.lines().count();
+    let last_line_length = src.lines().last().map_or(0, |l| l.len());
+
+    Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: line_count.saturating_sub(1) as u32,
+            character: last_line_length as u32,
+        },
+    }
 }
 
 /// Check if two ranges overlap.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1552,6 +1552,81 @@ fun main() {
     }
 
     #[test]
+    fn test_lsp_code_action_extract_function() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let test_content = "fun foo() {\n  let _ = 1 + 2\n}\n";
+        let test_file =
+            std::env::temp_dir().join("garden_lsp_test_code_action_extract_function.gdn");
+        std::fs::write(&test_file, test_content).expect("Failed to write test file");
+
+        let path = assert_cmd::cargo::cargo_bin("garden");
+        let mut child = Command::new(path)
+            .arg("lsp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn command");
+
+        let file_uri = format!("file://{}", test_file.display());
+
+        let init_request =
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+        let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
+
+        // Selection covers `1 + 2` on line 1.
+        let code_action_request = format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"textDocument/codeAction","params":{{"textDocument":{{"uri":"{}"}},"range":{{"start":{{"line":1,"character":10}},"end":{{"line":1,"character":15}}}},"context":{{"diagnostics":[]}}}}}}"#,
+            file_uri
+        );
+
+        let shutdown_request = r#"{"jsonrpc":"2.0","id":3,"method":"shutdown"}"#;
+        let exit = r#"{"jsonrpc":"2.0","method":"exit"}"#;
+
+        let input = format!(
+            "Content-Length: {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}",
+            init_request.len(), init_request,
+            initialized.len(), initialized,
+            code_action_request.len(), code_action_request,
+            shutdown_request.len(), shutdown_request,
+            exit.len(), exit
+        );
+
+        {
+            let stdin = child.stdin.as_mut().expect("Failed to get stdin");
+            stdin
+                .write_all(input.as_bytes())
+                .expect("Failed to write to stdin");
+        }
+
+        let output = child
+            .wait_with_output()
+            .expect("Failed to wait for command");
+
+        assert!(output.status.success());
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            stdout.contains(r#""id":2"#),
+            "Should contain code action response"
+        );
+
+        assert!(
+            stdout.contains("Extract function"),
+            "Should contain 'Extract function' code action title, got: {stdout}"
+        );
+
+        assert!(
+            stdout.contains(r#""kind":"refactor.extract""#),
+            "Should contain refactor.extract kind, got: {stdout}"
+        );
+
+        let _ = std::fs::remove_file(&test_file);
+    }
+
+    #[test]
     fn test_lsp_document_highlight() {
         use std::io::Write;
         use std::process::Stdio;


### PR DESCRIPTION
## Summary
This PR adds support for the "Extract function" refactoring code action in the Language Server Protocol (LSP) implementation. Users can now select an expression in their Garden code and use the extract function action to refactor it into a separate function.

## Key Changes
- **Import extract_function module**: Added import of `crate::extract_function::extract_function` to enable the refactoring functionality
- **Advertise RefactorExtract capability**: Updated the LSP server initialization to advertise support for `CodeActionKind::RefactorExtract` alongside existing `QuickFix` actions
- **Implement extract function code action**: Added `build_extract_function_action()` function that:
  - Converts LSP line/character positions to byte offsets
  - Validates that the selection is non-empty
  - Calls the extract_function utility to perform the refactoring
  - Returns a CodeAction with a WorkspaceEdit containing the refactored code
- **Extract helper function**: Refactored document range calculation into a reusable `whole_document_range()` function to avoid duplication between formatting and code action handlers
- **Add integration test**: Added `test_lsp_code_action_extract_function()` to verify the code action is properly advertised and functional through the LSP protocol

## Implementation Details
- The extract function action only appears when a non-empty range is selected
- The refactored code replaces the entire document (consistent with how formatting works)
- The extracted function is named "extracted" by default
- The code action properly integrates with the existing LSP infrastructure and error handling

https://claude.ai/code/session_019YbzBkeMSeRBPXwWHFjU3B