### PR TITLE
Rename destructure command to reftest-destructure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,14 +154,6 @@ enum CliCommands {
         #[clap(long)]
         new_name: String,
     },
-    /// Wrap the expression at the offset specified in a `match`.
-    Destructure {
-        path: PathBuf,
-        offset: Option<usize>,
-        end_offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
-    },
     /// Format a Garden file and print the re-indented source code.
     Format { path: PathBuf },
     /// Run the program specified, calling its main() function, then
@@ -196,6 +188,14 @@ enum CliCommands {
     ReftestComplete {
         path: PathBuf,
         offset: Option<usize>,
+    },
+    /// Wrap the expression at the offset specified in a `match`.
+    ReftestDestructure {
+        path: PathBuf,
+        offset: Option<usize>,
+        end_offset: Option<usize>,
+        #[clap(long)]
+        override_path: Option<PathBuf>,
     },
     /// Replace the expression at this offset with a function called
     /// `name`, and use the expression as the function's body.
@@ -518,7 +518,7 @@ fn main() {
                 }
             }
         }
-        CliCommands::Destructure {
+        CliCommands::ReftestDestructure {
             path,
             offset,
             end_offset,
@@ -906,7 +906,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_destructure() -> TestResult<()> {
+    fn reftest_destructure() -> TestResult<()> {
         run_golden_tests("destructure")
     }
 
@@ -1027,7 +1027,7 @@ mod tests {
         let path = assert_cmd::cargo::cargo_bin("garden");
         let mut cmd = Command::new(path);
 
-        cmd.arg("destructure")
+        cmd.arg("reftest-destructure")
             .arg("src/unit_test_files/destructure.gdn")
             .arg("49")
             .arg("54");

--- a/src/test_files/destructure/not_enum.gdn
+++ b/src/test_files/destructure/not_enum.gdn
@@ -4,6 +4,6 @@ fun bar() {
 //^
 }
 
-// args: destructure
+// args: reftest-destructure
 // expected exit status: 10
 // expected stderr: The expression at the selected position has type `Int`, which isn't an `enum`.

--- a/src/test_files/destructure/option.gdn
+++ b/src/test_files/destructure/option.gdn
@@ -9,7 +9,7 @@ fun bar() {
   let y = 2
 }
 
-// args: destructure
+// args: reftest-destructure
 // expected stdout:
 // fun foo(): Option<Int> {
 //   None

--- a/src/test_files/destructure/verify_expr.gdn
+++ b/src/test_files/destructure/verify_expr.gdn
@@ -7,7 +7,7 @@ method my_set_extension(this: Path): Path {
 //^^^^^^^^^^^^^^^^
 }
 
-// args: destructure
+// args: reftest-destructure
 // expected stdout:
 // // Ensure that we can still use destructuring on expressions used in
 // // verify positions, not infer positions (according to the type


### PR DESCRIPTION
## Summary
Rename the `destructure` CLI command to `reftest-destructure` to better reflect its purpose as a regression testing command for the destructuring refactoring feature.

## Changes
- Renamed `CliCommands::Destructure` variant to `CliCommands::ReftestDestructure`
- Updated the command handler in `main()` to use the new variant name
- Renamed test function `test_golden_destructure()` to `reftest_destructure()` for consistency with other reftest commands
- Updated all test files to use `reftest-destructure` in their `args:` directives:
  - `src/test_files/destructure/not_enum.gdn`
  - `src/test_files/destructure/option.gdn`
  - `src/test_files/destructure/verify_expr.gdn`
- Updated integration test to pass `reftest-destructure` argument instead of `destructure`

## Implementation Details
The command was moved to a more logical position in the `CliCommands` enum, grouped with other reftest commands (`ReftestHighlight`, etc.) rather than appearing earlier in the list. This improves code organization and makes the command's testing purpose more apparent.

https://claude.ai/code/session_0172q2cGPjT31QscA9nMbpLj