### PR TITLE
Replace eprintln! with structured logging via tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,8 @@ dependencies = [
  "strsim 0.10.0",
  "strum",
  "strum_macros",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -623,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +701,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ordered-float"
@@ -705,6 +731,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -1018,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1231,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1339,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ strum = "0.24.1"
 strum_macros = "0.24.1"
 rustc-hash = "2.1.0"
 normalize-path = "0.2.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[bin]]
 name = "garden"

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -14,6 +14,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Read, Write};
 use std::path::{Path, PathBuf};
+use tracing::error;
 use url::Url;
 
 /// Storage for open document contents, keyed by file path.
@@ -883,7 +884,7 @@ pub(crate) fn run_lsp() {
                 break;
             }
             Err(e) => {
-                eprintln!("Error reading message: {e}");
+                error!("Error reading message: {e}");
                 continue;
             }
         };
@@ -892,7 +893,7 @@ pub(crate) fn run_lsp() {
         let parsed: Message = match serde_json::from_value(message.clone()) {
             Ok(m) => m,
             Err(e) => {
-                eprintln!("Error parsing message: {e}");
+                error!("Error parsing message: {e}");
                 continue;
             }
         };
@@ -906,13 +907,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing initialize params");
+                            error!("Error parsing initialize params");
                             continue;
                         }
                     };
                     let response = handle_initialize(id, params);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -927,13 +928,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing completion params");
+                            error!("Error parsing completion params");
                             continue;
                         }
                     };
                     let response = handle_completion(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -945,13 +946,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing definition params");
+                            error!("Error parsing definition params");
                             continue;
                         }
                     };
                     let response = handle_definition(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -963,13 +964,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing hover params");
+                            error!("Error parsing hover params");
                             continue;
                         }
                     };
                     let response = handle_hover(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -981,13 +982,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing documentHighlight params");
+                            error!("Error parsing documentHighlight params");
                             continue;
                         }
                     };
                     let response = handle_document_highlight(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -999,13 +1000,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing formatting params");
+                            error!("Error parsing formatting params");
                             continue;
                         }
                     };
                     let response = handle_formatting(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -1017,13 +1018,13 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing code action params");
+                            error!("Error parsing code action params");
                             continue;
                         }
                     };
                     let response = handle_code_action(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
@@ -1035,33 +1036,33 @@ pub(crate) fn run_lsp() {
                     {
                         Some(p) => p,
                         None => {
-                            eprintln!("Error parsing rename params");
+                            error!("Error parsing rename params");
                             continue;
                         }
                     };
                     let response = handle_rename(id, params, &documents);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
             }
             Some("textDocument/didOpen") => {
                 let params = message.get("params").unwrap_or(&serde_json::Value::Null);
                 if let Err(e) = handle_did_open(params, &mut documents) {
-                    eprintln!("Error handling didOpen: {e}");
+                    error!("Error handling didOpen: {e}");
                 }
             }
             Some("textDocument/didChange") => {
                 let params = message.get("params").unwrap_or(&serde_json::Value::Null);
                 if let Err(e) = handle_did_change(params, &mut documents) {
-                    eprintln!("Error handling didChange: {e}");
+                    error!("Error handling didChange: {e}");
                 }
             }
             Some("shutdown") => {
                 if let Some(id) = parsed.id {
                     let response = handle_shutdown(id);
                     if let Err(e) = write_message(&response) {
-                        eprintln!("Error writing response: {e}");
+                        error!("Error writing response: {e}");
                     }
                 }
                 should_exit = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -574,12 +574,29 @@ fn main() {
             );
         }
         CliCommands::Lsp => {
+            init_tracing();
             lsp::run_lsp();
         }
         CliCommands::Nrepl { port, host } => {
+            init_tracing();
             nrepl::run_nrepl(&host, port, interrupted);
         }
     }
+}
+
+/// Initialize the tracing subscriber, writing logs to stderr.
+///
+/// Honours the `GARDEN_LOG` environment variable for filtering; defaults
+/// to `info` if unset.
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+
+    let filter = EnvFilter::try_from_env("GARDEN_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
 }
 
 /// Evaluate a garden file, then run eval-up-to and print the result.

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use serde_bencode::value::Value;
+use tracing::{error, info, warn};
 
 use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
