### PR TITLE
Add completion support for method call names with prefix

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -61,6 +61,25 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
                 };
                 return get_methods(&env, recv_ty, prefix);
             }
+            Expression_::MethodCall(recv, meth_sym, _) => {
+                // Only complete the method name itself, not when the
+                // cursor is inside the argument list.
+                let on_method_sym = meth_sym.position.contains_offset(offset)
+                    || (offset > 0 && meth_sym.position.contains_offset(offset - 1));
+                if !on_method_sym {
+                    continue;
+                }
+
+                let recv_id = recv.id;
+                let recv_ty = &summary.id_to_ty[&recv_id];
+
+                let prefix = if meth_sym.name.is_placeholder() {
+                    ""
+                } else {
+                    &meth_sym.name.text
+                };
+                return get_methods(&env, recv_ty, prefix);
+            }
             Expression_::NamespaceAccess(recv, sym) => {
                 let prefix = if sym.name.is_placeholder() {
                     ""

--- a/src/test_files/complete/method_call_with_prefix.gdn
+++ b/src/test_files/complete/method_call_with_prefix.gdn
@@ -1,0 +1,8 @@
+fun foo(o: Option<String>) {
+    o.or_v("")
+    //   ^
+}
+
+// args: complete
+// expected stdout:
+// {"label":"or_value","kind":2,"detail":"(T): T","insertText":"or_value($0)","insertTextFormat":2}


### PR DESCRIPTION
## Summary
This change adds support for completing method names when the cursor is positioned on the method name itself in a method call expression, including cases where the method name has a partial prefix.

## Key Changes
- Added a new pattern match case in `complete()` to handle `Expression_::MethodCall` expressions
- Implemented logic to detect when the cursor is positioned on the method symbol itself (not in the argument list)
- Reuses the existing `get_methods()` function to provide method completions filtered by the current method name prefix
- Added test case `method_call_with_prefix.gdn` demonstrating completion of `or_v` to `or_value` on an `Option<String>` receiver

## Implementation Details
- The completion only triggers when the cursor is directly on the method name symbol, preventing unwanted completions when editing method arguments
- Handles both cases where the method name is a placeholder (empty) and where it has partial text
- Extracts the receiver type from the type summary and passes it to `get_methods()` with the appropriate prefix for filtering

https://claude.ai/code/session_018UK9TygZbuqwFya9SwYYBr