### PR TITLE
Add nocheck directive to source code blocks in documentation

### DIFF
--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -86,7 +86,7 @@ fun write_method_page(type_name: String, method_name: String, out_dir: Path, bas
 fun render_doc_comment(heading: String, doc_comment: String, src: Option<String>, file: Option<Path>): String {
   let src = match src {
     Some(src) => {
-      "```title:\"Source Code\"\n" ^ drop_leading_comments(src) ^ "\n```"
+      "```garden nocheck title:\"Source Code\"\n" ^ drop_leading_comments(src) ^ "\n```"
     }
     None => ""
   }
@@ -98,7 +98,7 @@ fun render_doc_comment(heading: String, doc_comment: String, src: Option<String>
 }
 
 fun render_type_doc_comment(heading: String, doc_comment: String, src: String, methods: List<String>, type_name: String): String {
-  let src = "```title:\"Source Code\"\n" ^ drop_leading_comments(src) ^ "\n```"
+  let src = "```garden nocheck title:\"Source Code\"\n" ^ drop_leading_comments(src) ^ "\n```"
 
   let methods_section = if methods.is_empty() {
     ""


### PR DESCRIPTION
## Summary
Updated the documentation rendering functions to include the `nocheck` directive in Garden code blocks that display source code snippets.

## Changes
- Added `nocheck` directive to source code blocks in `render_doc_comment()` function
- Added `nocheck` directive to source code blocks in `render_type_doc_comment()` function

## Details
Both functions now generate markdown code blocks with the format `` ```garden nocheck title:"Source Code"`` instead of `` ```title:"Source Code"``. This prevents syntax checking/validation on the displayed source code snippets in the generated documentation, which is appropriate since these are read-only reference examples rather than executable code blocks.

https://claude.ai/code/session_011R4KjnEDVztcVAkyPhPo9i