### PR TITLE
Fix diagnostic margin width calculation for sparse line spans

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -215,7 +215,24 @@ fn format_pos_in_fun(
     };
 
     let s_lines: Vec<_> = src.lines().collect();
-    let margin_width = format!("{}", s_lines.len()).len();
+
+    let offset = position.start_offset;
+    let end_offset = position.end_offset;
+
+    let valid_offsets = !s_lines.is_empty() && offset < src.len() && end_offset < src.len();
+    let spans = if valid_offsets {
+        LinePositions::from(src).from_region(offset, end_offset)
+    } else {
+        vec![]
+    };
+
+    // Size the left margin to fit the largest line number we will print,
+    // not the largest line number in the file overall.
+    let max_line_shown = match spans.last() {
+        Some(last_span) => (last_span.line.as_usize() + context_lines + 1).min(s_lines.len()),
+        None => s_lines.len(),
+    };
+    let margin_width = format!("{}", max_line_shown).len().max(1);
 
     let formatted_pos = format!(
         "{}| {}:{}:{}",
@@ -241,12 +258,9 @@ fn format_pos_in_fun(
     }
     res.push('\n');
 
-    let offset = position.start_offset;
-    let end_offset = position.end_offset;
-
     if s_lines.is_empty() {
         // Nothing to do.
-    } else if offset >= src.len() || end_offset >= src.len() {
+    } else if !valid_offsets {
         // TODO: this can occur when the Vfs is stale relative to the
         // last time these functions were re-evaluated.
         let relevant_line = s_lines[0].to_owned();
@@ -254,10 +268,6 @@ fn format_pos_in_fun(
         res.push_str(&format_margin_num("?", margin_width, use_color));
         res.push_str(&format_src_line(&relevant_line, use_color));
     } else {
-        let line_positions = LinePositions::from(src);
-
-        let spans = line_positions.from_region(offset, end_offset);
-
         let mut is_first = true;
 
         if let Some(span) = spans.first() {

--- a/src/test_files/check/ambiguity_dot_access_or_assign.gdn
+++ b/src/test_files/check/ambiguity_dot_access_or_assign.gdn
@@ -13,10 +13,11 @@ public fun foo(): Unit {
 // expected stdout:
 // Error: Expected a method or field name after this.
 // 
-// --| src/test_files/check/ambiguity_dot_access_or_assign.gdn:7:4
-//  5|   // We expect an error here because it's parsed as `s.__placeholder`, and
-//  6|   // String values don't have fields.
-//  7|   s.
-//   |    ^
-//  8|   i = 2
-//  9| }
+// -| src/test_files/check/ambiguity_dot_access_or_assign.gdn:7:4
+// 5|   // We expect an error here because it's parsed as `s.__placeholder`, and
+// 6|   // String values don't have fields.
+// 7|   s.
+//  |    ^
+// 8|   i = 2
+// 9| }
+

--- a/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
+++ b/src/test_files/check/ambiguity_fun_call_or_tuple.gdn
@@ -18,12 +18,13 @@ fun add_one(i: Int): Int {
 // expected stdout:
 // Warning: Unused value.
 // 
-// --| src/test_files/check/ambiguity_fun_call_or_tuple.gdn:6:3
-//  4|   // Definitely a tuple, because there's whitespace before it.
-//  5|   let _y = x
-//  6|   (10, 11)
-//  7|   ^^^^^^^^
-//  8|   // Should be parsed as a call, not an if followed by a tuple (5).
+// -| src/test_files/check/ambiguity_fun_call_or_tuple.gdn:6:3
+// 4|   // Definitely a tuple, because there's whitespace before it.
+// 5|   let _y = x
+// 6|   (10, 11)
+// 7|   ^^^^^^^^
+// 8|   // Should be parsed as a call, not an if followed by a tuple (5).
 
 // expected stderr: 
 // 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/ambiguity_struct_literal_or_block.gdn
+++ b/src/test_files/check/ambiguity_struct_literal_or_block.gdn
@@ -15,21 +15,21 @@ public fun foo(): Unit {
 // expected stdout:
 // Error: Expected an expression after this.
 // 
-// --| src/test_files/check/ambiguity_struct_literal_or_block.gdn:6:20
-//  4|   while SomeStruct{} {}
-//  5| 
-//  6|   while SomeValue {}
-//  7|                    ^
-//  8|   // This is therefore a syntax error, because SomeValue cannot be a
+// -| src/test_files/check/ambiguity_struct_literal_or_block.gdn:6:20
+// 4|   while SomeStruct{} {}
+// 5| 
+// 6|   while SomeValue {}
+// 7|                    ^
+// 8|   // This is therefore a syntax error, because SomeValue cannot be a
 // 
 // Error: Expected `}` after this.
 // 
-// --| src/test_files/check/ambiguity_struct_literal_or_block.gdn:6:20
-//  4|   while SomeStruct{} {}
-//  5| 
-//  6|   while SomeValue {}
-//  7|                    ^
-//  8|   // This is therefore a syntax error, because SomeValue cannot be a
+// -| src/test_files/check/ambiguity_struct_literal_or_block.gdn:6:20
+// 4|   while SomeStruct{} {}
+// 5| 
+// 6|   while SomeValue {}
+// 7|                    ^
+// 8|   // This is therefore a syntax error, because SomeValue cannot be a
 // 
 // Error: Expected an expression after this.
 // 
@@ -38,3 +38,4 @@ public fun foo(): Unit {
 //  9|   // struct literal.
 // 10|   {}
 // 11| }  ^
+

--- a/src/test_files/check/assign_add.gdn
+++ b/src/test_files/check/assign_add.gdn
@@ -13,12 +13,12 @@ public fun foo() {
 // expected stdout:
 // Error: Expected an `Int` but got a `String`.
 // 
-// --| src/test_files/check/assign_add.gdn:5:10
-//  3|     x += 1 // OK
-//  4| 
-//  5|     x += "" // bad
-//  6|          ^^
-//  7|     let y = "abc"
+// -| src/test_files/check/assign_add.gdn:5:10
+// 3|     x += 1 // OK
+// 4| 
+// 5|     x += "" // bad
+// 6|          ^^
+// 7|     let y = "abc"
 // 
 // Error: `-=` can only be used with `Int` variables, but got a `String`.
 // 
@@ -26,3 +26,4 @@ public fun foo() {
 //  7|     let y = "abc"
 //  8|     y -= 2 // bad
 //  9| }   ^
+

--- a/src/test_files/check/bad_float_int_ops.gdn
+++ b/src/test_files/check/bad_float_int_ops.gdn
@@ -27,17 +27,17 @@ public fun using_int_add_op() {
 // expected stdout:
 // Error: You can only use `/.` for `Float` values. For `Int` values, use `/` instead.
 // 
-// --| src/test_files/check/bad_float_int_ops.gdn:2:5
-//  1| public fun using_float_op() {
-//  2|   1 /. 2
-//  3| }   ^^
+// -| src/test_files/check/bad_float_int_ops.gdn:2:5
+// 1| public fun using_float_op() {
+// 2|   1 /. 2
+// 3| }   ^^
 // 
 // Error: You can only use `*` for `Int` values. For `Float` values, use `*.` instead.
 // 
-// --| src/test_files/check/bad_float_int_ops.gdn:6:7
-//  5| public fun using_int_op() {
-//  6|   1.0 * 2.0
-//  7| }     ^
+// -| src/test_files/check/bad_float_int_ops.gdn:6:7
+// 5| public fun using_int_op() {
+// 6|   1.0 * 2.0
+// 7| }     ^
 // 
 // Error: You can only use `+` for `Int` values. For `Float` values, use `+.` instead.
 // 
@@ -48,3 +48,4 @@ public fun using_int_add_op() {
 
 // expected stderr: 
 // 3 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/bad_syntax_in_imported_file.gdn
+++ b/src/test_files/check/bad_syntax_in_imported_file.gdn
@@ -7,14 +7,15 @@ import "./has_bad_syntax.gdn"
 // expected stdout:
 // Error: Expected `=` after this.
 // 
-// --| src/test_files/check/has_bad_syntax.gdn:2:7
-//  1| public fun bar() {
-//  2|   let x
-//  3| }     ^
+// -| src/test_files/check/has_bad_syntax.gdn:2:7
+// 1| public fun bar() {
+// 2|   let x
+// 3| }     ^
 // 
 // Error: Expected an expression after this.
 // 
-// --| src/test_files/check/has_bad_syntax.gdn:2:7
-//  1| public fun bar() {
-//  2|   let x
-//  3| }     ^
+// -| src/test_files/check/has_bad_syntax.gdn:2:7
+// 1| public fun bar() {
+// 2|   let x
+// 3| }     ^
+

--- a/src/test_files/check/break_without_loop.gdn
+++ b/src/test_files/check/break_without_loop.gdn
@@ -16,11 +16,11 @@ public fun foo() {
 // expected stdout:
 // Error: `break` can only be used inside `for` or `while` loops.
 // 
-// --| src/test_files/check/break_without_loop.gdn:2:5
-//  1| public fun foo() {
-//  2|     break
-//  3|     ^^^^^
-//  4|     while True {
+// -| src/test_files/check/break_without_loop.gdn:2:5
+// 1| public fun foo() {
+// 2|     break
+// 3|     ^^^^^
+// 4|     while True {
 // 
 // Error: `break` can only be used inside `for` or `while` loops.
 // 
@@ -28,3 +28,4 @@ public fun foo() {
 //  8|         // Bad
 //  9|         fun() { break }
 // 10|     }           ^^^^^
+

--- a/src/test_files/check/cascading_errors.gdn
+++ b/src/test_files/check/cascading_errors.gdn
@@ -15,9 +15,10 @@ public fun foo() {
 // expected stdout:
 // Error: Unbound symbol: `no_such_fun`
 // 
-// --| src/test_files/check/cascading_errors.gdn:2:11
-//  1| public fun foo() {
-//  2|   let x = no_such_fun()
-//   |           ^^^^^^^^^^^
-//  3|   // Calling methods on an error type is fine.
-//  4|   x.len()
+// -| src/test_files/check/cascading_errors.gdn:2:11
+// 1| public fun foo() {
+// 2|   let x = no_such_fun()
+//  |           ^^^^^^^^^^^
+// 3|   // Calling methods on an error type is fine.
+// 4|   x.len()
+

--- a/src/test_files/check/dict_literal_syntax.gdn
+++ b/src/test_files/check/dict_literal_syntax.gdn
@@ -13,11 +13,11 @@ Dict["x" => 1, "y" => ]
 // expected stdout:
 // Error: Expected `,` or `]` after this.
 // 
-// --| src/test_files/check/dict_literal_syntax.gdn:7:13
-//  6| // Bad: forgotten comma.
-//  7| Dict["x" => 1 "y" => nono]
-//  8|             ^
-//  9| Dict["x" => 1, "y" => ]
+// -| src/test_files/check/dict_literal_syntax.gdn:7:13
+// 6| // Bad: forgotten comma.
+// 7| Dict["x" => 1 "y" => nono]
+// 8|             ^
+// 9| Dict["x" => 1, "y" => ]
 // 
 // Error: Expected an expression after this.
 // 
@@ -26,3 +26,4 @@ Dict["x" => 1, "y" => ]
 //  8| 
 //  9| Dict["x" => 1, "y" => ]
 // 10|                    ^^
+

--- a/src/test_files/check/dict_literal_types.gdn
+++ b/src/test_files/check/dict_literal_types.gdn
@@ -22,11 +22,11 @@ Dict["x" => 1, "y" => ""]
 // expected stdout:
 // Error: Unbound symbol: `no_such`
 // 
-// --| src/test_files/check/dict_literal_types.gdn:5:6
-//  4| // Bad: undefined key.
-//  5| Dict[no_such => 1]
-//  6|      ^^^^^^^
-//  7| // Bad: undefined value.
+// -| src/test_files/check/dict_literal_types.gdn:5:6
+// 4| // Bad: undefined key.
+// 5| Dict[no_such => 1]
+// 6|      ^^^^^^^
+// 7| // Bad: undefined value.
 // 
 // Error: Unbound symbol: `no_such2`
 // 
@@ -50,3 +50,4 @@ Dict["x" => 1, "y" => ""]
 // 17| // Bad: mixed value types.
 // 18| Dict["x" => 1, "y" => ""]
 // 19|                       ^^
+

--- a/src/test_files/check/equality_on_different_type.gdn
+++ b/src/test_files/check/equality_on_different_type.gdn
@@ -17,13 +17,13 @@ public fun bar(s: Option<String>, i: Option<Int>) {
 // expected stdout:
 // Warning: You should compare values of the same type, but got `String` and `Int`.
 // 
-// --| src/test_files/check/equality_on_different_type.gdn:3:8
-//  1| public fun foo(s: String, i: Int) {
-//  2|     // Always False.
-//  3|     if s == i {
-//   |        ^^^^^^
-//  4|         print("hello world")
-//  5|     }
+// -| src/test_files/check/equality_on_different_type.gdn:3:8
+// 1| public fun foo(s: String, i: Int) {
+// 2|     // Always False.
+// 3|     if s == i {
+//  |        ^^^^^^
+// 4|         print("hello world")
+// 5|     }
 // 
 // Warning: You should compare values of the same type, but got `Option<String>` and `Option<Int>`.
 // 
@@ -34,3 +34,4 @@ public fun bar(s: Option<String>, i: Option<Int>) {
 //   |        ^^^^^^
 // 11|         print("hello world")
 // 12|     }
+

--- a/src/test_files/check/fun_arity.gdn
+++ b/src/test_files/check/fun_arity.gdn
@@ -27,20 +27,20 @@
 // expected stdout:
 // Error: `range` requires an additional `Int` argument.
 // 
-// --| src/test_files/check/fun_arity.gdn:3:10
-//  1| {
-//  2|   // Too few arguments.
-//  3|   range(1)
-//  4|          ^
-//  5|   // Too few argument, special case when no arguments were provided.
+// -| src/test_files/check/fun_arity.gdn:3:10
+// 1| {
+// 2|   // Too few arguments.
+// 3|   range(1)
+// 4|          ^
+// 5|   // Too few argument, special case when no arguments were provided.
 // 
 // Error: `range` expects 2 arguments, but got 0.
 // 
-// --| src/test_files/check/fun_arity.gdn:6:8
-//  5|   // Too few argument, special case when no arguments were provided.
-//  6|   range()
-//  7|        ^^
-//  8|   // Too many arguments.
+// -| src/test_files/check/fun_arity.gdn:6:8
+// 5|   // Too few argument, special case when no arguments were provided.
+// 6|   range()
+// 7|        ^^
+// 8|   // Too many arguments.
 // 
 // Error: `string_repr` expects 1 argument, but got 3.
 // 
@@ -48,3 +48,4 @@
 //  8|   // Too many arguments.
 //  9|   string_repr(1, 2, 3)
 // 10| }                ^^^^
+

--- a/src/test_files/check/lambda_containing_if.gdn
+++ b/src/test_files/check/lambda_containing_if.gdn
@@ -14,10 +14,11 @@ public fun map_over_strings(lines: List<String>) {
 // expected stdout:
 // Error: Expected a type with a `starts_with` method, but got `Any`.
 // 
-// --| src/test_files/check/lambda_containing_if.gdn:3:12
-//  1| public fun map_over_strings(lines: List<String>) {
-//  2|     lines.map(fun(line) {
-//  3|         if line.starts_with("a") {
-//   |            ^^^^
-//  4|             "b"
-//  5|         } else {
+// -| src/test_files/check/lambda_containing_if.gdn:3:12
+// 1| public fun map_over_strings(lines: List<String>) {
+// 2|     lines.map(fun(line) {
+// 3|         if line.starts_with("a") {
+//  |            ^^^^
+// 4|             "b"
+// 5|         } else {
+

--- a/src/test_files/check/let_shadow_lambda.gdn
+++ b/src/test_files/check/let_shadow_lambda.gdn
@@ -16,12 +16,13 @@
 // expected stdout:
 // Warning: `x` is unused.
 // 
-// --| src/test_files/check/let_shadow_lambda.gdn:3:9
-//  1| {
-//  2|     // This is unused.
-//  3|     let x = "a"
-//  4|         ^
-//  5|     let f = fun() {
+// -| src/test_files/check/let_shadow_lambda.gdn:3:9
+// 1| {
+// 2|     // This is unused.
+// 3|     let x = "a"
+// 4|         ^
+// 5|     let f = fun() {
 
 // expected stderr: 
 // 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/list_mixed.gdn
+++ b/src/test_files/check/list_mixed.gdn
@@ -14,20 +14,20 @@ public fun returns_bools(): List<Bool> {
 // expected stdout:
 // Error: List elements have different types.
 // 
-// --| src/test_files/check/list_mixed.gdn:4:17
-//  3| {
-//  4|     let x = [1, True]
-//   |                 ^^^^
-//  5|     takes_bools(x)
-//  6| }
+// -| src/test_files/check/list_mixed.gdn:4:17
+// 3| {
+// 4|     let x = [1, True]
+//  |                 ^^^^
+// 5|     takes_bools(x)
+// 6| }
 // 
 // Error: Expected a `List<Bool>` but got a `List<Any>`.
 // 
-// --| src/test_files/check/list_mixed.gdn:5:17
-//  3| {
-//  4|     let x = [1, True]
-//  5|     takes_bools(x)
-//  6| }               ^
+// -| src/test_files/check/list_mixed.gdn:5:17
+// 3| {
+// 4|     let x = [1, True]
+// 5|     takes_bools(x)
+// 6| }               ^
 // 
 // Error: Expected a `Bool` but got an `Int`.
 // 
@@ -35,3 +35,4 @@ public fun returns_bools(): List<Bool> {
 //  8| public fun returns_bools(): List<Bool> {
 //  9|   [1, True]
 // 10| }  ^
+

--- a/src/test_files/check/method_return_generic.gdn
+++ b/src/test_files/check/method_return_generic.gdn
@@ -13,9 +13,10 @@ public fun subst_method_return_tys<T>() {
 // expected stdout:
 // Warning: Unfinished code.
 // 
-// --| src/test_files/check/method_return_generic.gdn:4:25
-//  2|   let items: List<(Int, T)> = []
-//  3| 
-//  4|   let t: (Int, T) = (0, todo())
-//  5|                         ^^^^^^
-//  6|   // Regression test: we should only substitute T once, so this code
+// -| src/test_files/check/method_return_generic.gdn:4:25
+// 2|   let items: List<(Int, T)> = []
+// 3| 
+// 4|   let t: (Int, T) = (0, todo())
+// 5|                         ^^^^^^
+// 6|   // Regression test: we should only substitute T once, so this code
+

--- a/src/test_files/check/missing_import_error_cascade.gdn
+++ b/src/test_files/check/missing_import_error_cascade.gdn
@@ -14,8 +14,9 @@ ns::stuff()
 // expected stdout:
 // Error: No such file `no_such.gdn`.
 // 
-// --| src/test_files/check/missing_import_error_cascade.gdn:2:8
-//  1| // This should have an error.
-//  2| import "no_such.gdn" as ns
-//   |        ^^^^^^^^^^^^^
-//  3| import "__fs.gdn" as fs
+// -| src/test_files/check/missing_import_error_cascade.gdn:2:8
+// 1| // This should have an error.
+// 2| import "no_such.gdn" as ns
+//  |        ^^^^^^^^^^^^^
+// 3| import "__fs.gdn" as fs
+

--- a/src/test_files/check/recursion_variable.gdn
+++ b/src/test_files/check/recursion_variable.gdn
@@ -32,8 +32,9 @@ public fun qux(x: Int, _y: Int): Int {
 // expected stdout:
 // Warning: `y` is only used in recursion, so is effectively unused.
 // 
-// --| src/test_files/check/recursion_variable.gdn:2:24
-//  1| // Should warn: y is only used in the recursive call.
-//  2| public fun foo(x: Int, y: Int): Int {
-//  3|     if (x == 0) {      ^
-//  4|         return 0
+// -| src/test_files/check/recursion_variable.gdn:2:24
+// 1| // Should warn: y is only used in the recursive call.
+// 2| public fun foo(x: Int, y: Int): Int {
+// 3|     if (x == 0) {      ^
+// 4|         return 0
+

--- a/src/test_files/check/repeated_bindings.gdn
+++ b/src/test_files/check/repeated_bindings.gdn
@@ -16,37 +16,38 @@ public fun bar(_: Int, _: Int, _: String) {
 // expected stdout:
 // Error: Duplicate parameter `x`.
 // 
-// --| src/test_files/check/repeated_bindings.gdn:1:24
-//  1| public fun foo(x: Int, x: Int) {
-//   |                        ^
-//  2|     let (y, y) = (1, 2)
-// --| src/test_files/check/repeated_bindings.gdn:1:16
-//  1| public fun foo(x: Int, x: Int) {
-//   |                ^ Note: The previous occurrence is here.
-//  2|     let (y, y) = (1, 2)
+// -| src/test_files/check/repeated_bindings.gdn:1:24
+// 1| public fun foo(x: Int, x: Int) {
+//  |                        ^
+// 2|     let (y, y) = (1, 2)
+// -| src/test_files/check/repeated_bindings.gdn:1:16
+// 1| public fun foo(x: Int, x: Int) {
+//  |                ^ Note: The previous occurrence is here.
+// 2|     let (y, y) = (1, 2)
 // 
 // Error: Duplicate variable  `y` in destructuring `let`.
 // 
-// --| src/test_files/check/repeated_bindings.gdn:2:13
-//  1| public fun foo(x: Int, x: Int) {
-//  2|     let (y, y) = (1, 2)
-//  3|             ^
-//  4|     let _f = fun(z, z) {}
-// --| src/test_files/check/repeated_bindings.gdn:2:10
-//  1| public fun foo(x: Int, x: Int) {
-//  2|     let (y, y) = (1, 2)
-//  3|          ^ Note: The previous occurrence is here.
-//  4|     let _f = fun(z, z) {}
+// -| src/test_files/check/repeated_bindings.gdn:2:13
+// 1| public fun foo(x: Int, x: Int) {
+// 2|     let (y, y) = (1, 2)
+// 3|             ^
+// 4|     let _f = fun(z, z) {}
+// -| src/test_files/check/repeated_bindings.gdn:2:10
+// 1| public fun foo(x: Int, x: Int) {
+// 2|     let (y, y) = (1, 2)
+// 3|          ^ Note: The previous occurrence is here.
+// 4|     let _f = fun(z, z) {}
 // 
 // Error: Duplicate parameter `z`.
 // 
-// --| src/test_files/check/repeated_bindings.gdn:4:21
-//  2|     let (y, y) = (1, 2)
-//  3| 
-//  4|     let _f = fun(z, z) {}
-//  5| }                   ^
-// --| src/test_files/check/repeated_bindings.gdn:4:18
-//  2|     let (y, y) = (1, 2)
-//  3| 
-//  4|     let _f = fun(z, z) {}
-//  5| }                ^ Note: The previous occurrence is here.
+// -| src/test_files/check/repeated_bindings.gdn:4:21
+// 2|     let (y, y) = (1, 2)
+// 3| 
+// 4|     let _f = fun(z, z) {}
+// 5| }                   ^
+// -| src/test_files/check/repeated_bindings.gdn:4:18
+// 2|     let (y, y) = (1, 2)
+// 3| 
+// 4|     let _f = fun(z, z) {}
+// 5| }                ^ Note: The previous occurrence is here.
+

--- a/src/test_files/check/repeated_bool.gdn
+++ b/src/test_files/check/repeated_bool.gdn
@@ -27,11 +27,11 @@ public fun no_repeats(x: Bool, y: Bool, z: Bool): Bool {
 // expected stdout:
 // Warning: This expression has already appeared in this `||` chain.
 // 
-// --| src/test_files/check/repeated_bool.gdn:3:15
-//  1| // Repeated operand in ||: should warn.
-//  2| public fun repeated_or(x: Bool, y: Bool): Bool {
-//  3|     x || y || x
-//  4| }             ^
+// -| src/test_files/check/repeated_bool.gdn:3:15
+// 1| // Repeated operand in ||: should warn.
+// 2| public fun repeated_or(x: Bool, y: Bool): Bool {
+// 3|     x || y || x
+// 4| }             ^
 // 
 // Warning: This expression has already appeared in this `&&` chain.
 // 
@@ -43,3 +43,4 @@ public fun no_repeats(x: Bool, y: Bool, z: Bool): Bool {
 
 // expected stderr: 
 // 2 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/same_literal_returns.gdn
+++ b/src/test_files/check/same_literal_returns.gdn
@@ -73,22 +73,22 @@ public fun different_variants(b: Bool): Bool {
 // expected stdout:
 // Warning: All code paths in `early_return_int()` return the same value `1`.
 // 
-// --| src/test_files/check/same_literal_returns.gdn:2:12
-//  1| // Should warn: early return and final expression are the same literal.
-//  2| public fun early_return_int(b: Bool): Int {
-//  3|     if b { ^^^^^^^^^^^^^^^^
-//  4|         return 1
-// --| src/test_files/check/same_literal_returns.gdn:4:16
-//  2| public fun early_return_int(b: Bool): Int {
-//  3|     if b {
-//  4|         return 1
-//  5|     }          ^ Note: Same value here.
-//  6|     1
-// --| src/test_files/check/same_literal_returns.gdn:6:5
-//  4|         return 1
-//  5|     }
-//  6|     1
-//  7| }   ^ Note: Same value here.
+// -| src/test_files/check/same_literal_returns.gdn:2:12
+// 1| // Should warn: early return and final expression are the same literal.
+// 2| public fun early_return_int(b: Bool): Int {
+// 3|     if b { ^^^^^^^^^^^^^^^^
+// 4|         return 1
+// -| src/test_files/check/same_literal_returns.gdn:4:16
+// 2| public fun early_return_int(b: Bool): Int {
+// 3|     if b {
+// 4|         return 1
+// 5|     }          ^ Note: Same value here.
+// 6|     1
+// -| src/test_files/check/same_literal_returns.gdn:6:5
+// 4|         return 1
+// 5|     }
+// 6|     1
+// 7| }   ^ Note: Same value here.
 // 
 // Warning: All code paths in `all_explicit_returns()` return the same value `1`.
 // 
@@ -181,3 +181,4 @@ public fun different_variants(b: Bool): Bool {
 
 // expected stderr: 
 // 1 issue can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/self_assign_compare.gdn
+++ b/src/test_files/check/self_assign_compare.gdn
@@ -77,13 +77,13 @@ public fun compare_different(x: Int, y: Int): Bool {
 // 
 // Warning: `x` is assigned to itself.
 // 
-// --| src/test_files/check/self_assign_compare.gdn:3:5
-//  1| // Self-assignment: should warn.
-//  2| public fun assign_self(x: Int): Int {
-//  3|     x = x
-//   |     ^^^^^
-//  4|     x
-//  5| }
+// -| src/test_files/check/self_assign_compare.gdn:3:5
+// 1| // Self-assignment: should warn.
+// 2| public fun assign_self(x: Int): Int {
+// 3|     x = x
+//  |     ^^^^^
+// 4|     x
+// 5| }
 // 
 // Warning: Both sides of `==` are identical.
 // 
@@ -119,3 +119,4 @@ public fun compare_different(x: Int, y: Int): Bool {
 
 // expected stderr: 
 // 2 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/type_error_if.gdn
+++ b/src/test_files/check/type_error_if.gdn
@@ -25,12 +25,12 @@ public fun stuff(): String {
 // expected stdout:
 // Error: Expected a `Bool` but got an `Int`.
 // 
-// --| src/test_files/check/type_error_if.gdn:2:6
-//  1| {
-//  2|   if 1 {
-//   |      ^
-//  3|     string_repr(1234)
-//  4|   } else {
+// -| src/test_files/check/type_error_if.gdn:2:6
+// 1| {
+// 2|   if 1 {
+//  |      ^
+// 3|     string_repr(1234)
+// 4|   } else {
 // 
 // Error: `if` and `else` have incompatible types: `String` and `Int`.
 // 
@@ -49,3 +49,4 @@ public fun stuff(): String {
 // 19|     123
 // 20|   } ^^^
 // 21| }
+

--- a/src/test_files/check/type_error_method_specialised_type.gdn
+++ b/src/test_files/check/type_error_method_specialised_type.gdn
@@ -13,27 +13,27 @@ public method very_bad<T>(this: T) {}
 // expected stdout:
 // Error: Methods must be generic in all their type parameters, for example `List<T>` rather than `List<Int>`.
 // 
-// --| src/test_files/check/type_error_method_specialised_type.gdn:5:30
-//  3| // We shouldn't allow this, because it's unclear whether `[].bad()`
-//  4| // dispatches to this method or not.
-//  5| public method bad(this: List<Int>) {}
-//  6|                              ^^^
-//  7| public method also_bad<T>(this: Result<T, T>) {}
+// -| src/test_files/check/type_error_method_specialised_type.gdn:5:30
+// 3| // We shouldn't allow this, because it's unclear whether `[].bad()`
+// 4| // dispatches to this method or not.
+// 5| public method bad(this: List<Int>) {}
+// 6|                              ^^^
+// 7| public method also_bad<T>(this: Result<T, T>) {}
 // 
 // Error: Methods cannot repeat generic type parameters.
 // 
-// --| src/test_files/check/type_error_method_specialised_type.gdn:7:43
-//  5| public method bad(this: List<Int>) {}
-//  6| 
-//  7| public method also_bad<T>(this: Result<T, T>) {}
-//  8|                                           ^
-//  9| public method very_bad<T>(this: T) {}
-// --| src/test_files/check/type_error_method_specialised_type.gdn:7:40
-//  5| public method bad(this: List<Int>) {}
-//  6| 
-//  7| public method also_bad<T>(this: Result<T, T>) {}
-//  8|                                        ^ Note: First occurrence here.
-//  9| public method very_bad<T>(this: T) {}
+// -| src/test_files/check/type_error_method_specialised_type.gdn:7:43
+// 5| public method bad(this: List<Int>) {}
+// 6| 
+// 7| public method also_bad<T>(this: Result<T, T>) {}
+// 8|                                           ^
+// 9| public method very_bad<T>(this: T) {}
+// -| src/test_files/check/type_error_method_specialised_type.gdn:7:40
+// 5| public method bad(this: List<Int>) {}
+// 6| 
+// 7| public method also_bad<T>(this: Result<T, T>) {}
+// 8|                                        ^ Note: First occurrence here.
+// 9| public method very_bad<T>(this: T) {}
 // 
 // Error: Methods must be defined on specific types, such as `List`, not generic types.
 // 
@@ -42,3 +42,4 @@ public method very_bad<T>(this: T) {}
 //  8| 
 //  9| public method very_bad<T>(this: T) {}
 // 10|                                 ^
+

--- a/src/test_files/check/unbound_var.gdn
+++ b/src/test_files/check/unbound_var.gdn
@@ -13,18 +13,19 @@ public fun foo() {
 // expected stdout:
 // Error: No such variable `x`. If you want to define a new local variable, write `let x =`.
 // 
-// --| src/test_files/check/unbound_var.gdn:3:3
-//  1| public fun foo() {
-//  2|   // These should be errors.
-//  3|   x = 1
-//   |   ^
-//  4|   y += 2
+// -| src/test_files/check/unbound_var.gdn:3:3
+// 1| public fun foo() {
+// 2|   // These should be errors.
+// 3|   x = 1
+//  |   ^
+// 4|   y += 2
 // 
 // Error: No such variable `y`. If you want to define a new local variable, write `let y =`.
 // 
-// --| src/test_files/check/unbound_var.gdn:4:3
-//  2|   // These should be errors.
-//  3|   x = 1
-//  4|   y += 2
-//  5|   ^
-//  6|   // But later uses of these variables shouldn't have cascading
+// -| src/test_files/check/unbound_var.gdn:4:3
+// 2|   // These should be errors.
+// 3|   x = 1
+// 4|   y += 2
+// 5|   ^
+// 6|   // But later uses of these variables shouldn't have cascading
+

--- a/src/test_files/check/unreachable.gdn
+++ b/src/test_files/check/unreachable.gdn
@@ -62,11 +62,11 @@ public fun good2(): Int {
 // 
 // Warning: Unreachable code after `while` loop which never terminates.
 // 
-// --| src/test_files/check/unreachable.gdn:3:3
-//  1| public fun bad1(): Int {
-//  2|   while True {}
-//  3|   1
-//  4| } ^
+// -| src/test_files/check/unreachable.gdn:3:3
+// 1| public fun bad1(): Int {
+// 2|   while True {}
+// 3|   1
+// 4| } ^
 // 
 // Warning: Unreachable code after `return`.
 // 
@@ -75,3 +75,4 @@ public fun good2(): Int {
 //  7|   return 1
 //  8|   2
 //  9| } ^
+

--- a/src/test_files/check/unused_func.gdn
+++ b/src/test_files/check/unused_func.gdn
@@ -54,13 +54,13 @@ method used_meth(this: String): Unit {}
 // expected stdout:
 // Warning: `not_called` is never called.
 // 
-// --| src/test_files/check/unused_func.gdn:5:5
-//  3| fun called_from_uncalled() {}
-//  4| 
-//  5| fun not_called() {
-//   |     ^^^^^^^^^^
-//  6|   called_from_uncalled()
-//  7| }
+// -| src/test_files/check/unused_func.gdn:5:5
+// 3| fun called_from_uncalled() {}
+// 4| 
+// 5| fun not_called() {
+//  |     ^^^^^^^^^^
+// 6|   called_from_uncalled()
+// 7| }
 // 
 // Warning: `unreachable_cycle` is never called.
 // 
@@ -109,3 +109,4 @@ method used_meth(this: String): Unit {}
 //   |     ^^^^^^^^^^^^^^^^^^^
 // 22|   unreachable_cycle_1()
 // 23| }
+

--- a/src/test_files/check/unused_literal.gdn
+++ b/src/test_files/check/unused_literal.gdn
@@ -13,49 +13,50 @@ public fun example() {
 // expected stdout:
 // Warning: Unused value.
 // 
-// --| src/test_files/check/unused_literal.gdn:2:3
-//  1| public fun example() {
-//  2|   42
-//   |   ^^
-//  3|   "hello"
-//  4|   [1, 2, 3]
+// -| src/test_files/check/unused_literal.gdn:2:3
+// 1| public fun example() {
+// 2|   42
+//  |   ^^
+// 3|   "hello"
+// 4|   [1, 2, 3]
 // 
 // Warning: Unused value.
 // 
-// --| src/test_files/check/unused_literal.gdn:3:3
-//  1| public fun example() {
-//  2|   42
-//  3|   "hello"
-//   |   ^^^^^^^
-//  4|   [1, 2, 3]
-//  5|   Dict[]
+// -| src/test_files/check/unused_literal.gdn:3:3
+// 1| public fun example() {
+// 2|   42
+// 3|   "hello"
+//  |   ^^^^^^^
+// 4|   [1, 2, 3]
+// 5|   Dict[]
 // 
 // Warning: Unused value.
 // 
-// --| src/test_files/check/unused_literal.gdn:4:3
-//  2|   42
-//  3|   "hello"
-//  4|   [1, 2, 3]
-//   |   ^^^^^^^^^
-//  5|   Dict[]
+// -| src/test_files/check/unused_literal.gdn:4:3
+// 2|   42
+// 3|   "hello"
+// 4|   [1, 2, 3]
+//  |   ^^^^^^^^^
+// 5|   Dict[]
 // 
 // Warning: Unused value.
 // 
-// --| src/test_files/check/unused_literal.gdn:5:3
-//  3|   "hello"
-//  4|   [1, 2, 3]
-//  5|   Dict[]
-//  6|   ^^^^^^
-//  7|   let x = 10
+// -| src/test_files/check/unused_literal.gdn:5:3
+// 3|   "hello"
+// 4|   [1, 2, 3]
+// 5|   Dict[]
+// 6|   ^^^^^^
+// 7|   let x = 10
 // 
 // Warning: Unnecessary `let`, this value is immediately returned.
 // 
-// --| src/test_files/check/unused_literal.gdn:7:11
-//  5|   Dict[]
-//  6| 
-//  7|   let x = 10
-//  8|   x       ^^
-//  9| }
+// -| src/test_files/check/unused_literal.gdn:7:11
+// 5|   Dict[]
+// 6| 
+// 7|   let x = 10
+// 8|   x       ^^
+// 9| }
 
 // expected stderr: 
 // 6 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/check/unused_shadowed_var.gdn
+++ b/src/test_files/check/unused_shadowed_var.gdn
@@ -14,20 +14,21 @@ public fun f(): Int {
 // expected stdout:
 // Warning: `xy` is unused.
 // 
-// --| src/test_files/check/unused_shadowed_var.gdn:3:7
-//  1| public fun f(): Int {
-//  2|   // should warn
-//  3|   let xy = 0
-//  4|       ^^
-//  5|   // should also warn
+// -| src/test_files/check/unused_shadowed_var.gdn:3:7
+// 1| public fun f(): Int {
+// 2|   // should warn
+// 3|   let xy = 0
+// 4|       ^^
+// 5|   // should also warn
 // 
 // Warning: `x` is unused.
 // 
-// --| src/test_files/check/unused_shadowed_var.gdn:6:7
-//  5|   // should also warn
-//  6|   let x = 1
-//  7|       ^
-//  8|   let x = 1
+// -| src/test_files/check/unused_shadowed_var.gdn:6:7
+// 5|   // should also warn
+// 6|   let x = 1
+// 7|       ^
+// 8|   let x = 1
 
 // expected stderr: 
 // 2 issues can be fixed automatically (use `--fix`).
+

--- a/src/test_files/parser/accidental_rust_dbg.gdn
+++ b/src/test_files/parser/accidental_rust_dbg.gdn
@@ -64,14 +64,14 @@ fun foo() {
 // expected stderr:
 // Error: Parse error: Unrecognized syntax `!`
 // 
-// --| src/test_files/parser/accidental_rust_dbg.gdn:2:8
-//  1| fun foo() {
-//  2|     dbg!(1);
-//  3| }      ^
+// -| src/test_files/parser/accidental_rust_dbg.gdn:2:8
+// 1| fun foo() {
+// 2|     dbg!(1);
+// 3| }      ^
 // Error: Parse error: Unrecognized syntax `;`
 // 
-// --| src/test_files/parser/accidental_rust_dbg.gdn:2:12
-//  1| fun foo() {
-//  2|     dbg!(1);
-//  3| }          ^
+// -| src/test_files/parser/accidental_rust_dbg.gdn:2:12
+// 1| fun foo() {
+// 2|     dbg!(1);
+// 3| }          ^
 

--- a/src/test_files/parser/incomplete_enum.gdn
+++ b/src/test_files/parser/incomplete_enum.gdn
@@ -46,8 +46,8 @@ fun bar() {}
 // expected stderr:
 // Error: Parse error: Expected `{` after this.
 // 
-// --| src/test_files/parser/incomplete_enum.gdn:1:6
-//  1| enum Foo
-//  2|      ^^^
-//  3| fun bar() {}
+// -| src/test_files/parser/incomplete_enum.gdn:1:6
+// 1| enum Foo
+// 2|      ^^^
+// 3| fun bar() {}
 

--- a/src/test_files/parser/incomplete_fun.gdn
+++ b/src/test_files/parser/incomplete_fun.gdn
@@ -7,9 +7,9 @@ test bar {
 // expected stderr:
 // Error: Parse error: Expected a symbol after this.
 // 
-// --| src/test_files/parser/incomplete_fun.gdn:1:1
-//  1| fun
-//   | ^^^
-//  2| 
-//  3| test bar {
+// -| src/test_files/parser/incomplete_fun.gdn:1:1
+// 1| fun
+//  | ^^^
+// 2| 
+// 3| test bar {
 

--- a/src/test_files/parser/incomplete_fun_with_params.gdn
+++ b/src/test_files/parser/incomplete_fun_with_params.gdn
@@ -64,8 +64,8 @@ fun bar() {}
 // expected stderr:
 // Error: Parse error: Expected `{` after this.
 // 
-// --| src/test_files/parser/incomplete_fun_with_params.gdn:1:9
-//  1| fun foo()
-//  2|         ^
-//  3| fun bar() {}
+// -| src/test_files/parser/incomplete_fun_with_params.gdn:1:9
+// 1| fun foo()
+// 2|         ^
+// 3| fun bar() {}
 

--- a/src/test_files/parser/incomplete_struct.gdn
+++ b/src/test_files/parser/incomplete_struct.gdn
@@ -46,8 +46,8 @@ fun bar() {}
 // expected stderr:
 // Error: Parse error: Expected `{` after this.
 // 
-// --| src/test_files/parser/incomplete_struct.gdn:1:8
-//  1| struct Foo
-//  2|        ^^^
-//  3| fun bar() {}
+// -| src/test_files/parser/incomplete_struct.gdn:1:8
+// 1| struct Foo
+// 2|        ^^^
+// 3| fun bar() {}
 

--- a/src/test_files/parser/int_literal_overflow.gdn
+++ b/src/test_files/parser/int_literal_overflow.gdn
@@ -33,8 +33,8 @@ println(0123456789101112131415160123456789101112131415)
 // expected stderr:
 // Error: Parse error: `0123456789101112131415160123456789101112131415` is outside the range of valid integer values. Integers must be between `-9223372036854775808` and `9223372036854775807`.
 // 
-// --| src/test_files/parser/int_literal_overflow.gdn:1:9
-//  1| println(0123456789101112131415160123456789101112131415)
-//  2|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//  3| // args: dump-ast
+// -| src/test_files/parser/int_literal_overflow.gdn:1:9
+// 1| println(0123456789101112131415160123456789101112131415)
+// 2|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// 3| // args: dump-ast
 

--- a/src/test_files/parser/malformed_fun_keyword.gdn
+++ b/src/test_files/parser/malformed_fun_keyword.gdn
@@ -39,20 +39,20 @@ ffun foo(_: Bool) {
 // expected stderr:
 // Error: Parse error: Expected `,` or `)` after this.
 // 
-// --| src/test_files/parser/malformed_fun_keyword.gdn:2:10
-//  1| // We don't really care how this parses, but it shouldn't crash the parser.
-//  2| ffun foo(_: Bool) {
-//  3| }        ^
+// -| src/test_files/parser/malformed_fun_keyword.gdn:2:10
+// 1| // We don't really care how this parses, but it shouldn't crash the parser.
+// 2| ffun foo(_: Bool) {
+// 3| }        ^
 // Error: Parse error: Expected an expression after this.
 // 
-// --| src/test_files/parser/malformed_fun_keyword.gdn:2:10
-//  1| // We don't really care how this parses, but it shouldn't crash the parser.
-//  2| ffun foo(_: Bool) {
-//  3| }        ^
+// -| src/test_files/parser/malformed_fun_keyword.gdn:2:10
+// 1| // We don't really care how this parses, but it shouldn't crash the parser.
+// 2| ffun foo(_: Bool) {
+// 3| }        ^
 // Error: Parse error: Expected an expression after this.
 // 
-// --| src/test_files/parser/malformed_fun_keyword.gdn:2:10
-//  1| // We don't really care how this parses, but it shouldn't crash the parser.
-//  2| ffun foo(_: Bool) {
-//  3| }        ^
+// -| src/test_files/parser/malformed_fun_keyword.gdn:2:10
+// 1| // We don't really care how this parses, but it shouldn't crash the parser.
+// 2| ffun foo(_: Bool) {
+// 3| }        ^
 

--- a/src/test_files/parser/missing_punct.gdn
+++ b/src/test_files/parser/missing_punct.gdn
@@ -44,8 +44,8 @@ foo(a b)
 // expected stderr:
 // Error: Parse error: Expected `,` or `)` after this.
 // 
-// --| src/test_files/parser/missing_punct.gdn:1:5
-//  1| foo(a b)
-//  2|     ^
-//  3| // args: dump-ast
+// -| src/test_files/parser/missing_punct.gdn:1:5
+// 1| foo(a b)
+// 2|     ^
+// 3| // args: dump-ast
 

--- a/src/test_files/parser/struct_missing_name.gdn
+++ b/src/test_files/parser/struct_missing_name.gdn
@@ -26,9 +26,9 @@ struct { x: Int }
 // expected stderr:
 // Error: Parse error: Expected a type name after this.
 // 
-// --| src/test_files/parser/struct_missing_name.gdn:1:1
-//  1| struct { x: Int }
-//   | ^^^^^^
-//  2| 
-//  3| // args: dump-ast
+// -| src/test_files/parser/struct_missing_name.gdn:1:1
+// 1| struct { x: Int }
+//  | ^^^^^^
+// 2| 
+// 3| // args: dump-ast
 

--- a/src/test_files/parser/tuple_field_access.gdn
+++ b/src/test_files/parser/tuple_field_access.gdn
@@ -91,17 +91,17 @@ fun foo(p) {
 // expected stderr:
 // Error: Parse error: Garden does not support tuple field access like `.0` or `.1`. Use destructuring instead, for example: `let (x, y) = value`.
 // 
-// ---| src/test_files/parser/tuple_field_access.gdn:2:6
-//   1| fun foo(p) {
-//   2|     p.0
-//    |      ^
-//   3|     p.1
-//   4| }
+// -| src/test_files/parser/tuple_field_access.gdn:2:6
+// 1| fun foo(p) {
+// 2|     p.0
+//  |      ^
+// 3|     p.1
+// 4| }
 // Error: Parse error: Garden does not support tuple field access like `.0` or `.1`. Use destructuring instead, for example: `let (x, y) = value`.
 // 
-// ---| src/test_files/parser/tuple_field_access.gdn:3:6
-//   1| fun foo(p) {
-//   2|     p.0
-//   3|     p.1
-//   4| }    ^
+// -| src/test_files/parser/tuple_field_access.gdn:3:6
+// 1| fun foo(p) {
+// 2|     p.0
+// 3|     p.1
+// 4| }    ^
 

--- a/src/test_files/parser/unfinished_dot.gdn
+++ b/src/test_files/parser/unfinished_dot.gdn
@@ -64,8 +64,8 @@ fun foo(s: String) {
 // expected stderr:
 // Error: Parse error: Expected a method or field name after this.
 // 
-// --| src/test_files/parser/unfinished_dot.gdn:2:6
-//  1| fun foo(s: String) {
-//  2|     s.
-//  3| }    ^
+// -| src/test_files/parser/unfinished_dot.gdn:2:6
+// 1| fun foo(s: String) {
+// 2|     s.
+// 3| }    ^
 

--- a/src/test_files/parser/unfinished_fun_header.gdn
+++ b/src/test_files/parser/unfinished_fun_header.gdn
@@ -106,31 +106,31 @@ f{
 // expected stderr:
 // Error: Parse error: Expected a symbol after this.
 // 
-// ---| src/test_files/parser/unfinished_fun_header.gdn:1:2
-//   1| f{
-//    |  ^
-//   2|     let xx = 99
-//   3|     let yy = xx + 1
+// -| src/test_files/parser/unfinished_fun_header.gdn:1:2
+// 1| f{
+//  |  ^
+// 2|     let xx = 99
+// 3|     let yy = xx + 1
 // Error: Parse error: Expected a symbol after this.
 // 
-// ---| src/test_files/parser/unfinished_fun_header.gdn:2:14
-//   1| f{
-//   2|     let xx = 99
-//    |              ^^
-//   3|     let yy = xx + 1
-//   4|     yy + 10
+// -| src/test_files/parser/unfinished_fun_header.gdn:2:14
+// 1| f{
+// 2|     let xx = 99
+//  |              ^^
+// 3|     let yy = xx + 1
+// 4|     yy + 10
 // Error: Parse error: Expected `:` after this.
 // 
-// ---| src/test_files/parser/unfinished_fun_header.gdn:4:5
-//   2|     let xx = 99
-//   3|     let yy = xx + 1
-//   4|     yy + 10
-//   5| }   ^^
+// -| src/test_files/parser/unfinished_fun_header.gdn:4:5
+// 2|     let xx = 99
+// 3|     let yy = xx + 1
+// 4|     yy + 10
+// 5| }   ^^
 // Error: Parse error: Expected an expression after this.
 // 
-// ---| src/test_files/parser/unfinished_fun_header.gdn:4:5
-//   2|     let xx = 99
-//   3|     let yy = xx + 1
-//   4|     yy + 10
-//   5| }   ^^
+// -| src/test_files/parser/unfinished_fun_header.gdn:4:5
+// 2|     let xx = 99
+// 3|     let yy = xx + 1
+// 4|     yy + 10
+// 5| }   ^^
 

--- a/src/test_files/parser/unfinished_match.gdn
+++ b/src/test_files/parser/unfinished_match.gdn
@@ -79,10 +79,10 @@ fun foo(src) {
 // expected stderr:
 // Error: Parse error: Expected `{` after this.
 // 
-// --| src/test_files/parser/unfinished_match.gdn:2:11
-//  1| fun foo(src) {
-//  2|     match src
-//   |           ^^^
-//  3|             
-//  4|     ("")
+// -| src/test_files/parser/unfinished_match.gdn:2:11
+// 1| fun foo(src) {
+// 2|     match src
+//  |           ^^^
+// 3|             
+// 4|     ("")
 

--- a/src/test_files/parser/unfinished_params.gdn
+++ b/src/test_files/parser/unfinished_params.gdn
@@ -59,8 +59,8 @@ public fun foo: Option<Int> {
 // expected stderr:
 // Error: Parse error: Expected `(` after this.
 // 
-// --| src/test_files/parser/unfinished_params.gdn:1:12
-//  1| public fun foo: Option<Int> {
-//  2|   None     ^^^
-//  3| }
+// -| src/test_files/parser/unfinished_params.gdn:1:12
+// 1| public fun foo: Option<Int> {
+// 2|   None     ^^^
+// 3| }
 

--- a/src/test_files/run_code_blocks/bad_definition.gdn
+++ b/src/test_files/run_code_blocks/bad_definition.gdn
@@ -9,8 +9,9 @@ fun foo() {}
 // expected stderr:
 // Error: No such file `./no_such_file.gdn`.
 // 
-// --| src/test_files/run_code_blocks/bad_definition.gdn:1:8
-//  1| import "./no_such_file.gdn"
-//  2|        ^^^^^^^^^^^^^^^^^^^^
-//  3| /// ```
+// -| src/test_files/run_code_blocks/bad_definition.gdn:1:8
+// 1| import "./no_such_file.gdn"
+// 2|        ^^^^^^^^^^^^^^^^^^^^
+// 3| /// ```
 // Checked 1 block in 1 file.
+

--- a/src/test_files/run_code_blocks/exception_line_number.gdn
+++ b/src/test_files/run_code_blocks/exception_line_number.gdn
@@ -11,7 +11,8 @@ fun foo() {}
 // expected exit status: 1
 // expected stderr:
 // Exception: oops
-// --| src/test_files/run_code_blocks/exception_line_number.gdn:4:2	 __toplevel__
-//  4|  throw("oops")
-//   |  ^^^^^^^^^^^^^
+// -| src/test_files/run_code_blocks/exception_line_number.gdn:4:2	 __toplevel__
+// 4|  throw("oops")
+//  |  ^^^^^^^^^^^^^
 // Checked 1 block in 1 file.
+

--- a/src/test_files/runtime/assert.gdn
+++ b/src/test_files/runtime/assert.gdn
@@ -6,6 +6,7 @@
 // args: run
 // expected stderr:
 // Exception: Expected `3` but got `2`.
-// --| src/test_files/runtime/assert.gdn:3:10	 __toplevel__
-//  3|   assert((1 + 1) == 3)
-//   |          ^^^^^^^^^^^^
+// -| src/test_files/runtime/assert.gdn:3:10	 __toplevel__
+// 3|   assert((1 + 1) == 3)
+//  |          ^^^^^^^^^^^^
+

--- a/src/test_files/runtime/binop_eval_order.gdn
+++ b/src/test_files/runtime/binop_eval_order.gdn
@@ -7,6 +7,7 @@
 // args: run
 // expected stderr:
 // Exception: lhs
-// --| src/test_files/runtime/binop_eval_order.gdn:4:3	 __toplevel__
-//  4|   throw("lhs") + throw("rhs")
-//   |   ^^^^^^^^^^^^
+// -| src/test_files/runtime/binop_eval_order.gdn:4:3	 __toplevel__
+// 4|   throw("lhs") + throw("rhs")
+//  |   ^^^^^^^^^^^^
+

--- a/src/test_files/runtime/div_zero.gdn
+++ b/src/test_files/runtime/div_zero.gdn
@@ -5,6 +5,7 @@
 // args: run
 // expected stderr:
 // Exception: Tried to divide 5 by zero.
-// --| src/test_files/runtime/div_zero.gdn:2:7	 __toplevel__
-//  2|   dbg(5 / 0)
-//   |       ^^^^^
+// -| src/test_files/runtime/div_zero.gdn:2:7	 __toplevel__
+// 2|   dbg(5 / 0)
+//  |       ^^^^^
+

--- a/src/test_files/runtime/dot_access_bad_type.gdn
+++ b/src/test_files/runtime/dot_access_bad_type.gdn
@@ -6,6 +6,7 @@
 // args: run
 // expected stderr:
 // Exception: Expected `struct` but `1` has type `Int`.
-// --| src/test_files/runtime/dot_access_bad_type.gdn:3:5	 __toplevel__
-//  3|     x.y
-//   |     ^
+// -| src/test_files/runtime/dot_access_bad_type.gdn:3:5	 __toplevel__
+// 3|     x.y
+//  |     ^
+

--- a/src/test_files/runtime/dot_access_enum.gdn
+++ b/src/test_files/runtime/dot_access_enum.gdn
@@ -6,6 +6,7 @@
 // args: run
 // expected stderr:
 // Exception: Expected `struct` but `Some(1)` has type `Option<Int>`.
-// --| src/test_files/runtime/dot_access_enum.gdn:3:5	 __toplevel__
-//  3|     x.y
-//   |     ^
+// -| src/test_files/runtime/dot_access_enum.gdn:3:5	 __toplevel__
+// 3|     x.y
+//  |     ^
+

--- a/src/test_files/runtime/error.gdn
+++ b/src/test_files/runtime/error.gdn
@@ -14,12 +14,13 @@ fun caller() {
 // expected stderr:
 // Exception: oh no
 // oh dear
-// --| src/test_files/runtime/error.gdn:2:3	 fun callee()
-//  2|   throw("oh no\noh dear")
-//   |   ^^^^^^^^^^^^^^^^^^^^^^^
-// --| src/test_files/runtime/error.gdn:6:3	 fun caller()
-//  6|   callee()
-//   |   ^^^^^^^^
+// -| src/test_files/runtime/error.gdn:2:3	 fun callee()
+// 2|   throw("oh no\noh dear")
+//  |   ^^^^^^^^^^^^^^^^^^^^^^^
+// -| src/test_files/runtime/error.gdn:6:3	 fun caller()
+// 6|   callee()
+//  |   ^^^^^^^^
 // --| src/test_files/runtime/error.gdn:10:3	 __toplevel__
 // 10|   caller()
 //   |   ^^^^^^^^
+

--- a/src/test_files/runtime/float_divide_zero.gdn
+++ b/src/test_files/runtime/float_divide_zero.gdn
@@ -5,6 +5,7 @@
 // args: run
 // expected stderr:
 // Exception: Tried to divide 1.0 by zero.
-// --| src/test_files/runtime/float_divide_zero.gdn:2:7	 __toplevel__
-//  2|   dbg(1.0 /. 0.0)
-//   |       ^^^^^^^^^^
+// -| src/test_files/runtime/float_divide_zero.gdn:2:7	 __toplevel__
+// 2|   dbg(1.0 /. 0.0)
+//  |       ^^^^^^^^^^
+

--- a/src/test_files/runtime/if_without_else.gdn
+++ b/src/test_files/runtime/if_without_else.gdn
@@ -12,9 +12,10 @@ fun foo(b: Bool): Int {
 // args: run
 // expected stderr:
 // Exception: Expected `Int` but got `Unit`.
-// --| src/test_files/runtime/if_without_else.gdn:1:19	 fun foo()
-//  1| fun foo(b: Bool): Int {
-//   |                   ^^^
-// --| src/test_files/runtime/if_without_else.gdn:9:5	 __toplevel__
-//  9|     foo(True)
-//   |     ^^^^^^^^^
+// -| src/test_files/runtime/if_without_else.gdn:1:19	 fun foo()
+// 1| fun foo(b: Bool): Int {
+//  |                   ^^^
+// -| src/test_files/runtime/if_without_else.gdn:9:5	 __toplevel__
+// 9|     foo(True)
+//  |     ^^^^^^^^^
+

--- a/src/test_files/runtime/import_as_not_external.gdn
+++ b/src/test_files/runtime/import_as_not_external.gdn
@@ -7,6 +7,7 @@ import "./lib.gdn" as f
 // args: run
 // expected stderr:
 // Exception: `bar` is not marked as `external` in `src/test_files/runtime/lib.gdn`. 
-// --| src/test_files/runtime/import_as_not_external.gdn:4:10	 __toplevel__
-//  4|   dbg(f::bar())
-//   |          ^^^
+// -| src/test_files/runtime/import_as_not_external.gdn:4:10	 __toplevel__
+// 4|   dbg(f::bar())
+//  |          ^^^
+

--- a/src/test_files/runtime/import_missing_file.gdn
+++ b/src/test_files/runtime/import_missing_file.gdn
@@ -7,6 +7,7 @@ import "./no_such_file.gdn"
 // args: run
 // expected stderr:
 // Exception: No such file `./no_such_file.gdn`.
-// --| src/test_files/runtime/import_missing_file.gdn:1:8	 __toplevel__
-//  1| import "./no_such_file.gdn"
-//   |        ^^^^^^^^^^^^^^^^^^^^
+// -| src/test_files/runtime/import_missing_file.gdn:1:8	 __toplevel__
+// 1| import "./no_such_file.gdn"
+//  |        ^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test_files/runtime/import_not_external.gdn
+++ b/src/test_files/runtime/import_not_external.gdn
@@ -7,6 +7,7 @@ import "./lib.gdn"
 // args: run
 // expected stderr:
 // Exception: No such variable `bar`.
-// --| src/test_files/runtime/import_not_external.gdn:4:7	 __toplevel__
-//  4|   dbg(bar())
-//   |       ^^^
+// -| src/test_files/runtime/import_not_external.gdn:4:7	 __toplevel__
+// 4|   dbg(bar())
+//  |       ^^^
+

--- a/src/test_files/runtime/let_hint_invalid.gdn
+++ b/src/test_files/runtime/let_hint_invalid.gdn
@@ -5,6 +5,7 @@
 // args: run
 // expected stderr:
 // Exception: Expected `String` but `123` has type `Int`.
-// --| src/test_files/runtime/let_hint_invalid.gdn:2:21	 __toplevel__
-//  2|     let x: String = 123
-//   |                     ^^^
+// -| src/test_files/runtime/let_hint_invalid.gdn:2:21	 __toplevel__
+// 2|     let x: String = 123
+//  |                     ^^^
+

--- a/src/test_files/runtime/list_get.gdn
+++ b/src/test_files/runtime/list_get.gdn
@@ -9,6 +9,7 @@ dbg(items.get("oh no wrong type"))
 
 // expected stderr:
 // Exception: Expected `Int` but `"oh no wrong type"` has type `String`.
-// --| src/test_files/runtime/list_get.gdn:5:15	 __toplevel__
-//  5| dbg(items.get("oh no wrong type"))
-//   |               ^^^^^^^^^^^^^^^^^^
+// -| src/test_files/runtime/list_get.gdn:5:15	 __toplevel__
+// 5| dbg(items.get("oh no wrong type"))
+//  |               ^^^^^^^^^^^^^^^^^^
+

--- a/src/test_files/runtime/method_missing.gdn
+++ b/src/test_files/runtime/method_missing.gdn
@@ -6,6 +6,7 @@
 // args: run
 // expected stderr:
 // Exception: `Path{ p: "/" }` has type `Path` which has no method named `stuff`.
-// --| src/test_files/runtime/method_missing.gdn:3:5	 __toplevel__
-//  3|   p.stuff()
-//   |     ^^^^^
+// -| src/test_files/runtime/method_missing.gdn:3:5	 __toplevel__
+// 3|   p.stuff()
+//  |     ^^^^^
+

--- a/src/test_files/runtime/modulo.gdn
+++ b/src/test_files/runtime/modulo.gdn
@@ -11,6 +11,7 @@
 
 // expected stderr:
 // Exception: Tried to calculate the remainder of dividing 10 by zero.
-// --| src/test_files/runtime/modulo.gdn:4:3	 __toplevel__
-//  4|   10 % 0
-//   |   ^^^^^^
+// -| src/test_files/runtime/modulo.gdn:4:3	 __toplevel__
+// 4|   10 % 0
+//  |   ^^^^^^
+

--- a/src/test_files/runtime/nonexistent_type_return_type_arg.gdn
+++ b/src/test_files/runtime/nonexistent_type_return_type_arg.gdn
@@ -9,9 +9,10 @@ fun foo(): Option<NoSuchType> {
 // args: run
 // expected stderr:
 // Exception: No such type: NoSuchType
-// --| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:1:12	 fun foo()
-//  1| fun foo(): Option<NoSuchType> {
-//   |            ^^^^^^^^^^^^^^^^^^
-// --| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:6:5	 __toplevel__
-//  6|     foo()
-//   |     ^^^^^
+// -| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:1:12	 fun foo()
+// 1| fun foo(): Option<NoSuchType> {
+//  |            ^^^^^^^^^^^^^^^^^^
+// -| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:6:5	 __toplevel__
+// 6|     foo()
+//  |     ^^^^^
+

--- a/src/test_files/runtime/return_invalid_list.gdn
+++ b/src/test_files/runtime/return_invalid_list.gdn
@@ -10,9 +10,10 @@ fun foo(): List<Int> {
 // args: run
 // expected stderr:
 // Exception: Expected `List<Int>` but `[""]` has type `List<String>`.
-// --| src/test_files/runtime/return_invalid_list.gdn:1:12	 fun foo()
-//  1| fun foo(): List<Int> {
-//   |            ^^^^^^^^^
-// --| src/test_files/runtime/return_invalid_list.gdn:6:5	 __toplevel__
-//  6|     foo()
-//   |     ^^^^^
+// -| src/test_files/runtime/return_invalid_list.gdn:1:12	 fun foo()
+// 1| fun foo(): List<Int> {
+//  |            ^^^^^^^^^
+// -| src/test_files/runtime/return_invalid_list.gdn:6:5	 __toplevel__
+// 6|     foo()
+//  |     ^^^^^
+

--- a/src/test_files/runtime/return_invalid_option.gdn
+++ b/src/test_files/runtime/return_invalid_option.gdn
@@ -10,9 +10,10 @@ fun foo(): Option<Int> {
 // args: run
 // expected stderr:
 // Exception: Expected `Option<Int>` but `Some("")` has type `Option<String>`.
-// --| src/test_files/runtime/return_invalid_option.gdn:1:12	 fun foo()
-//  1| fun foo(): Option<Int> {
-//   |            ^^^^^^^^^^^
-// --| src/test_files/runtime/return_invalid_option.gdn:6:5	 __toplevel__
-//  6|     foo()
-//   |     ^^^^^
+// -| src/test_files/runtime/return_invalid_option.gdn:1:12	 fun foo()
+// 1| fun foo(): Option<Int> {
+//  |            ^^^^^^^^^^^
+// -| src/test_files/runtime/return_invalid_option.gdn:6:5	 __toplevel__
+// 6|     foo()
+//  |     ^^^^^
+

--- a/src/test_files/runtime/return_invalid_unit.gdn
+++ b/src/test_files/runtime/return_invalid_unit.gdn
@@ -7,9 +7,10 @@ fun foo(): Int {}
 // args: run
 // expected stderr:
 // Exception: Expected `Int` but got `Unit`.
-// --| src/test_files/runtime/return_invalid_unit.gdn:1:12	 fun foo()
-//  1| fun foo(): Int {}
-//   |            ^^^
-// --| src/test_files/runtime/return_invalid_unit.gdn:4:5	 __toplevel__
-//  4|     foo()
-//   |     ^^^^^
+// -| src/test_files/runtime/return_invalid_unit.gdn:1:12	 fun foo()
+// 1| fun foo(): Int {}
+//  |            ^^^
+// -| src/test_files/runtime/return_invalid_unit.gdn:4:5	 __toplevel__
+// 4|     foo()
+//  |     ^^^^^
+

--- a/src/test_files/runtime/stack_trace.gdn
+++ b/src/test_files/runtime/stack_trace.gdn
@@ -17,12 +17,13 @@ fun call_it2() {
 // args: run
 // expected stderr:
 // Exception: No such variable `no_such`.
-// --| src/test_files/runtime/stack_trace.gdn:6:5	 fun call_it()
-//  6|     no_such()
-//   |     ^^^^^^^
+// -| src/test_files/runtime/stack_trace.gdn:6:5	 fun call_it()
+// 6|     no_such()
+//  |     ^^^^^^^
 // --| src/test_files/runtime/stack_trace.gdn:10:5	 fun call_it2()
 // 10|     call_it()
 //   |     ^^^^^^^^^
 // --| src/test_files/runtime/stack_trace.gdn:14:5	 __toplevel__
 // 14|     call_it2()
 //   |     ^^^^^^^^^^
+

--- a/src/test_files/runtime/string_method_type_error.gdn
+++ b/src/test_files/runtime/string_method_type_error.gdn
@@ -5,6 +5,7 @@
 // args: run
 // expected stderr:
 // Exception: Expected `String` but `123` has type `Int`.
-// --| src/test_files/runtime/string_method_type_error.gdn:2:18	 __toplevel__
-//  2|   "foo".index_of(123)
-//   |                  ^^^
+// -| src/test_files/runtime/string_method_type_error.gdn:2:18	 __toplevel__
+// 2|   "foo".index_of(123)
+//  |                  ^^^
+

--- a/src/test_files/runtime/struct_create_invalid_types.gdn
+++ b/src/test_files/runtime/struct_create_invalid_types.gdn
@@ -10,6 +10,7 @@ struct Foo {
 // args: run
 // expected stderr:
 // Exception: Incorrect type for field: Expected `Int` but `"abc"` has type `String`.
-// --| src/test_files/runtime/struct_create_invalid_types.gdn:6:17	 __toplevel__
-//  6|     dbg(Foo{ x: "abc" })
-//   |                 ^^^^^
+// -| src/test_files/runtime/struct_create_invalid_types.gdn:6:17	 __toplevel__
+// 6|     dbg(Foo{ x: "abc" })
+//  |                 ^^^^^
+

--- a/src/test_files/runtime/struct_create_missing_fields.gdn
+++ b/src/test_files/runtime/struct_create_missing_fields.gdn
@@ -10,6 +10,7 @@ struct Foo {
 // args: run
 // expected stderr:
 // Exception: Missing fields from `Foo`: `x`.
-// --| src/test_files/runtime/struct_create_missing_fields.gdn:6:9	 __toplevel__
-//  6|     dbg(Foo{})
-//   |         ^^^^^
+// -| src/test_files/runtime/struct_create_missing_fields.gdn:6:9	 __toplevel__
+// 6|     dbg(Foo{})
+//  |         ^^^^^
+

--- a/src/test_files/runtime/struct_extra_field.gdn
+++ b/src/test_files/runtime/struct_extra_field.gdn
@@ -7,6 +7,7 @@ struct Foo {}
 // args: run
 // expected stderr:
 // Exception: `Foo` does not have a field named `x`.
-// --| src/test_files/runtime/struct_extra_field.gdn:4:10	 __toplevel__
-//  4|     Foo{ x: 1 }
-//   |          ^
+// -| src/test_files/runtime/struct_extra_field.gdn:4:10	 __toplevel__
+// 4|     Foo{ x: 1 }
+//  |          ^
+

--- a/src/test_files/runtime/struct_invalid_type_param.gdn
+++ b/src/test_files/runtime/struct_invalid_type_param.gdn
@@ -14,9 +14,9 @@ fun foo(): Box<Int> {
 // args: run
 // expected stderr:
 // Exception: Expected `Box<Int>` but `Box{ value: "not an int" }` has type `Box<String>`.
-// --| src/test_files/runtime/struct_invalid_type_param.gdn:5:12	 fun foo()
-//  5| fun foo(): Box<Int> {
-//   |            ^^^^^^^^
+// -| src/test_files/runtime/struct_invalid_type_param.gdn:5:12	 fun foo()
+// 5| fun foo(): Box<Int> {
+//  |            ^^^^^^^^
 // --| src/test_files/runtime/struct_invalid_type_param.gdn:10:5	 __toplevel__
 // 10|     foo()
 //   |     ^^^^^

--- a/src/test_files/runtime/struct_syntax_invalid_type.gdn
+++ b/src/test_files/runtime/struct_syntax_invalid_type.gdn
@@ -7,6 +7,7 @@ enum Foo { X }
 // args: run
 // expected stderr:
 // Exception: `Foo` is not a struct, so it cannot be initialized with struct syntax.
-// --| src/test_files/runtime/struct_syntax_invalid_type.gdn:4:5	 __toplevel__
-//  4|     Foo{ x: 1 }
-//   |     ^^^
+// -| src/test_files/runtime/struct_syntax_invalid_type.gdn:4:5	 __toplevel__
+// 4|     Foo{ x: 1 }
+//  |     ^^^
+

--- a/src/test_files/runtime/struct_undefined_type.gdn
+++ b/src/test_files/runtime/struct_undefined_type.gdn
@@ -5,6 +5,7 @@
 // args: run
 // expected stderr:
 // Exception: No type exists named `Foo`.
-// --| src/test_files/runtime/struct_undefined_type.gdn:2:5	 __toplevel__
-//  2|     Foo{ x: 1 }
-//   |     ^^^
+// -| src/test_files/runtime/struct_undefined_type.gdn:2:5	 __toplevel__
+// 2|     Foo{ x: 1 }
+//  |     ^^^
+


### PR DESCRIPTION
## Summary
Fixed a bug in diagnostic formatting where the left margin width was calculated based on the total number of lines in the file, rather than the actual lines being displayed. This caused misalignment when error spans were far from the beginning of the file.

## Changes
- **Modified `src/diagnostics.rs`**: Updated `format_pos_in_fun()` to calculate margin width based on the maximum line number that will actually be displayed in the diagnostic output, not the total file size
  - Extract offset validation logic earlier to determine which line spans will be shown
  - Use `LinePositions::from_region()` to get only the relevant spans
  - Calculate `max_line_shown` from the last displayed span plus context lines
  - Use `max(1)` to ensure minimum margin width of 1

## Test Updates
Updated all golden test files to reflect the corrected diagnostic output formatting:
- Changed `--| ` prefix to `-| ` (single dash instead of double)
- Adjusted line number alignment to match the new, more compact margin widths
- Affected ~50 test files across check, parser, and runtime test suites

## Implementation Details
The fix ensures that when displaying a diagnostic for a line deep in a file, the margin only needs to be wide enough for the lines actually shown (typically the error line plus a few context lines), not the entire file. This makes diagnostics more compact and readable while maintaining proper alignment.

https://claude.ai/code/session_01N6a1sQx34QGrhKxmYsu3kQ