### PR TITLE
Rename reftest CLI commands and functions to use consistent naming

### DIFF
--- a/src/hover.rs
+++ b/src/hover.rs
@@ -8,7 +8,7 @@ use crate::parser::parse_toplevel_items;
 use crate::parser::vfs::Vfs;
 use crate::pos_to_id::find_item_at;
 
-pub fn show_type(src: &str, path: &Path, offset: usize) {
+pub fn reftest_hover(src: &str, path: &Path, offset: usize) {
     let mut id_gen = IdGenerator::default();
     let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ enum CliCommands {
         override_path: Option<PathBuf>,
     },
     /// Show possible completions at the position given.
-    Complete {
+    ReftestComplete {
         path: PathBuf,
         offset: Option<usize>,
     },
@@ -393,7 +393,7 @@ fn main() {
                 println!("{}", serde_json::to_string(&placeholder_pos).unwrap());
             }
         }
-        CliCommands::Complete { offset, path } => {
+        CliCommands::ReftestComplete { offset, path } => {
             let abs_path = to_abs_path(&path);
             let src = read_utf8_or_die(&abs_path);
             let offset = offset.unwrap_or_else(|| {
@@ -908,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_complete() -> TestResult<()> {
+    fn reftest_complete() -> TestResult<()> {
         run_golden_tests("complete")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ use std::time::Instant;
 use clap::{Parser, Subcommand};
 use eval::{eval_up_to, EvalUpToErr, StdoutMode};
 use go_to_def::print_pos;
-use hover::show_type;
+use hover::reftest_hover;
 use json_session::{handle_request, start_eval_thread};
 use parser::vfs::{to_abs_path, Vfs, VfsPathBuf};
 use test_runner::{run_sandboxed_tests_in_file, run_tests_in_files};
@@ -220,7 +220,7 @@ enum CliCommands {
     /// Run Garden code blocks in markdown and .gdn files.
     RunCodeBlocks { paths: Vec<PathBuf> },
     /// Show the type of the expression at the position given.
-    ShowType { path: PathBuf },
+    ReftestHover { path: PathBuf },
     /// Show the definition position of the value at the position
     /// given.
     DefinitionPosition {
@@ -352,12 +352,12 @@ fn main() {
             let src = read_utf8_or_die(&abs_path);
             dump_ast(&src, &abs_path)
         }
-        CliCommands::ShowType { path } => {
+        CliCommands::ReftestHover { path } => {
             let abs_path = to_abs_path(&path);
             let src = read_utf8_or_die(&abs_path);
             let offset = caret_finder::find_caret_offset(&src)
                 .expect("Could not find comment containing `^` in source.");
-            show_type(&src, &abs_path, offset)
+            reftest_hover(&src, &abs_path, offset)
         }
         CliCommands::DefinitionPosition {
             path,
@@ -948,7 +948,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_hover() -> TestResult<()> {
+    fn reftest_hover() -> TestResult<()> {
         run_golden_tests("hover")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ enum CliCommands {
     },
     /// Print the positions of all occurrences of the local variable
     /// at the position given. One JSON-encoded position per line.
-    Highlight { path: PathBuf },
+    ReftestHighlight { path: PathBuf },
     /// Parse the Garden program at the path specified and print the
     /// AST.
     DumpAst { path: PathBuf },
@@ -376,7 +376,7 @@ fn main() {
             let src_path = to_abs_path(&override_path.unwrap_or(path));
             print_pos(&src, &src_path, offset, has_caret)
         }
-        CliCommands::Highlight { path } => {
+        CliCommands::ReftestHighlight { path } => {
             let abs_path = to_abs_path(&path);
             let src = read_utf8_or_die(&abs_path);
 
@@ -943,7 +943,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_highlight() -> TestResult<()> {
+    fn reftest_highlight() -> TestResult<()> {
         run_golden_tests("highlight")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ enum CliCommands {
     ReftestHover { path: PathBuf },
     /// Show the definition position of the value at the position
     /// given.
-    DefinitionPosition {
+    ReftestPosition {
         path: PathBuf,
         offset: Option<usize>,
         #[clap(long)]
@@ -359,7 +359,7 @@ fn main() {
                 .expect("Could not find comment containing `^` in source.");
             reftest_hover(&src, &abs_path, offset)
         }
-        CliCommands::DefinitionPosition {
+        CliCommands::ReftestPosition {
             path,
             offset,
             override_path,
@@ -938,7 +938,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_go_to_def() -> TestResult<()> {
+    fn reftest_position() -> TestResult<()> {
         run_golden_tests("go_to_def")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ enum CliCommands {
     /// a JSON session.
     ///
     /// Lines starting `//` are ignored.
-    TestJson { path: PathBuf },
+    ReftestJsonSession { path: PathBuf },
     /// Check the Garden program at the path specified for issues.
     Check {
         path: PathBuf,
@@ -405,7 +405,7 @@ fn main() {
                 println!("{}", serde_json::to_string(&item).unwrap());
             }
         }
-        CliCommands::TestJson { path } => {
+        CliCommands::ReftestJsonSession { path } => {
             let abs_path = to_abs_path(&path);
             let src = read_utf8_or_die(&abs_path);
 
@@ -953,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_json_session() -> TestResult<()> {
+    fn reftest_json_session() -> TestResult<()> {
         run_golden_tests("json_session")
     }
 

--- a/src/test_files/complete/import_built_in.gdn
+++ b/src/test_files/complete/import_built_in.gdn
@@ -1,5 +1,5 @@
 import "__ra"
 //           ^
 
-// args: complete
+// args: reftest-complete
 // expected stdout: {"label":"__random.gdn","kind":17}

--- a/src/test_files/complete/import_relative.gdn
+++ b/src/test_files/complete/import_relative.gdn
@@ -1,5 +1,5 @@
 import "./prelude"
 //               ^
 
-// args: complete
+// args: reftest-complete
 // expected stdout: {"label":"prelude_fun.gdn","kind":17}

--- a/src/test_files/complete/list.gdn
+++ b/src/test_files/complete/list.gdn
@@ -4,7 +4,7 @@ fun foo() {
     //   ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"append","kind":2,"detail":"(T): List<T>","insertText":"append($0)","insertTextFormat":2}
 // {"label":"contains","kind":2,"detail":"(T): Bool","insertText":"contains($0)","insertTextFormat":2}

--- a/src/test_files/complete/local_variable.gdn
+++ b/src/test_files/complete/local_variable.gdn
@@ -6,7 +6,7 @@ fun example() {
 //   ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"foo","kind":6,"detail":": Int"}
 // {"label":"foobar","kind":6,"detail":": String"}

--- a/src/test_files/complete/local_variable_with_params.gdn
+++ b/src/test_files/complete/local_variable_with_params.gdn
@@ -4,7 +4,7 @@ fun example(first_arg: Int, second_arg: String) {
 //    ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"first_arg","kind":6,"detail":": Int"}
 // {"label":"first_local","kind":6,"detail":": Bool"}

--- a/src/test_files/complete/method.gdn
+++ b/src/test_files/complete/method.gdn
@@ -3,7 +3,7 @@ fun file_name(s: String) {
 //   ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"as_int()","kind":2,"detail":"(): Option<Int>","insertText":"as_int()","insertTextFormat":2}
 // {"label":"chars()","kind":2,"detail":"(): List<String>","insertText":"chars()","insertTextFormat":2}

--- a/src/test_files/complete/method_call_with_prefix.gdn
+++ b/src/test_files/complete/method_call_with_prefix.gdn
@@ -3,6 +3,6 @@ fun foo(o: Option<String>) {
     //   ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"or_value","kind":2,"detail":"(T): T","insertText":"or_value($0)","insertTextFormat":2}

--- a/src/test_files/complete/method_with_prefix.gdn
+++ b/src/test_files/complete/method_with_prefix.gdn
@@ -3,7 +3,7 @@ fun foo(s: String) {
     //    ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"strip_prefix","kind":2,"detail":"(String): String","insertText":"strip_prefix($0)","insertTextFormat":2}
 // {"label":"strip_suffix","kind":2,"detail":"(String): String","insertText":"strip_suffix($0)","insertTextFormat":2}

--- a/src/test_files/complete/method_with_prefix_eol.gdn
+++ b/src/test_files/complete/method_with_prefix_eol.gdn
@@ -3,7 +3,7 @@ fun foo(s: String) {
   //    ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"strip_prefix","kind":2,"detail":"(String): String","insertText":"strip_prefix($0)","insertTextFormat":2}
 // {"label":"strip_suffix","kind":2,"detail":"(String): String","insertText":"strip_suffix($0)","insertTextFormat":2}

--- a/src/test_files/complete/method_with_trailing.gdn
+++ b/src/test_files/complete/method_with_trailing.gdn
@@ -6,7 +6,7 @@ fun file_name(s: String) {
     x = 2
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"as_int()","kind":2,"detail":"(): Option<Int>","insertText":"as_int()","insertTextFormat":2}
 // {"label":"chars()","kind":2,"detail":"(): List<String>","insertText":"chars()","insertTextFormat":2}

--- a/src/test_files/complete/namespace.gdn
+++ b/src/test_files/complete/namespace.gdn
@@ -3,7 +3,7 @@ import "__random.gdn" as random
 random::
 //     ^
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"choose","kind":3,"detail":"(List<T>): Option<T>","insertText":"choose($0)","insertTextFormat":2}
 // {"label":"int()","kind":3,"detail":"(): Int","insertText":"int()","insertTextFormat":2}

--- a/src/test_files/complete/namespace_with_trailing_paren.gdn
+++ b/src/test_files/complete/namespace_with_trailing_paren.gdn
@@ -3,6 +3,6 @@ import "__random.gdn" as random
 random::int()
 //         ^
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"int","kind":3,"detail":"(): Int","insertText":"int","insertTextFormat":2}

--- a/src/test_files/complete/prelude_fun.gdn
+++ b/src/test_files/complete/prelude_fun.gdn
@@ -1,5 +1,5 @@
 read_
 //  ^
 
-// args: complete
+// args: reftest-complete
 // expected stdout: {"label":"read_line","kind":6,"detail":": Fun<(), Result<String, String>>"}

--- a/src/test_files/complete/struct.gdn
+++ b/src/test_files/complete/struct.gdn
@@ -8,7 +8,7 @@ fun foo(p: Person) {
 //   ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"name","kind":5,"detail":": String"}
 // {"label":"num_pets","kind":5,"detail":": Int"}

--- a/src/test_files/complete/struct_construct.gdn
+++ b/src/test_files/complete/struct_construct.gdn
@@ -7,6 +7,6 @@ fun foo() {
   //                 ^
 }
 
-// args: complete
+// args: reftest-complete
 // expected stdout:
 // {"label":"join","kind":2,"detail":"(List<String>): String","insertText":"join($0)","insertTextFormat":2}

--- a/src/test_files/go_to_def/assign_update.gdn
+++ b/src/test_files/go_to_def/assign_update.gdn
@@ -4,6 +4,6 @@ fun file_name() {
     //^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/assign_update.gdn"}

--- a/src/test_files/go_to_def/assignment.gdn
+++ b/src/test_files/go_to_def/assignment.gdn
@@ -4,6 +4,6 @@ fun file_name() {
     //^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/assignment.gdn"}

--- a/src/test_files/go_to_def/enum_variant.gdn
+++ b/src/test_files/go_to_def/enum_variant.gdn
@@ -8,6 +8,6 @@ fun foo() {
     //^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":18,"end_offset":24,"line_number":1,"end_line_number":1,"column":4,"end_column":10,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/enum_variant.gdn"}

--- a/src/test_files/go_to_def/enum_variant_with_payload.gdn
+++ b/src/test_files/go_to_def/enum_variant_with_payload.gdn
@@ -8,6 +8,6 @@ fun foo() {
   //^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":18,"end_offset":24,"line_number":1,"end_line_number":1,"column":2,"end_column":8,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/enum_variant_with_payload.gdn"}

--- a/src/test_files/go_to_def/fun_paren.gdn
+++ b/src/test_files/go_to_def/fun_paren.gdn
@@ -8,6 +8,6 @@ public fun bar() {
   // ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":4,"end_offset":7,"line_number":0,"end_line_number":0,"column":4,"end_column":7,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/fun_paren.gdn"}

--- a/src/test_files/go_to_def/fun_type.gdn
+++ b/src/test_files/go_to_def/fun_type.gdn
@@ -1,6 +1,6 @@
 fun foo(_f: Fun<(), Int>) {}
 //          ^
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/import.gdn
+++ b/src/test_files/go_to_def/import.gdn
@@ -1,6 +1,6 @@
 import "./some_lib.gdn"
 //       ^
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":0,"end_offset":0,"line_number":0,"end_line_number":0,"column":0,"end_column":0,"path":"GDN_TEST_ROOT/./some_lib.gdn"}

--- a/src/test_files/go_to_def/import_as.gdn
+++ b/src/test_files/go_to_def/import_as.gdn
@@ -3,6 +3,6 @@ import "__reflect.gdn" as reflect
 reflect::lex("abc")
 // ^
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":26,"end_offset":33,"line_number":0,"end_line_number":0,"column":26,"end_column":33,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/import_as.gdn"}

--- a/src/test_files/go_to_def/let_definition_site.gdn
+++ b/src/test_files/go_to_def/let_definition_site.gdn
@@ -3,6 +3,6 @@ fun file_name() {
     //    ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/let_definition_site.gdn"}

--- a/src/test_files/go_to_def/let_override_path.gdn
+++ b/src/test_files/go_to_def/let_override_path.gdn
@@ -4,6 +4,6 @@ fun file_name() {
     //^
 }
 
-// args: definition-position --override-path="new_path.gdn"
+// args: reftest-position --override-path="new_path.gdn"
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/new_path.gdn"}

--- a/src/test_files/go_to_def/let_symbol.gdn
+++ b/src/test_files/go_to_def/let_symbol.gdn
@@ -4,6 +4,6 @@ fun file_name() {
     //^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/let_symbol.gdn"}

--- a/src/test_files/go_to_def/method_in_prelude.gdn
+++ b/src/test_files/go_to_def/method_in_prelude.gdn
@@ -3,6 +3,6 @@ fun foo(s: String) {
   // ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/method_name.gdn
+++ b/src/test_files/go_to_def/method_name.gdn
@@ -3,6 +3,6 @@ fun file_name(path: String) {
     //   ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/namespace_fun.gdn
+++ b/src/test_files/go_to_def/namespace_fun.gdn
@@ -3,6 +3,6 @@ import "__reflect.gdn" as reflect
 reflect::lex("abc")
 //        ^
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":950,"end_offset":953,"line_number":40,"end_line_number":40,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}

--- a/src/test_files/go_to_def/parameter.gdn
+++ b/src/test_files/go_to_def/parameter.gdn
@@ -3,6 +3,6 @@ fun foo(path: String) {
     // ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":8,"end_offset":12,"line_number":0,"end_line_number":0,"column":8,"end_column":12,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/parameter.gdn"}

--- a/src/test_files/go_to_def/prelude_fun.gdn
+++ b/src/test_files/go_to_def/prelude_fun.gdn
@@ -3,6 +3,6 @@ fun foo() {
   // ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/struct_field.gdn
+++ b/src/test_files/go_to_def/struct_field.gdn
@@ -7,6 +7,6 @@ fun demo(p: Person) {
   // ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":18,"end_offset":22,"line_number":1,"end_line_number":1,"column":2,"end_column":6,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/struct_field.gdn"}

--- a/src/test_files/go_to_def/struct_literal.gdn
+++ b/src/test_files/go_to_def/struct_literal.gdn
@@ -5,6 +5,6 @@ fun demo() {
   //       ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":7,"end_offset":12,"line_number":0,"end_line_number":0,"column":7,"end_column":12,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/struct_literal.gdn"}

--- a/src/test_files/go_to_def/struct_literal_field.gdn
+++ b/src/test_files/go_to_def/struct_literal_field.gdn
@@ -7,6 +7,6 @@ public fun demo() {
   //        ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":18,"end_offset":22,"line_number":1,"end_line_number":1,"column":2,"end_column":6,"path":"GDN_TEST_ROOT/src/test_files/go_to_def/struct_literal_field.gdn"}

--- a/src/test_files/go_to_def/type_from_builtins.gdn
+++ b/src/test_files/go_to_def/type_from_builtins.gdn
@@ -3,6 +3,6 @@ fun foo(): Int {
     123
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_in_enum_payload.gdn
+++ b/src/test_files/go_to_def/type_in_enum_payload.gdn
@@ -3,6 +3,6 @@ enum Foo {
   //    ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_in_local.gdn
+++ b/src/test_files/go_to_def/type_in_local.gdn
@@ -3,6 +3,6 @@ fun foo() {
     //     ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_in_parameter.gdn
+++ b/src/test_files/go_to_def/type_in_parameter.gdn
@@ -2,6 +2,6 @@ fun foo(_: Bool) {
     //     ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_in_return.gdn
+++ b/src/test_files/go_to_def/type_in_return.gdn
@@ -2,6 +2,6 @@ fun foo(): Unit {
     //     ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_in_struct.gdn
+++ b/src/test_files/go_to_def/type_in_struct.gdn
@@ -3,6 +3,6 @@ struct Thing {
   //    ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/go_to_def/type_parameter.gdn
+++ b/src/test_files/go_to_def/type_parameter.gdn
@@ -2,6 +2,6 @@ fun foo(_: List<String>) {
     //          ^
 }
 
-// args: definition-position
+// args: reftest-position
 // expected stdout:
 // {"start_offset":GDN_TEST_POS,"end_offset":GDN_TEST_POS,"line_number":GDN_TEST_POS,"end_line_number":GDN_TEST_POS,"column":GDN_TEST_POS,"end_column":GDN_TEST_POS,"path":"GDN_TEST_ROOT/__prelude.gdn"}

--- a/src/test_files/highlight/distinct_vars.gdn
+++ b/src/test_files/highlight/distinct_vars.gdn
@@ -5,7 +5,7 @@ fun file_name() {
     foo + bar
 }
 
-// args: highlight
+// args: reftest-highlight
 // expected stdout:
 // {"start_offset":42,"end_offset":45,"line_number":2,"end_line_number":2,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/highlight/distinct_vars.gdn"}
 // {"start_offset":70,"end_offset":73,"line_number":4,"end_line_number":4,"column":10,"end_column":13,"path":"GDN_TEST_ROOT/src/test_files/highlight/distinct_vars.gdn"}

--- a/src/test_files/highlight/from_usage.gdn
+++ b/src/test_files/highlight/from_usage.gdn
@@ -5,7 +5,7 @@ fun file_name() {
     foo = foo + 1
 }
 
-// args: highlight
+// args: reftest-highlight
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/highlight/from_usage.gdn"}
 // {"start_offset":38,"end_offset":41,"line_number":2,"end_line_number":2,"column":4,"end_column":7,"path":"GDN_TEST_ROOT/src/test_files/highlight/from_usage.gdn"}

--- a/src/test_files/highlight/local.gdn
+++ b/src/test_files/highlight/local.gdn
@@ -5,7 +5,7 @@ fun file_name() {
     foo = foo + 1
 }
 
-// args: highlight
+// args: reftest-highlight
 // expected stdout:
 // {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/src/test_files/highlight/local.gdn"}
 // {"start_offset":50,"end_offset":53,"line_number":3,"end_line_number":3,"column":4,"end_column":7,"path":"GDN_TEST_ROOT/src/test_files/highlight/local.gdn"}

--- a/src/test_files/highlight/no_variable.gdn
+++ b/src/test_files/highlight/no_variable.gdn
@@ -3,4 +3,4 @@ fun foo() {
   // ^
 }
 
-// args: highlight
+// args: reftest-highlight

--- a/src/test_files/highlight/param.gdn
+++ b/src/test_files/highlight/param.gdn
@@ -4,7 +4,7 @@ fun file_name(foo: Int) {
     let _ = foo + bar
 }
 
-// args: highlight
+// args: reftest-highlight
 // expected stdout:
 // {"start_offset":14,"end_offset":17,"line_number":0,"end_line_number":0,"column":14,"end_column":17,"path":"GDN_TEST_ROOT/src/test_files/highlight/param.gdn"}
 // {"start_offset":57,"end_offset":60,"line_number":2,"end_line_number":2,"column":14,"end_column":17,"path":"GDN_TEST_ROOT/src/test_files/highlight/param.gdn"}

--- a/src/test_files/hover/after_syntax_error.gdn
+++ b/src/test_files/hover/after_syntax_error.gdn
@@ -6,5 +6,5 @@ fun file_name(path: String) {
   //^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: String

--- a/src/test_files/hover/assignment_receiver.gdn
+++ b/src/test_files/hover/assignment_receiver.gdn
@@ -4,5 +4,5 @@ fun foo() {
   //^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: Int

--- a/src/test_files/hover/error_type.gdn
+++ b/src/test_files/hover/error_type.gdn
@@ -3,4 +3,4 @@ fun foo(s: String) {
     // ^
 }
 
-// args: show-type
+// args: reftest-hover

--- a/src/test_files/hover/infer_no_value.gdn
+++ b/src/test_files/hover/infer_no_value.gdn
@@ -3,5 +3,5 @@ fun do_stuff() {
     //  ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: Result<Int, NoValue>

--- a/src/test_files/hover/let_symbol.gdn
+++ b/src/test_files/hover/let_symbol.gdn
@@ -3,5 +3,5 @@ fun file_name() {
     //  ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: Int

--- a/src/test_files/hover/match.gdn
+++ b/src/test_files/hover/match.gdn
@@ -6,5 +6,5 @@ fun foo(v: Option<Int>) {
     }
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: Int

--- a/src/test_files/hover/method_receiver.gdn
+++ b/src/test_files/hover/method_receiver.gdn
@@ -4,5 +4,5 @@ fun file_name(path: String): String {
   parts.last().or_throw()
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: String

--- a/src/test_files/hover/parameter.gdn
+++ b/src/test_files/hover/parameter.gdn
@@ -2,5 +2,5 @@ fun foo(path: String) {
     //  ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: String

--- a/src/test_files/hover/prelude_fun.gdn
+++ b/src/test_files/hover/prelude_fun.gdn
@@ -3,7 +3,7 @@ fun foo() {
   // ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout:
 // Fun<(String), NoValue>
 // Stop the program immediately, and report the error message given.

--- a/src/test_files/hover/tuple_with_syntax_error.gdn
+++ b/src/test_files/hover/tuple_with_syntax_error.gdn
@@ -3,5 +3,5 @@ fun foo() {
     //     ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: Int

--- a/src/test_files/hover/type.gdn
+++ b/src/test_files/hover/type.gdn
@@ -2,5 +2,5 @@ fun foo(_: String) {
   //        ^
 }
 
-// args: show-type
+// args: reftest-hover
 // expected stdout: A Unicode string, such as `"hello world"`.

--- a/src/test_files/json_session/add.json
+++ b/src/test_files/json_session/add.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "1 + 2" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/call_in_context.json
+++ b/src/test_files/json_session/call_in_context.json
@@ -2,7 +2,7 @@
 { "method": "run", "input": "foo()" }
 { "method": "run", "input": "dbg(x)" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/doc_namespace.json
+++ b/src/test_files/json_session/doc_namespace.json
@@ -1,7 +1,7 @@
 { "method": "run", "input": "import \"__reflect.gdn\" as r" }
 { "method": "run", "input": ":doc r::lex" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/empty.json
+++ b/src/test_files/json_session/empty.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/fun.json
+++ b/src/test_files/json_session/fun.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "fun foo() {}" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/interrupt.json
+++ b/src/test_files/json_session/interrupt.json
@@ -2,7 +2,7 @@
 { "method": "interrupt", "input": "" }
 { "method": "run", "input": "2 + 3" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/interrupt_after_run.json
+++ b/src/test_files/json_session/interrupt_after_run.json
@@ -3,7 +3,7 @@
 { "method": "interrupt", "input": "" }
 { "method": "run", "input": "2 + 3" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/let.json
+++ b/src/test_files/json_session/let.json
@@ -1,7 +1,7 @@
 { "method": "run", "input": "let x = 2" }
 { "method": "run", "input": "x * 3" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/load.json
+++ b/src/test_files/json_session/load.json
@@ -1,6 +1,6 @@
 { "method": "load", "input": "fun foo() {}", "path": "x.gdn", "offset": 0, "end_offset": 12 }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/load_command.json
+++ b/src/test_files/json_session/load_command.json
@@ -1,7 +1,7 @@
 { "method": "run", "input": ":load src/test_files/json_session/load_me.gdn" }
 { "method": "run", "input": "add_one(3)" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/load_command_no_such_file.json
+++ b/src/test_files/json_session/load_command_no_such_file.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": ":load no_such_file.gdn" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/malformed.json
+++ b/src/test_files/json_session/malformed.json
@@ -1,6 +1,6 @@
 {}
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/methods_command.gdn
+++ b/src/test_files/json_session/methods_command.gdn
@@ -1,6 +1,6 @@
 { "method": "run", "input": ":methods String::s" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/parse_error.gdn
+++ b/src/test_files/json_session/parse_error.gdn
@@ -1,6 +1,6 @@
 { "method": "run", "input": "1 +" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/print.json
+++ b/src/test_files/json_session/print.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "println(\"hello world\")", "id": 42 }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/resume_error_should_error_again.json
+++ b/src/test_files/json_session/resume_error_should_error_again.json
@@ -2,7 +2,7 @@
 { "method": "run", "input": "f()" }
 { "method": "run", "input": ":resume" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/resume_toplevel.json
+++ b/src/test_files/json_session/resume_toplevel.json
@@ -1,7 +1,7 @@
 { "method": "run", "input": ":resume" }
 { "method": "run", "input": ":resume" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/run_in_context.json
+++ b/src/test_files/json_session/run_in_context.json
@@ -3,7 +3,7 @@
 { "method": "run", "input": "x" }
 { "method": "run", "input": "y" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/test.json
+++ b/src/test_files/json_session/test.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "test foo {}" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/test_failing.json
+++ b/src/test_files/json_session/test_failing.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "test foo { throw(\"foo\") }" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/test_then_block.json
+++ b/src/test_files/json_session/test_then_block.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "test foo {} { 1 + 2 }" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/type_command.json
+++ b/src/test_files/json_session/type_command.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": ":type fun() {}" }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {

--- a/src/test_files/json_session/warning.json
+++ b/src/test_files/json_session/warning.json
@@ -1,6 +1,6 @@
 { "method": "run", "input": "{ let x = 1 }", "id": 1 }
 
-// args: test-json
+// args: reftest-json-session
 // expected stdout:
 // {
 //   "kind": {


### PR DESCRIPTION
This PR renames CLI commands and related functions to use a consistent `reftest-` prefix for regression testing commands, improving clarity about their purpose.

## Summary
The codebase had inconsistent naming for regression testing (reftest) commands. This change standardizes all reftest-related CLI commands and their corresponding functions to use a clear `reftest-` prefix, making it immediately obvious which commands are for testing purposes.

## Key Changes

**CLI Commands renamed:**
- `TestJson` → `ReftestJsonSession`
- `ShowType` → `ReftestHover`
- `DefinitionPosition` → `ReftestPosition`
- `Complete` → `ReftestComplete`
- `Highlight` → `ReftestHighlight`

**Functions renamed:**
- `show_type()` → `reftest_hover()` in `src/hover.rs`

**Test functions renamed:**
- `test_golden_complete()` → `reftest_complete()`
- `test_golden_go_to_def()` → `reftest_position()`
- `test_golden_highlight()` → `reftest_highlight()`
- `test_golden_hover()` → `reftest_hover()`
- `test_golden_json_session()` → `reftest_json_session()`

**Test file arguments updated:**
All test files in `src/test_files/` have been updated to use the new command names:
- `// args: complete` → `// args: reftest-complete`
- `// args: definition-position` → `// args: reftest-position`
- `// args: highlight` → `// args: reftest-highlight`
- `// args: show-type` → `// args: reftest-hover`
- `// args: test-json` → `// args: reftest-json-session`

## Implementation Details
The changes maintain full backward compatibility in functionality while improving code clarity. All test files have been updated to reference the new command names, ensuring the test infrastructure continues to work correctly with the renamed commands.

https://claude.ai/code/session_01TbmDo3fprGg8z6QLZSPiKU