### PR TITLE
Capture stdout in nREPL server and send to clients

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -250,6 +250,10 @@ pub(crate) enum StdoutMode {
     /// consume stdout in a REPL session or the playground backend
     /// without getting confused.
     WriteJson(StdoutJsonFormat),
+    /// Append the string to the given buffer instead of writing it to
+    /// stdout. Used by the nREPL server to capture output and send it
+    /// back to the connected client.
+    WriteToBuffer(Arc<std::sync::Mutex<String>>),
     /// Don't write anything to stdout when print() is called, treat
     /// it as a no-op. This is used when running tests in a sandbox.
     DoNotWrite,
@@ -2646,6 +2650,9 @@ fn eval_built_in_call(
                     // needs a test
                     print_as_json(&response, session.pretty_print_json);
                 }
+                StdoutMode::WriteToBuffer(buf) => {
+                    buf.lock().expect("stdout buffer poisoned").push_str(s);
+                }
                 StdoutMode::DoNotWrite => {}
             }
 
@@ -2672,7 +2679,7 @@ fn eval_built_in_call(
             saved_values.push(receiver_value.clone());
 
             let s = check_string(&arg_values[0], &arg_positions[0], saved_values, env)?;
-            match session.stdout_mode {
+            match &session.stdout_mode {
                 StdoutMode::WriteDirectly => {
                     println!("{s}");
                 }
@@ -2691,6 +2698,11 @@ fn eval_built_in_call(
                         s: format!("{s}\n"),
                     };
                     print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteToBuffer(buf) => {
+                    let mut b = buf.lock().expect("stdout buffer poisoned");
+                    b.push_str(s);
+                    b.push('\n');
                 }
                 StdoutMode::DoNotWrite => {}
             }

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -13,7 +13,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use serde_bencode::value::Value;
@@ -122,6 +122,7 @@ fn handle_eval(
     code: &str,
     env: &mut Env,
     session: &Session,
+    stdout_buf: &Arc<Mutex<String>>,
     base_msg: &HashMap<Vec<u8>, Value>,
 ) -> Vec<Value> {
     let path = PathBuf::from("__nrepl.gdn");
@@ -169,7 +170,16 @@ fn handle_eval(
         responses.push(Value::Dict(warn_msg));
     }
 
-    match eval_toplevel_exprs_then_stop(&items, env, session, ns.clone()) {
+    let eval_result = eval_toplevel_exprs_then_stop(&items, env, session, ns.clone());
+
+    let captured = std::mem::take(&mut *stdout_buf.lock().expect("stdout buffer poisoned"));
+    if !captured.is_empty() {
+        let mut out_msg = base_msg.clone();
+        out_msg.insert(b"out".to_vec(), bstr(captured));
+        responses.push(Value::Dict(out_msg));
+    }
+
+    match eval_result {
         Ok(value) => {
             let value_str = match value {
                 Some(v) => v.display(env),
@@ -366,15 +376,16 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) -> V
 
             let env = conn.sessions.get_mut(&session_id).unwrap();
 
+            let stdout_buf = Arc::new(Mutex::new(String::new()));
             let session = Session {
                 interrupted: Arc::clone(&conn.interrupted),
-                stdout_mode: StdoutMode::WriteDirectly,
+                stdout_mode: StdoutMode::WriteToBuffer(Arc::clone(&stdout_buf)),
                 start_time: Instant::now(),
                 trace_exprs: false,
                 pretty_print_json: false,
             };
 
-            handle_eval(&code, env, &session, &base)
+            handle_eval(&code, env, &session, &stdout_buf, &base)
         }
         "" => {
             let mut msg = base;


### PR DESCRIPTION
## Summary
This change implements stdout capture in the nREPL server, allowing printed output from evaluated code to be sent back to connected clients instead of being written directly to the server's stdout.

## Key Changes
- Added `WriteToBuffer` variant to `StdoutMode` enum that appends output to a thread-safe `Arc<Mutex<String>>` buffer
- Modified `handle_eval` in nREPL to:
  - Create a stdout buffer for each eval session
  - Pass the buffer to the `Session` struct via the new `WriteToBuffer` mode
  - Capture any buffered output after evaluation completes
  - Send captured output back to the client as an "out" message in the nREPL response
- Updated `eval_built_in_call` to handle the new `WriteToBuffer` stdout mode for both `print()` and `println()` built-in functions
- Added `Mutex` import to support thread-safe buffer access

## Implementation Details
- The stdout buffer is created as an `Arc<Mutex<String>>` to allow safe sharing between the evaluation context and the message handler
- After evaluation, the buffer is drained using `std::mem::take()` to extract captured output
- Only non-empty captured output is included in the response message to avoid unnecessary traffic
- The implementation maintains backward compatibility with existing stdout modes (`WriteDirectly`, `WriteJson`, `DoNotWrite`)

https://claude.ai/code/session_0166p15zkYisExcFHQkocdJ7