### PR TITLE
Rename CLI command to ReftestRename for clarity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,16 +144,6 @@ enum CliCommands {
         #[clap(long)]
         override_path: Option<PathBuf>,
     },
-    /// Rename the local variable at this offset to the new name
-    /// specified.
-    Rename {
-        path: PathBuf,
-        offset: Option<usize>,
-        #[clap(long)]
-        override_path: Option<PathBuf>,
-        #[clap(long)]
-        new_name: String,
-    },
     /// Format a Garden file and print the re-indented source code.
     Format { path: PathBuf },
     /// Run the program specified, calling its main() function, then
@@ -234,6 +224,16 @@ enum CliCommands {
     ReftestPosition {
         path: PathBuf,
         offset: Option<usize>,
+    },
+    /// Rename the local variable at this offset to the new name
+    /// specified.
+    ReftestRename {
+        path: PathBuf,
+        offset: Option<usize>,
+        #[clap(long)]
+        override_path: Option<PathBuf>,
+        #[clap(long)]
+        new_name: String,
     },
     /// Parse the Garden program at the path specified and print the
     /// AST.
@@ -425,7 +425,7 @@ fn main() {
             drop(sender);
             handle.join().unwrap();
         }
-        CliCommands::Rename {
+        CliCommands::ReftestRename {
             path,
             new_name,
             offset,
@@ -961,7 +961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_golden_rename() -> TestResult<()> {
+    fn reftest_rename() -> TestResult<()> {
         run_golden_tests("rename")
     }
 

--- a/src/test_files/rename/function.gdn
+++ b/src/test_files/rename/function.gdn
@@ -7,7 +7,7 @@ public fun do_stuff() {
   increment(123)
 }
 
-// args: rename --new-name increment_new
+// args: reftest-rename --new-name increment_new
 // expected stdout:
 // fun increment_new(foo: Int): Int {
 //     foo + 1

--- a/src/test_files/rename/local.gdn
+++ b/src/test_files/rename/local.gdn
@@ -5,7 +5,7 @@ fun file_name() {
     foo = foo + 1
 }
 
-// args: rename --new-name new_foo
+// args: reftest-rename --new-name new_foo
 // expected stdout:
 // fun file_name() {
 //     let new_foo = 1

--- a/src/test_files/rename/nothing_to_rename.gdn
+++ b/src/test_files/rename/nothing_to_rename.gdn
@@ -3,6 +3,6 @@ fun foo() {
   // ^
 }
 
-// args: rename --new-name new_foo
+// args: reftest-rename --new-name new_foo
 // expected exit status: 10
 // expected stderr: No symbol found at offset 17

--- a/src/test_files/rename/param.gdn
+++ b/src/test_files/rename/param.gdn
@@ -3,7 +3,7 @@ fun file_name(foo: Int) {
     let _ = foo
 }
 
-// args: rename --new-name new_foo
+// args: reftest-rename --new-name new_foo
 // expected stdout:
 // fun file_name(new_foo: Int) {
 //     let _ = new_foo


### PR DESCRIPTION
## Summary
Renamed the `Rename` CLI command to `ReftestRename` to better reflect its purpose as a reftest (regression test) command rather than a general-purpose rename tool.

## Key Changes
- Renamed `CliCommands::Rename` variant to `CliCommands::ReftestRename` in the enum definition
- Updated the match arm in `main()` to handle the renamed variant
- Renamed the test function from `test_golden_rename()` to `reftest_rename()` to follow naming conventions
- Updated all test file argument directives from `rename` to `reftest-rename` in:
  - `src/test_files/rename/function.gdn`
  - `src/test_files/rename/local.gdn`
  - `src/test_files/rename/nothing_to_rename.gdn`
  - `src/test_files/rename/param.gdn`

## Implementation Details
This change clarifies that the rename functionality is specifically for regression testing purposes, not a general refactoring tool. The command-line interface now uses `reftest-rename` instead of `rename` to avoid confusion with potential future refactoring features.

https://claude.ai/code/session_01LFWcpnyJZfNXHqRHc6jwx2