### PR TITLE
Emit individual values for each toplevel expression in playground

### DIFF
--- a/src/sandboxed_playground.rs
+++ b/src/sandboxed_playground.rs
@@ -7,11 +7,14 @@ use std::time::Instant;
 
 use serde::Serialize;
 
+use crate::checks::check_toplevel_items_in_env;
+use crate::diagnostics::Severity;
 use crate::env::Env;
 use crate::eval::{
-    eval_toplevel_items, EvalError, ExceptionInfo, Session, StdoutJsonFormat, StdoutMode,
+    eval_exprs, eval_tests, load_toplevel_items, EvalError, ExceptionInfo, Session,
+    StdoutJsonFormat, StdoutMode, ToplevelEvalSummary,
 };
-use crate::parser::ast::IdGenerator;
+use crate::parser::ast::{Expression, IdGenerator, ToplevelItem};
 use crate::parser::parse_toplevel_items;
 use crate::parser::vfs::Vfs;
 use crate::test_runner::describe_tests;
@@ -25,9 +28,9 @@ struct PlaygroundResponse {
 
 /// Run a Garden program in sandboxed mode and print the result as JSON.
 ///
-/// Evaluates all toplevel items in order, stopping on the first error.
-/// Prints JSON with an `error` field that is null on success or contains
-/// an error message on failure.
+/// Evaluates each toplevel expression in order, stopping on the first
+/// error. Each evaluated value (excluding `Unit`) is emitted as its
+/// own JSON response.
 pub(crate) fn run_sandboxed_playground(src: &str, path: &Path, interrupted: Arc<AtomicBool>) {
     let mut id_gen = IdGenerator::default();
     let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
@@ -53,8 +56,8 @@ pub(crate) fn run_sandboxed_playground(src: &str, path: &Path, interrupted: Arc<
         pretty_print_json: false,
     };
 
-    let responses = match eval_toplevel_items(&vfs_path, &items, &mut env, &session) {
-        Ok(summary) => {
+    let responses = match run(&items, &mut env, &session, &vfs_path) {
+        Ok((summary, values)) => {
             let mut items = vec![];
             if !summary.tests.is_empty() {
                 items.push(PlaygroundResponse {
@@ -63,12 +66,24 @@ pub(crate) fn run_sandboxed_playground(src: &str, path: &Path, interrupted: Arc<
                 });
             }
 
-            let last_value = summary.values.last().cloned().unwrap_or_else(Value::unit);
-            let value_display = last_value.display(&env);
-            items.push(PlaygroundResponse {
-                error: None,
-                value: Some(value_display),
-            });
+            let displays: Vec<String> = values
+                .iter()
+                .filter_map(|v| v.display_unless_unit(&env))
+                .collect();
+
+            if displays.is_empty() {
+                items.push(PlaygroundResponse {
+                    error: None,
+                    value: Some("Unit".to_owned()),
+                });
+            } else {
+                for display in displays {
+                    items.push(PlaygroundResponse {
+                        error: None,
+                        value: Some(display),
+                    });
+                }
+            }
 
             items
         }
@@ -105,4 +120,54 @@ pub(crate) fn run_sandboxed_playground(src: &str, path: &Path, interrupted: Arc<
         let json = serde_json::to_string(&response).expect("Failed to serialize response");
         println!("{}", json);
     }
+}
+
+/// Evaluate the toplevel items, capturing a value for each toplevel
+/// expression or block individually.
+fn run(
+    items: &[ToplevelItem],
+    env: &mut Env,
+    session: &Session,
+    vfs_path: &crate::parser::vfs::VfsPathBuf,
+) -> Result<(ToplevelEvalSummary, Vec<Value>), EvalError> {
+    let mut defs = vec![];
+    let mut expr_groups: Vec<Vec<Expression>> = vec![];
+    for item in items {
+        match item {
+            ToplevelItem::Expr(toplevel_expression) => {
+                expr_groups.push(vec![toplevel_expression.0.clone()]);
+            }
+            ToplevelItem::Block(block) => {
+                expr_groups.push(block.exprs.iter().map(|e| e.as_ref().clone()).collect());
+            }
+            _ => {
+                defs.push(item.clone());
+            }
+        }
+    }
+
+    let ns = env.current_namespace();
+    let (mut diagnostics, _new_syms) = load_toplevel_items(&defs, env, ns.clone());
+    for diagnostic in diagnostics.iter() {
+        if matches!(diagnostic.severity, Severity::Error) {
+            return Err(EvalError::Exception(ExceptionInfo {
+                position: diagnostic.position.clone(),
+                message: diagnostic.message.clone(),
+            }));
+        }
+    }
+
+    diagnostics.extend(check_toplevel_items_in_env(vfs_path, items, env, ns));
+
+    let summary = eval_tests(items, env, session);
+
+    let mut values = vec![];
+    for group in &expr_groups {
+        let group_values = eval_exprs(group, env, session)?;
+        if let Some(last) = group_values.into_iter().last() {
+            values.push(last);
+        }
+    }
+
+    Ok((summary, values))
 }

--- a/src/test_files/playground/multiple_values.gdn
+++ b/src/test_files/playground/multiple_values.gdn
@@ -1,0 +1,7 @@
+1 + 1
+2 + 2
+
+// args: playground-run
+// expected stdout:
+// {"error":null,"value":"2"}
+// {"error":null,"value":"4"}


### PR DESCRIPTION
## Summary
Modified the sandboxed playground to emit a separate JSON response for each toplevel expression or block, rather than only returning the last evaluated value. This allows users to see the results of all expressions in their program.

## Key Changes
- Refactored `run_sandboxed_playground` to use a new `run()` helper function that separates toplevel definitions from expressions/blocks
- Changed output format to emit one JSON response per toplevel expression (excluding `Unit` values), instead of a single response with the last value
- Updated response handling to filter out `Unit` values using a new `display_unless_unit()` method, with special handling to show "Unit" if all expressions evaluate to `Unit`
- Reorganized imports to include new functions: `eval_exprs`, `eval_tests`, `load_toplevel_items`, and types like `ToplevelEvalSummary`
- Added `check_toplevel_items_in_env` call to validate toplevel items during evaluation
- Added test case `multiple_values.gdn` demonstrating the new behavior with two expressions that each produce their own JSON output

## Implementation Details
- The `run()` function groups toplevel items into definitions (functions, types, etc.) and expression groups (individual expressions or blocks)
- Definitions are loaded first and validated before expression evaluation
- Each expression group is evaluated separately, capturing the last value from each group
- Non-`Unit` values are displayed as individual JSON responses in order

https://claude.ai/code/session_011fjvB5Y7ZF3jsZNps5Wwwz