### PR TITLE
CI: Only run actionlint when GitHub Actions files change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: ls
-      - uses: raven-actions/actionlint@v2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            actions:
+              - '.github/**'
+      - if: steps.filter.outputs.actions == 'true'
+        uses: raven-actions/actionlint@v2
 
   build_docs:
     name: Build documentation


### PR DESCRIPTION
## Summary
Optimize the CI workflow to only run actionlint when files in `.github/` directory are modified, reducing unnecessary workflow checks.

## Changes
- Added `dorny/paths-filter@v3` step to detect changes in `.github/**` paths
- Made actionlint step conditional on the filter output, only running when GitHub Actions files are modified
- Removed unnecessary `ls` command from the workflow

## Implementation Details
The workflow now uses path filtering to conditionally execute actionlint. This reduces CI overhead by skipping the linter when only non-workflow files are changed, while ensuring all GitHub Actions files are still validated when they are modified.

https://claude.ai/code/session_01StLABXM7kjRTwWA2WmS9fx