### PR TITLE
Add function name symbol tracking for rename refactoring

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -299,6 +299,11 @@ impl TypeCheckVisitor<'_> {
             self.current_item = Some(def_id);
         }
 
+        if let Some(name_sym) = &fun_info.name_sym {
+            self.id_to_def_pos
+                .insert(name_sym.id, name_sym.position.clone());
+        }
+
         let mut type_bindings = FxHashMap::default();
         for type_param in &fun_info.type_params {
             type_bindings.insert(type_param.name.clone(), None);

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -84,6 +84,10 @@ pub(crate) trait Visitor {
     // a separate method because Rust does not have a notion of
     // calling a 'super method'.
     fn visit_fun_info_default(&mut self, fun_info: &FunInfo) {
+        if let Some(name_sym) = &fun_info.name_sym {
+            self.visit_symbol(name_sym);
+        }
+
         for type_param in &fun_info.type_params {
             self.visit_type_symbol(type_param);
         }

--- a/src/test_files/rename/function.gdn
+++ b/src/test_files/rename/function.gdn
@@ -1,0 +1,18 @@
+fun increment(foo: Int): Int {
+    //    ^
+    foo + 1
+}
+
+public fun do_stuff() {
+  increment(123)
+}
+
+// args: rename --new-name increment_new
+// expected stdout:
+// fun increment_new(foo: Int): Int {
+//     foo + 1
+// }
+// 
+// public fun do_stuff() {
+//   increment_new(123)
+// }


### PR DESCRIPTION
## Summary
This change enables the rename refactoring to properly handle function names by tracking function name symbols in the type checker and visitor infrastructure.

## Key Changes
- **Type Checker**: Added tracking of function name symbols to the `id_to_def_pos` map, allowing the rename refactoring to locate function name definitions
- **Visitor**: Extended `visit_fun_info_default` to visit function name symbols, ensuring they are properly processed during AST traversal
- **Test Case**: Added a test file demonstrating rename refactoring on a function name, verifying that both the function definition and all call sites are correctly renamed

## Implementation Details
The changes follow the existing pattern for symbol tracking in the codebase. The function name symbol (when present) is now:
1. Visited during AST traversal via the visitor pattern
2. Registered in the position mapping used by the rename refactoring to identify definition locations

This allows the rename refactoring to work correctly with function names, updating both the function declaration and all references to it throughout the codebase.

https://claude.ai/code/session_01Bm3Q2cW1QvAz8wb8qkDJ95