### PR TITLE
Add typos spell-checking to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Check TS formatting
         run: npx prettier --check "website/**/*.ts"
 
+  typos:
+    name: Check spelling
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
+
   actionlint:
     name: Actionlint
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
Add a new spell-checking job to the CI workflow using the `crate-ci/typos` action to catch spelling errors in the codebase.

## Changes
- Added a new `typos` job to `.github/workflows/test.yml` that runs on `ubuntu-24.04`
- The job uses `actions/checkout@v4` to access the repository code
- Integrated `crate-ci/typos@master` action to perform automated spell-checking
- The job runs in parallel with other CI checks like formatting and actionlint

## Details
This adds an additional quality gate to the CI pipeline to catch common spelling mistakes before they are merged. The typos checker will validate spelling across the entire repository.

https://claude.ai/code/session_01Ai2SAVHPr6Xg1L4b6winVG