### PR TITLE
Don't insert parentheses in completions when user has already typed them

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -27,6 +27,11 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
     let ns = env.get_or_create_namespace(path);
     load_toplevel_items(&items, &mut env, ns.clone());
 
+    // If a `(` already follows the cursor, the user has already
+    // typed the call parentheses, so completion should not insert
+    // them again.
+    let has_trailing_paren = src[offset..].starts_with('(');
+
     // Check both offset and offset-1 to handle cursor positions at
     // the end of expressions (e.g., right after a dot in "foo.").
     let mut ids_at_pos = vec![];
@@ -59,7 +64,7 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
                 } else {
                     &meth_sym.name.text
                 };
-                return get_methods(&env, recv_ty, prefix);
+                return get_methods(&env, recv_ty, prefix, has_trailing_paren);
             }
             Expression_::NamespaceAccess(recv, sym) => {
                 let prefix = if sym.name.is_placeholder() {
@@ -72,7 +77,12 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
                 // to be a variable we can statically identify, so we
                 // can just assume variable here.
                 if let Expression_::Variable(recv_symbol) = &recv.expr_ {
-                    return get_namespace_functions(ns, &recv_symbol.name, prefix);
+                    return get_namespace_functions(
+                        ns,
+                        &recv_symbol.name,
+                        prefix,
+                        has_trailing_paren,
+                    );
                 }
                 return vec![];
             }
@@ -143,7 +153,12 @@ fn get_local_variables(bindings: &[(SymbolName, Type)], prefix: &str) -> Vec<Com
     items
 }
 
-fn get_methods(env: &Env, recv_ty: &Type, prefix: &str) -> Vec<CompletionItem> {
+fn get_methods(
+    env: &Env,
+    recv_ty: &Type,
+    prefix: &str,
+    has_trailing_paren: bool,
+) -> Vec<CompletionItem> {
     let Some(type_name) = recv_ty.type_name() else {
         return vec![];
     };
@@ -181,7 +196,11 @@ fn get_methods(env: &Env, recv_ty: &Type, prefix: &str) -> Vec<CompletionItem> {
             None => "".to_owned(),
         };
 
-        let (label, insert_text) = if params.is_empty() {
+        let (label, insert_text) = if has_trailing_paren {
+            // The user has already typed `(`, so don't insert
+            // parentheses again.
+            (method_name.text.clone(), method_name.text.clone())
+        } else if params.is_empty() {
             // Complete parentheses too if there are zero parameters.
             let name = format!("{}()", method_name.text);
             (name.clone(), name)
@@ -233,6 +252,7 @@ fn get_namespace_functions(
     current_ns: Rc<RefCell<NamespaceInfo>>,
     ns_name: &SymbolName,
     prefix: &str,
+    has_trailing_paren: bool,
 ) -> Vec<CompletionItem> {
     let current_ns = current_ns.borrow();
     let Some(value) = current_ns.values.get(ns_name) else {
@@ -277,7 +297,11 @@ fn get_namespace_functions(
             None => "".to_owned(),
         };
 
-        let (label, insert_text) = if params.is_empty() {
+        let (label, insert_text) = if has_trailing_paren {
+            // The user has already typed `(`, so don't insert
+            // parentheses again.
+            (value_name.text.clone(), value_name.text.clone())
+        } else if params.is_empty() {
             let name = format!("{}()", value_name.text);
             (name.clone(), name)
         } else {

--- a/src/test_files/complete/namespace_with_trailing_paren.gdn
+++ b/src/test_files/complete/namespace_with_trailing_paren.gdn
@@ -1,0 +1,8 @@
+import "__random.gdn" as random
+
+random::int()
+//         ^
+
+// args: complete
+// expected stdout:
+// {"label":"int","kind":3,"detail":"(): Int","insertText":"int","insertTextFormat":2}


### PR DESCRIPTION
## Summary
This PR fixes an issue where code completions would insert parentheses even when the user had already typed an opening parenthesis after the cursor position. This resulted in duplicate parentheses in the completed code.

## Key Changes
- Added detection of trailing `(` character immediately after the cursor position in the completion context
- Passed `has_trailing_paren` flag through to `get_methods()` and `get_namespace_functions()` completion functions
- Updated completion logic to skip parenthesis insertion when a trailing paren is already present
- Added test case verifying correct behavior when completing a function call with trailing parenthesis

## Implementation Details
- The `has_trailing_paren` check is performed early in the `complete()` function by examining the source text after the cursor offset
- Both method completions and namespace function completions now respect this flag
- When `has_trailing_paren` is true, the completion inserts only the function/method name without any parentheses, regardless of parameter count
- The logic gracefully handles the case where parentheses should still be inserted (when no trailing paren exists)

https://claude.ai/code/session_018d9p3LugdCysP6nbwpUT1e