### PR TITLE
Update CLI usage message to include [OPTIONS] placeholder

### DIFF
--- a/src/test_files/json_session/load_me.gdn
+++ b/src/test_files/json_session/load_me.gdn
@@ -6,6 +6,6 @@ fun add_one(x: Int): Int {
 // expected stderr:
 // error: unrecognized subcommand 'src/test_files/json_session/load_me.gdn'
 // 
-// Usage: garden <COMMAND>
+// Usage: garden [OPTIONS] <COMMAND>
 // 
 // For more information, try '--help'.


### PR DESCRIPTION
## Summary
Updated the CLI usage message in the test file to reflect the actual command-line interface, which accepts optional flags before the subcommand.

## Changes
- Modified the expected usage output from `garden <COMMAND>` to `garden [OPTIONS] <COMMAND>` to accurately represent that the garden CLI accepts optional arguments before the subcommand is specified

## Details
This change updates a test expectation in `src/test_files/json_session/load_me.gdn` to match the actual behavior of the garden CLI, which supports options/flags that can be provided before the subcommand argument.

https://claude.ai/code/session_01BncQacmrPwKqcxQyxKmhtu