### PR TITLE
Normalize trailing newlines in formatted output

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -57,7 +57,17 @@ pub(crate) fn format(src: &str, path: &Path) -> String {
     let src_after_blanks = normalize_blank_lines(&src_after_indent, &visitor.toplevel_start_lines);
 
     // Phase 7: Fix type annotation spacing
-    fix_type_annotation_spacing(&src_after_blanks, &vfs_path)
+    let mut result = fix_type_annotation_spacing(&src_after_blanks, &vfs_path);
+
+    // Phase 8: Ensure non-empty output ends with exactly one newline.
+    while result.ends_with("\n\n") {
+        result.pop();
+    }
+    if !result.is_empty() && !result.ends_with('\n') {
+        result.push('\n');
+    }
+
+    result
 }
 
 /// Represents an indentation edit for a specific line.

--- a/src/test_files/format/trailing_newlines.gdn
+++ b/src/test_files/format/trailing_newlines.gdn
@@ -1,0 +1,11 @@
+fun foo() {
+  let x = 1
+}
+
+
+
+// args: format
+// expected stdout:
+// fun foo() {
+//   let x = 1
+// }


### PR DESCRIPTION
## Summary
This change ensures that formatted code consistently ends with exactly one newline, improving output consistency and preventing trailing whitespace issues.

## Key Changes
- **Phase 8 added to formatting pipeline**: Introduced a new normalization phase after type annotation spacing fixes that:
  - Removes excess trailing newlines (collapses multiple consecutive newlines to none)
  - Ensures non-empty files end with exactly one newline
- **Test case added**: New test file `trailing_newlines.gdn` validates that multiple trailing blank lines are normalized to a single newline

## Implementation Details
The normalization logic:
1. Strips all trailing newlines by repeatedly popping while the result ends with `\n\n`
2. Adds back a single newline if the result is non-empty and doesn't already end with one
3. Leaves empty files unchanged

This ensures consistent formatting behavior regardless of the input file's trailing whitespace.

https://claude.ai/code/session_01Mvgx2FWkUQ8BbZiSSMrDM4