### PR TITLE
Upgrade goldentests dev dependency to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,12 +380,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "goldentests"
-version = "1.4.1"
+name = "globset"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5cf23a0e42b915eb405d068a7969de8ab8f80d093f50cd1c7a2ba82f6f2de6"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "goldentests"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d88aa4e6b007bc5ac5bde27e3a7088942667fd858507bdf0176e0329b8a60b4"
 dependencies = [
  "colored",
+ "globset",
  "rayon",
  "serde",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.0.14"
 escargot = "0.5"
-goldentests = "1.4.0"
+goldentests = "1.4.2"
 predicates = "3"
 
 [profile.release]


### PR DESCRIPTION
## Summary
Updates the `goldentests` dev dependency from version 1.4.0 to 1.4.2 to pick up bug fixes and improvements in the test framework.

## Changes
- Bumped `goldentests` version in `Cargo.toml` from `1.4.0` to `1.4.2`

This is a patch version update of the dev dependency used for running reftests, which should not affect the Garden language implementation itself.

https://claude.ai/code/session_01H9R5j7p6vU2JjhwGA9HTGW