### PR TITLE
Add import completions for built-in modules

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -177,10 +177,6 @@ fn get_import_completions(import_info: &ImportInfo, src_path: &Path) -> Vec<Comp
         }
     } else {
         for (name, _) in BUILT_IN_FILES {
-            if *name == "__prelude.gdn" {
-                continue;
-            }
-
             if !name.starts_with(path_str) {
                 continue;
             }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -8,7 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::checks::type_checker::check_types;
 use crate::env::Env;
-use crate::eval::load_toplevel_items;
+use crate::eval::{load_toplevel_items, BUILT_IN_FILES};
 use crate::garden_type::Type;
 use crate::namespaces::NamespaceInfo;
 use crate::parser::ast::{AstId, Expression_, IdGenerator, ImportInfo, SymbolName, ToplevelItem};
@@ -144,38 +144,53 @@ fn get_import_completions(import_info: &ImportInfo, src_path: &Path) -> Vec<Comp
         return vec![];
     };
 
-    let Some(prefix) = path_str.strip_prefix("./") else {
-        return vec![];
-    };
-
-    let Some(parent_dir) = src_path.parent() else {
-        return vec![];
-    };
-
-    let Ok(entries) = fs::read_dir(parent_dir) else {
-        return vec![];
-    };
-
     let mut items: Vec<CompletionItem> = vec![];
-    for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
+
+    if let Some(prefix) = path_str.strip_prefix("./") {
+        let Some(parent_dir) = src_path.parent() else {
+            return vec![];
         };
 
-        if !name.ends_with(".gdn") {
-            continue;
-        }
+        let Ok(entries) = fs::read_dir(parent_dir) else {
+            return vec![];
+        };
 
-        if !name.starts_with(prefix) {
-            continue;
-        }
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else {
+                continue;
+            };
 
-        items.push(CompletionItem {
-            label: name.to_owned(),
-            kind: Some(CompletionItemKind::File),
-            ..Default::default()
-        });
+            if !name.ends_with(".gdn") {
+                continue;
+            }
+
+            if !name.starts_with(prefix) {
+                continue;
+            }
+
+            items.push(CompletionItem {
+                label: name.to_owned(),
+                kind: Some(CompletionItemKind::File),
+                ..Default::default()
+            });
+        }
+    } else {
+        for (name, _) in BUILT_IN_FILES {
+            if *name == "__prelude.gdn" {
+                continue;
+            }
+
+            if !name.starts_with(path_str) {
+                continue;
+            }
+
+            items.push(CompletionItem {
+                label: (*name).to_owned(),
+                kind: Some(CompletionItemKind::File),
+                ..Default::default()
+            });
+        }
     }
 
     items.sort_by(|a, b| a.label.cmp(&b.label));

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -659,7 +659,7 @@ fn insert_imported_namespace(
     }
 }
 
-const BUILT_IN_FILES: &[(&str, &str)] = &[
+pub(crate) const BUILT_IN_FILES: &[(&str, &str)] = &[
     ("__prelude.gdn", include_str!("__prelude.gdn")),
     ("__fs.gdn", include_str!("__fs.gdn")),
     ("__random.gdn", include_str!("__random.gdn")),

--- a/src/test_files/complete/import_built_in.gdn
+++ b/src/test_files/complete/import_built_in.gdn
@@ -1,0 +1,6 @@
+import "__ra"
+//           ^
+
+// args: complete
+// expected stdout:
+// {"label":"__random.gdn","kind":17}


### PR DESCRIPTION
## Summary
This PR adds support for import completions when importing built-in modules in Garden. Previously, completions only worked for relative file imports (using `./` prefix). Now users can also get completions for built-in modules like `__random.gdn` and `__fs.gdn`.

## Key Changes
- **Export `BUILT_IN_FILES` constant**: Made the `BUILT_IN_FILES` constant public in `src/eval.rs` so it can be accessed from the completions module
- **Refactor import completion logic**: Modified `get_import_completions()` in `src/completions.rs` to handle two cases:
  - Relative imports (with `./` prefix): Lists `.gdn` files from the parent directory
  - Built-in imports: Lists available built-in modules, excluding the internal `__prelude.gdn`
- **Add test case**: Created `src/test_files/complete/import_built_in.gdn` to verify that importing `__ra` correctly suggests `__random.gdn`

## Implementation Details
- The completion logic now uses an `if-else` structure to distinguish between relative and built-in imports
- Built-in module completions filter out `__prelude.gdn` since it's an internal implementation detail
- Both completion paths sort results alphabetically for consistent output

https://claude.ai/code/session_01TyaBPJ4hUhNZwKXyZK4Bdk