### PR TITLE
Add "Destructure enum" code action to LSP

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -23,6 +23,7 @@ type DocumentStore = FxHashMap<PathBuf, String>;
 use crate::checks::check_toplevel_items_in_env;
 use crate::checks::type_checker::check_types;
 use crate::completions;
+use crate::destructure::destructure;
 use crate::diagnostics::{Autofix, Diagnostic as GardenDiagnostic, Severity};
 use crate::env::Env;
 use crate::eval::load_toplevel_items;
@@ -354,6 +355,7 @@ fn handle_initialize(
                 code_action_kinds: Some(vec![
                     CodeActionKind::QuickFix,
                     CodeActionKind::RefactorExtract,
+                    CodeActionKind::RefactorRewrite,
                 ]),
                 ..Default::default()
             })),
@@ -704,6 +706,10 @@ fn handle_code_action(
         actions.push(CodeActionResponse::CodeAction(action));
     }
 
+    if let Some(action) = build_destructure_action(&src, &path, uri, &params.range) {
+        actions.push(CodeActionResponse::CodeAction(action));
+    }
+
     JsonRpcResponse::new(id, actions)
 }
 
@@ -800,6 +806,46 @@ fn build_extract_function_action(
     Some(CodeAction {
         title: "Extract function".to_owned(),
         kind: Some(CodeActionKind::RefactorExtract),
+        edit: Some(workspace_edit),
+        ..Default::default()
+    })
+}
+
+/// Build a "Destructure enum" code action for the selected range, if the
+/// selection covers an expression with an enum type.
+fn build_destructure_action(
+    src: &str,
+    path: &Path,
+    uri: &Uri,
+    range: &Range,
+) -> Option<CodeAction> {
+    let start_offset = line_char_to_offset(
+        src,
+        range.start.line as usize,
+        range.start.character as usize,
+    );
+    let end_offset =
+        line_char_to_offset(src, range.end.line as usize, range.end.character as usize);
+
+    let new_src = destructure(src, path, start_offset, end_offset).ok()?;
+
+    let full_range = whole_document_range(src);
+    let text_edit = TextEdit {
+        range: full_range,
+        new_text: new_src,
+    };
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(uri.clone(), vec![text_edit]);
+
+    let workspace_edit = WorkspaceEdit {
+        changes: Some(changes),
+        ..Default::default()
+    };
+
+    Some(CodeAction {
+        title: "Destructure enum".to_owned(),
+        kind: Some(CodeActionKind::RefactorRewrite),
         edit: Some(workspace_edit),
         ..Default::default()
     })


### PR DESCRIPTION
## Summary
This PR adds a new "Destructure enum" code action to the Language Server Protocol implementation, allowing users to automatically destructure enum expressions in their Garden code.

## Key Changes
- Import the `destructure` module from `crate::destructure`
- Register `CodeActionKind::RefactorRewrite` in the LSP server capabilities to advertise support for rewrite-style code actions
- Implement `build_destructure_action()` function that:
  - Converts the selected range from line/character coordinates to byte offsets
  - Calls the `destructure()` function to generate the refactored code
  - Creates a `WorkspaceEdit` that replaces the entire document with the destructured version
  - Returns a `CodeAction` with title "Destructure enum" and kind `RefactorRewrite`
- Integrate the new action into `handle_code_action()` to include it in the list of available code actions

## Implementation Details
The destructure action follows the same pattern as the existing extract function code action:
- Uses `line_char_to_offset()` to convert LSP range coordinates to byte offsets in the source
- Applies the transformation via `destructure()` which handles the actual AST analysis and rewriting
- Replaces the full document range to ensure the entire file is updated consistently
- Gracefully returns `None` if destructuring is not applicable to the selected range

https://claude.ai/code/session_01QjavLJbQmNZCYafNvrFow4