@@ -396,7 +397,7 @@ fn serve_connection(stream: TcpStream, interrupted: Arc<AtomicBool>) {
         .peer_addr()
         .map(|a| a.to_string())
         .unwrap_or_else(|_| "<unknown>".to_owned());
-    eprintln!("nREPL: client connected from {peer}");
+    info!("nREPL: client connected from {peer}");
 
     let mut writer = stream.try_clone().expect("Could not clone TCP stream");
     let mut reader = BufReader::new(stream);
@@ -407,12 +408,12 @@ fn serve_connection(stream: TcpStream, interrupted: Arc<AtomicBool>) {
         let request = match read_message(&mut reader) {
             Ok(Some(Value::Dict(d))) => d,
             Ok(Some(_)) => {
-                eprintln!("nREPL: ignoring non-dict request");
+                warn!("nREPL: ignoring non-dict request");
                 continue;
             }
             Ok(None) => break,
             Err(e) => {
-                eprintln!("nREPL: error reading request: {e}");
+                error!("nREPL: error reading request: {e}");
                 break;
             }
         };
@@ -420,17 +421,17 @@ fn serve_connection(stream: TcpStream, interrupted: Arc<AtomicBool>) {
         let responses = handle_message(&mut conn, &request);
         for response in responses {
             if let Err(e) = write_message(&mut writer, &response) {
-                eprintln!("nREPL: error writing response: {e}");
+                error!("nREPL: error writing response: {e}");
                 return;
             }
         }
         if let Err(e) = writer.flush() {
-            eprintln!("nREPL: error flushing writer: {e}");
+            error!("nREPL: error flushing writer: {e}");
             return;
         }
     }
 
-    eprintln!("nREPL: client {peer} disconnected");
+    info!("nREPL: client {peer} disconnected");
 }
 
 /// Run an nREPL server, listening on `host:port`.
@@ -439,7 +440,7 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
     let listener = match TcpListener::bind(&addr) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("nREPL: could not bind to {addr}: {e}");
+            error!("nREPL: could not bind to {addr}: {e}");
             std::process::exit(1);
         }
     };
@@ -448,7 +449,7 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         .local_addr()
         .map(|a| a.to_string())
         .unwrap_or_else(|_| addr.clone());
-    eprintln!("nREPL server started on {local}");
+    info!("nREPL server started on {local}");
 
     for stream in listener.incoming() {
         match stream {
@@ -460,7 +461,7 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
                     .expect("Could not spawn nREPL client thread");
             }
             Err(e) => {
-                eprintln!("nREPL: error accepting connection: {e}");
+                error!("nREPL: error accepting connection: {e}");
             }
         }
     }

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use serde_bencode::value::Value;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
@@ -286,6 +286,9 @@ fn base_response(request: &HashMap<Vec<u8>, Value>) -> HashMap<Vec<u8>, Value> {
 /// Handle a single request message from the client.
 fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) -> Vec<Value> {
     let op = dict_get(request, "op").and_then(as_str).unwrap_or("");
+    let id = dict_get(request, "id").and_then(as_str).unwrap_or("");
+    let session = dict_get(request, "session").and_then(as_str).unwrap_or("");
+    debug!(op, id, session, "nREPL: received request");
 
     let base = base_response(request);
 


### PR DESCRIPTION
## Summary
This PR replaces all `eprintln!` calls with structured logging using the `tracing` crate, providing better control over log levels and filtering through environment variables.

## Key Changes
- Added `tracing` and `tracing-subscriber` dependencies to `Cargo.toml`
- Imported `tracing::{error, info, warn}` macros in `src/lsp.rs` and `src/nrepl.rs`
- Replaced all `eprintln!` calls with appropriate `tracing` macros:
  - `error!()` for error conditions (parsing failures, I/O errors, etc.)
  - `info!()` for informational messages (server startup, client connections)
  - `warn!()` for warning conditions (unexpected message formats)
- Added `init_tracing()` function in `src/main.rs` to initialize the tracing subscriber with:
  - Stderr output writer
  - Environment variable filtering via `GARDEN_LOG` (defaults to `info` level)
- Called `init_tracing()` before running LSP and nREPL servers

## Implementation Details
- The tracing subscriber is configured to respect the `GARDEN_LOG` environment variable for log level filtering, allowing users to control verbosity without code changes
- All error messages maintain their original content while gaining structured logging benefits
- The initialization is only performed for LSP and nREPL modes, keeping other CLI commands unaffected

https://claude.ai/code/session_01Fxq8aq82faz5TVZGCZ45c2