### PR TITLE
Report Garden version as structured dict in nREPL

### DIFF
--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -309,8 +309,17 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) -> V
                 ops_dict.insert(op.as_bytes().to_vec(), Value::Dict(HashMap::new()));
             }
 
+            let garden_major: i64 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or(0);
+            let garden_minor: i64 = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or(0);
+
             let versions = bencode_dict(vec![
-                (b"garden".to_vec(), bstr(env!("CARGO_PKG_VERSION"))),
+                (
+                    b"garden".to_vec(),
+                    bencode_dict(vec![
+                        (b"major".to_vec(), Value::Int(garden_major)),
+                        (b"minor".to_vec(), Value::Int(garden_minor)),
+                    ]),
+                ),
                 (
                     b"nrepl".to_vec(),
                     bencode_dict(vec![


### PR DESCRIPTION
## Summary
Changed the nREPL version reporting for Garden to use a structured dictionary format with separate major and minor version fields, instead of a simple string version.

## Key Changes
- Parse `CARGO_PKG_VERSION_MAJOR` and `CARGO_PKG_VERSION_MINOR` compile-time environment variables as integers
- Replace the flat string version `(b"garden".to_vec(), bstr(env!("CARGO_PKG_VERSION")))` with a nested dictionary structure containing `major` and `minor` integer fields
- This allows nREPL clients to programmatically access version components without string parsing

## Implementation Details
The version information is now reported as:
```
"garden" => {
  "major" => <integer>,
  "minor" => <integer>
}
```

This structured approach provides better compatibility with nREPL clients that need to check version compatibility and makes the version information more machine-readable.

https://claude.ai/code/session_01DpgBfwV1cmrAQhSh21qkH7