### PR TITLE
Update CLAUDE.md: Remove CHANGELOG.md update requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,7 @@ import "__fs.gdn" as fs
 fs::list_directory(Path{ p: "/"})
 ```
 
-When adding built-in functions, always update the CHANGELOG.md with a
-concise summary.
+Do not make changes to CHANGELOG.md.
 
 # Writing Error Messages
 


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md documentation to clarify that contributors should not make changes to CHANGELOG.md.

## Changes
- Removed the instruction that required updating CHANGELOG.md when adding built-in functions
- Replaced it with an explicit directive: "Do not make changes to CHANGELOG.md"

## Rationale
This change clarifies the contribution guidelines by removing the expectation that developers manually update the changelog, likely indicating that changelog management is handled through an automated process or by maintainers during release cycles.

https://claude.ai/code/session_0111KtzffvEidJUn1yMcsAVK