### PR TITLE
Reorganize reftest CLI commands in alphabetical order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,11 +191,6 @@ enum CliCommands {
     ///
     /// Used for testing the eval-up-to feature.
     TestEvalUpTo { path: PathBuf },
-    /// Evaluate all the entries in the .jsonl file as if they were in
-    /// a JSON session.
-    ///
-    /// Lines starting `//` are ignored.
-    ReftestJsonSession { path: PathBuf },
     /// Check the Garden program at the path specified for issues.
     Check {
         path: PathBuf,
@@ -219,16 +214,6 @@ enum CliCommands {
     },
     /// Run Garden code blocks in markdown and .gdn files.
     RunCodeBlocks { paths: Vec<PathBuf> },
-    /// Show the type of the expression at the position given.
-    ReftestHover { path: PathBuf },
-    /// Show the definition position of the value at the position
-    /// given.
-    ReftestPosition {
-        path: PathBuf,
-        offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
-    },
     /// Show possible completions at the position given.
     ReftestComplete {
         path: PathBuf,
@@ -237,6 +222,21 @@ enum CliCommands {
     /// Print the positions of all occurrences of the local variable
     /// at the position given. One JSON-encoded position per line.
     ReftestHighlight { path: PathBuf },
+    /// Show the type of the expression at the position given.
+    ReftestHover { path: PathBuf },
+    /// Evaluate all the entries in the .jsonl file as if they were in
+    /// a JSON session.
+    ///
+    /// Lines starting `//` are ignored.
+    ReftestJsonSession { path: PathBuf },
+    /// Show the definition position of the value at the position
+    /// given.
+    ReftestPosition {
+        path: PathBuf,
+        offset: Option<usize>,
+        #[clap(long)]
+        override_path: Option<PathBuf>,
+    },
     /// Parse the Garden program at the path specified and print the
     /// AST.
     DumpAst { path: PathBuf },


### PR DESCRIPTION
This change reorganizes the reftest-related CLI commands in the `CliCommands` enum to be in alphabetical order, improving maintainability and consistency.

## Changes Made

- Moved `ReftestComplete` before `ReftestHover`
- Moved `ReftestHighlight` before `ReftestHover`
- Moved `ReftestJsonSession` after `ReftestHover`
- Moved `ReftestPosition` after `ReftestJsonSession`

The reftest commands now appear in alphabetical order: `ReftestComplete`, `ReftestHighlight`, `ReftestHover`, `ReftestJsonSession`, and `ReftestPosition`.

## Implementation Details

This is a pure refactoring with no functional changes. The enum variant definitions and their associated data remain identical; only their declaration order within the enum has changed.

https://claude.ai/code/session_01DCMFH58qbLCKGSxxbEJSLM