### PR TITLE
Limit workflow triggers to main branch for push events

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
-on: [pull_request, push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   coverage:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Docker Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build-docker:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 name: CI
 


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow triggers to only run on push events to the main branch, while maintaining pull request triggers on all branches.

## Key Changes
- **coverage.yml**: Modified push trigger to only run on main branch
- **docker.yml**: Modified push trigger to only run on main branch
- **test.yml**: Modified push trigger to only run on main branch

All three workflows now follow the same trigger pattern:
- Push events: Limited to `main` branch only
- Pull request events: Triggered on all branches

## Rationale
This change reduces unnecessary workflow executions on feature branches while maintaining full CI/CD coverage for pull requests and the main branch. This helps optimize CI/CD resource usage and provides faster feedback on feature branches.

https://claude.ai/code/session_01Y9U9fbbU68TSkwNAkRGaxL