### PR TITLE
Add import path completion for relative imports

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::fs;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -10,7 +11,7 @@ use crate::env::Env;
 use crate::eval::load_toplevel_items;
 use crate::garden_type::Type;
 use crate::namespaces::NamespaceInfo;
-use crate::parser::ast::{AstId, Expression_, IdGenerator, SymbolName};
+use crate::parser::ast::{AstId, Expression_, IdGenerator, ImportInfo, SymbolName, ToplevelItem};
 use crate::parser::parse_toplevel_items;
 use crate::pos_to_id::{find_expr_of_id, find_item_at};
 use crate::types::TypeDef;
@@ -43,6 +44,16 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
 
     let mut seen_expr_ids = FxHashSet::default();
     for id in ids_at_pos.iter().rev() {
+        if let AstId::Import(import_id) = id {
+            for item in &items {
+                if let ToplevelItem::Import(info) = item {
+                    if info.id == *import_id {
+                        return get_import_completions(info, path);
+                    }
+                }
+            }
+            continue;
+        }
         let AstId::Expr(expr_id) = id else {
             continue;
         };
@@ -124,6 +135,51 @@ pub(crate) fn complete(src: &str, path: &Path, offset: usize) -> Vec<CompletionI
         }
     }
     vec![]
+}
+
+/// Files in the directory of `src_path` that could be imported with
+/// the relative path the user has started typing.
+fn get_import_completions(import_info: &ImportInfo, src_path: &Path) -> Vec<CompletionItem> {
+    let Some(path_str) = import_info.path.to_str() else {
+        return vec![];
+    };
+
+    let Some(prefix) = path_str.strip_prefix("./") else {
+        return vec![];
+    };
+
+    let Some(parent_dir) = src_path.parent() else {
+        return vec![];
+    };
+
+    let Ok(entries) = fs::read_dir(parent_dir) else {
+        return vec![];
+    };
+
+    let mut items: Vec<CompletionItem> = vec![];
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+
+        if !name.ends_with(".gdn") {
+            continue;
+        }
+
+        if !name.starts_with(prefix) {
+            continue;
+        }
+
+        items.push(CompletionItem {
+            label: name.to_owned(),
+            kind: Some(CompletionItemKind::File),
+            ..Default::default()
+        });
+    }
+
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    items
 }
 
 /// Values that are available in the toplevel of this namespace.

--- a/src/test_files/complete/import_relative.gdn
+++ b/src/test_files/complete/import_relative.gdn
@@ -1,0 +1,6 @@
+import "./prelude"
+//               ^
+
+// args: complete
+// expected stdout:
+// {"label":"prelude_fun.gdn","kind":17}


### PR DESCRIPTION
## Summary
This PR adds autocompletion support for relative import paths in Garden files. When a user is typing an import statement with a relative path (e.g., `import "./pre..."`), the editor will now suggest matching `.gdn` files in the same directory.

## Key Changes
- Added `get_import_completions()` function that:
  - Extracts the relative path prefix from an import statement
  - Reads the directory containing the source file
  - Filters for `.gdn` files matching the typed prefix
  - Returns sorted completion items with file kind
  
- Updated the main `complete()` function to:
  - Detect when the cursor is positioned within an import statement
  - Route import-related completions to the new `get_import_completions()` function
  - Import `ImportInfo` and `ToplevelItem` types from the AST module

- Added test case `import_relative.gdn` to verify completion works for relative import paths

## Implementation Details
- The completion only triggers for relative paths starting with `./` to avoid ambiguity with other import styles
- File filtering is case-sensitive and only matches files with the `.gdn` extension
- Results are sorted alphabetically for consistent ordering
- Gracefully handles edge cases (missing parent directory, unreadable paths, non-UTF8 filenames)

https://claude.ai/code/session_018uqPebMxZfXDAL3JJGPPg5