### PR TITLE
Remove override_path parameter from reftest-position command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,8 +234,6 @@ enum CliCommands {
     ReftestPosition {
         path: PathBuf,
         offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
     },
     /// Parse the Garden program at the path specified and print the
     /// AST.
@@ -359,11 +357,7 @@ fn main() {
                 .expect("Could not find comment containing `^` in source.");
             reftest_hover(&src, &abs_path, offset)
         }
-        CliCommands::ReftestPosition {
-            path,
-            offset,
-            override_path,
-        } => {
+        CliCommands::ReftestPosition { path, offset } => {
             let abs_path = to_abs_path(&path);
             let src = read_utf8_or_die(&abs_path);
 
@@ -373,8 +367,7 @@ fn main() {
                     .expect("Could not find comment containing `^` in source.")
             });
 
-            let src_path = to_abs_path(&override_path.unwrap_or(path));
-            print_pos(&src, &src_path, offset, has_caret)
+            print_pos(&src, &abs_path, offset, has_caret)
         }
         CliCommands::ReftestHighlight { path } => {
             let abs_path = to_abs_path(&path);

--- a/src/test_files/go_to_def/let_override_path.gdn
+++ b/src/test_files/go_to_def/let_override_path.gdn
@@ -1,9 +1,0 @@
-fun file_name() {
-    let foo = 1
-    foo
-    //^
-}
-
-// args: reftest-position --override-path="new_path.gdn"
-// expected stdout:
-// {"start_offset":26,"end_offset":29,"line_number":1,"end_line_number":1,"column":8,"end_column":11,"path":"GDN_TEST_ROOT/new_path.gdn"}


### PR DESCRIPTION
## Summary
Removes the `--override-path` CLI parameter from the `reftest-position` command and simplifies the position reporting logic to always use the actual file path being analyzed.

## Changes
- Removed `override_path: Option<PathBuf>` field from the `ReftestPosition` CLI command struct
- Removed the `#[clap(long)]` attribute that exposed `--override-path` as a CLI flag
- Simplified the `print_pos` function call to use `abs_path` directly instead of conditionally using `override_path`
- Removed the test file `let_override_path.gdn` that was testing the `--override-path` functionality

## Details
The `--override-path` parameter allowed overriding the file path in the position output, which appears to have been a testing utility that is no longer needed. By removing this parameter, the reftest-position command now has simpler, more predictable behavior where the reported path always matches the file being analyzed.

https://claude.ai/code/session_01TnBag1jaT57RyY1KjxqFJ9