### PR TITLE
Pass has_trailing_paren to get_methods completion function

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -83,7 +83,7 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
                 } else {
                     &meth_sym.name.text
                 };
-                return get_methods(&env, recv_ty, prefix);
+                return get_methods(&env, recv_ty, prefix, has_trailing_paren);
             }
             Expression_::NamespaceAccess(recv, sym) => {
                 let prefix = if sym.name.is_placeholder() {


### PR DESCRIPTION
## Summary
Updated the `get_methods` function call to include the `has_trailing_paren` parameter, allowing the completion logic to consider whether a trailing parenthesis is present when generating method completions.

## Changes
- Modified the `complete` function in `src/completions.rs` to pass the `has_trailing_paren` variable to `get_methods()`
- This enables the completion engine to provide context-aware suggestions based on whether the user has already typed an opening parenthesis

## Details
The `has_trailing_paren` flag is now propagated to the `get_methods` function, which can use this information to adjust completion behavior (e.g., filtering suggestions or adjusting formatting for method calls that already have parentheses).

https://claude.ai/code/session_019CQyWt46g23PXDpwrB9Wtc