### PR TITLE
Handle function calls on NoValue types in type checker

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1481,6 +1481,16 @@ impl TypeCheckVisitor<'_> {
                     inferred_type: None,
                 }
             }
+            _ if recv_ty.is_no_value() => {
+                for arg in &paren_args.arguments {
+                    // We still want to check arguments as far as possible.
+                    self.infer_expr(&arg.expr, type_bindings, expected_return_ty);
+                }
+
+                // NoValue is a bottom type, so it's a subtype of any
+                // function type. Calling it produces NoValue.
+                Type::no_value()
+            }
             _ => {
                 for arg in &paren_args.arguments {
                     // We still want to check arguments as far as possible.

--- a/src/test_files/check/call_no_value.gdn
+++ b/src/test_files/check/call_no_value.gdn
@@ -1,0 +1,5 @@
+{
+  throw("")(123)
+}
+
+// args: check


### PR DESCRIPTION
## Summary
Added support for type checking function calls where the receiver is a NoValue type (bottom type). This ensures the type checker gracefully handles calls on expressions that throw or otherwise produce NoValue.

## Key Changes
- Added a new match arm in the type checker to handle calls on NoValue receiver types
- When a function call is made on a NoValue expression, the type checker:
  - Still validates all arguments by inferring their types
  - Returns NoValue as the result type (since NoValue is a bottom type that is a subtype of any function type)
- Added test case `call_no_value.gdn` to verify the behavior with `throw("")(123)`

## Implementation Details
The new case treats NoValue as a valid (though unusual) function type. This is semantically correct since NoValue represents unreachable code—a call on an expression that never returns is itself unreachable and produces NoValue. The implementation ensures argument expressions are still type-checked for error reporting purposes, even though the call itself will never execute.

https://claude.ai/code/session_01DjDmobJbJZAgjWcdHDCkN1