### PR TITLE
Handle Ctrl-C differently for nREPL server vs other modes

### DIFF
--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -1276,14 +1276,29 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         .unwrap_or_else(|_| addr.clone());
     info!("nREPL server started on {local}");
 
-    for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
+    // Use a non-blocking listener so the accept loop can periodically
+    // check the interrupted flag and shut down on Ctrl-C.
+    if let Err(e) = listener.set_nonblocking(true) {
+        error!("nREPL: could not set listener to non-blocking: {e}");
+        std::process::exit(1);
+    }
+
+    loop {
+        if interrupted.load(Ordering::SeqCst) {
+            info!("nREPL: shutting down");
+            return;
+        }
+
+        match listener.accept() {
+            Ok((stream, _)) => {
                 let interrupted = Arc::clone(&interrupted);
                 std::thread::Builder::new()
                     .name("nrepl-client".to_owned())
                     .spawn(move || serve_connection(stream, interrupted))
                     .expect("Could not spawn nREPL client thread");
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
             }
             Err(e) => {
                 error!("nREPL: error accepting connection: {e}");


### PR DESCRIPTION
## Summary
Modified Ctrl-C signal handling to differentiate between the nREPL server mode and other CLI modes. The nREPL server now terminates the process on Ctrl-C, while other modes continue to use the interrupt flag mechanism.

## Key Changes
- Moved argument parsing to the beginning of `main()` to enable command-type checking before setting up signal handlers
- Added conditional logic to check if the command is `CliCommands::Nrepl`
- For nREPL mode: Ctrl-C now calls `std::process::exit(130)` to terminate the server process
- For other modes: Preserved the original behavior of setting an interrupt flag via `AtomicBool`

## Implementation Details
- The nREPL server uses exit code 130, which is the standard exit code for SIGINT termination (128 + 2)
- This change allows the nREPL server to be properly terminated by Ctrl-C while maintaining the existing interrupt mechanism for REPL and JSON session modes

https://claude.ai/code/session_01E6d1s8ZRtLzdgBZUbWJRpT