### PR TITLE
Rename extract refactoring commands to use reftest prefix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -923,12 +923,12 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_extract_function() -> TestResult<()> {
+    fn reftest_extract_function() -> TestResult<()> {
         run_golden_tests("extract_function")
     }
 
     #[test]
-    fn test_golden_extract_variable() -> TestResult<()> {
+    fn reftest_extract_variable() -> TestResult<()> {
         run_golden_tests("extract_variable")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,28 +154,6 @@ enum CliCommands {
         #[clap(long)]
         new_name: String,
     },
-    /// Replace the expression at this offset with a variable called
-    /// `name`, and use the expression as the variables's definition.
-    ExtractVariable {
-        path: PathBuf,
-        offset: Option<usize>,
-        end_offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
-        #[clap(long)]
-        name: String,
-    },
-    /// Replace the expression at this offset with a function called
-    /// `name`, and use the expression as the function's body.
-    ExtractFunction {
-        path: PathBuf,
-        offset: Option<usize>,
-        end_offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
-        #[clap(long)]
-        name: String,
-    },
     /// Wrap the expression at the offset specified in a `match`.
     Destructure {
         path: PathBuf,
@@ -218,6 +196,28 @@ enum CliCommands {
     ReftestComplete {
         path: PathBuf,
         offset: Option<usize>,
+    },
+    /// Replace the expression at this offset with a function called
+    /// `name`, and use the expression as the function's body.
+    ReftestExtractFunction {
+        path: PathBuf,
+        offset: Option<usize>,
+        end_offset: Option<usize>,
+        #[clap(long)]
+        override_path: Option<PathBuf>,
+        #[clap(long)]
+        name: String,
+    },
+    /// Replace the expression at this offset with a variable called
+    /// `name`, and use the expression as the variables's definition.
+    ReftestExtractVariable {
+        path: PathBuf,
+        offset: Option<usize>,
+        end_offset: Option<usize>,
+        #[clap(long)]
+        override_path: Option<PathBuf>,
+        #[clap(long)]
+        name: String,
     },
     /// Print the positions of all occurrences of the local variable
     /// at the position given. One JSON-encoded position per line.
@@ -461,7 +461,7 @@ fn main() {
                 }
             }
         }
-        CliCommands::ExtractVariable {
+        CliCommands::ReftestExtractVariable {
             path,
             offset,
             end_offset,
@@ -493,7 +493,7 @@ fn main() {
                 }
             }
         }
-        CliCommands::ExtractFunction {
+        CliCommands::ReftestExtractFunction {
             path,
             offset,
             end_offset,

--- a/src/test_files/extract_function/constant.gdn
+++ b/src/test_files/extract_function/constant.gdn
@@ -8,7 +8,7 @@ fun contains_expr() {
 
 fun after() {}
 
-// args: extract-function --name bar
+// args: reftest-extract-function --name bar
 // expected stdout:
 // fun before() {}
 // 

--- a/src/test_files/extract_function/free_variable.gdn
+++ b/src/test_files/extract_function/free_variable.gdn
@@ -12,7 +12,7 @@ fun contains_expr(i: Int) {
   let _ = y + 3
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun increment(i: Int): Int {
 //   i + 1

--- a/src/test_files/extract_function/fun_has_doc_comment.gdn
+++ b/src/test_files/extract_function/fun_has_doc_comment.gdn
@@ -4,7 +4,7 @@ fun demo() {
   //      ^^^^^
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun extracted_fun(): Int {
 //   1 + 2

--- a/src/test_files/extract_function/ignore_var_from_let.gdn
+++ b/src/test_files/extract_function/ignore_var_from_let.gdn
@@ -3,7 +3,7 @@ fun demo() {
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun extracted_fun(): Unit {
 //   for x in [] { let y = "stuff" print(y) }

--- a/src/test_files/extract_function/ignore_var_from_match.gdn
+++ b/src/test_files/extract_function/ignore_var_from_match.gdn
@@ -3,7 +3,7 @@ fun demo(opt_s: Option<String>) {
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun extracted_fun(opt_s: Option<String>): Unit {
 //   match opt_s { Some(s) => { print(s) } None => {} }

--- a/src/test_files/extract_function/repeated_variable.gdn
+++ b/src/test_files/extract_function/repeated_variable.gdn
@@ -6,7 +6,7 @@ fun contains_expr(i: Int) {
   //      ^^^^^
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun extracted_fun(x: Int): Int {
 //   x + x

--- a/src/test_files/extract_function/type_error.gdn
+++ b/src/test_files/extract_function/type_error.gdn
@@ -4,7 +4,7 @@ fun contains_expr() {
 //^^^^^^^^^^^^^^^^
 }
 
-// args: extract-function --name extracted_fun
+// args: reftest-extract-function --name extracted_fun
 // expected stdout:
 // fun extracted_fun(x: Int) {
 //   x.no_such_meth()

--- a/src/test_files/extract_variable/fun_arg_nested_binop.gdn
+++ b/src/test_files/extract_variable/fun_arg_nested_binop.gdn
@@ -3,7 +3,7 @@ public fun demo() {
   //             ^^^^^^^^^^^^^^^^^
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // public fun demo() {
 //   let extracted_var = "x" ^ ("y" ^ "z")

--- a/src/test_files/extract_variable/inner_binop.gdn
+++ b/src/test_files/extract_variable/inner_binop.gdn
@@ -5,7 +5,7 @@ public fun demo() {
   //                    ^^^^^^^^^
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // public fun demo() {
 //   // Extracted variable init value should not have parentheses.

--- a/src/test_files/extract_variable/list_element.gdn
+++ b/src/test_files/extract_variable/list_element.gdn
@@ -7,7 +7,7 @@ fun demo() {
   let _ = y
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // fun demo() {
 //   let x = 1

--- a/src/test_files/extract_variable/loop_header.gdn
+++ b/src/test_files/extract_variable/loop_header.gdn
@@ -5,7 +5,7 @@ fun demo() {
   }
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // fun demo() {
 //   let extracted_var = [1, 2]

--- a/src/test_files/extract_variable/loop_subexpression.gdn
+++ b/src/test_files/extract_variable/loop_subexpression.gdn
@@ -5,7 +5,7 @@ fun demo() {
   }
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // fun demo() {
 //   for x in [1, 2, 3] {

--- a/src/test_files/extract_variable/match_block.gdn
+++ b/src/test_files/extract_variable/match_block.gdn
@@ -8,7 +8,7 @@ public fun demo() {
   }
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // public fun demo() {
 //   match Some("foo") {

--- a/src/test_files/extract_variable/match_block_fun.gdn
+++ b/src/test_files/extract_variable/match_block_fun.gdn
@@ -10,7 +10,7 @@ public fun demo() {
   }
 }
 
-// args: extract-variable --name extracted_var
+// args: reftest-extract-variable --name extracted_var
 // expected stdout:
 // fun bar(_) {}
 // 


### PR DESCRIPTION
This PR renames the `ExtractVariable` and `ExtractFunction` CLI commands to `ReftestExtractVariable` and `ReftestExtractFunction` respectively, along with updating all corresponding test files and test function names.

## Changes Made

- **CLI Command Renames**: Updated enum variants in `CliCommands` to use the `Reftest` prefix:
  - `ExtractVariable` → `ReftestExtractVariable`
  - `ExtractFunction` → `ReftestExtractFunction`

- **Command Handler Updates**: Updated the match arms in `main()` to handle the renamed commands

- **Test Function Renames**: Updated test function names to follow the new naming convention:
  - `test_golden_extract_function` → `reftest_extract_function`
  - `test_golden_extract_variable` → `reftest_extract_variable`

- **Test File Updates**: Updated all test files in `src/test_files/extract_function/` and `src/test_files/extract_variable/` to use the new command names in their `args:` directives:
  - `extract-function` → `reftest-extract-function`
  - `extract-variable` → `reftest-extract-variable`

## Rationale

This change clarifies that these commands are regression test (reftest) utilities for the extract refactoring functionality, distinguishing them from potential user-facing refactoring commands.

https://claude.ai/code/session_01J9k1BuCvp5UzsEGpWCgz8U