### PR TITLE
Add eprint() and eprintln() built-in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ shell::run("ls", ["-l", "/"])
 shell::get_env("HOME")
 ```
 
+Added `eprint()` and `eprintln()` for writing to stderr.
+
 ## Tooling
 
 Added a `--trace` CLI flag that enables expression tracing when

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -870,7 +870,7 @@ public fun throw(message: String): NoValue {
   __BUILT_IN_IMPLEMENTATION
 }
 
-/// Write a string to stdout. See also `println()`.
+/// Write a string to stdout. See also `println()` and `eprint()`.
 ///
 /// ```
 /// print("hello world\n")
@@ -879,12 +879,30 @@ public fun print(_: String): Unit {
   __BUILT_IN_IMPLEMENTATION
 }
 
-/// Write a string to stdout, with a newline appended. See also `print()`.
+/// Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.
 ///
 /// ```
 /// println("hello world")
 /// ```
 public fun println(_: String): Unit {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+/// Write a string to stderr. See also `eprintln()` and `print()`.
+///
+/// ```
+/// eprint("hello world in stderr\n")
+/// ```
+public fun eprint(_: String): Unit {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+/// Write a string to stderr, with a newline appended. See also `eprint()` and `println()`.
+///
+/// ```
+/// eprintln("hello world in stderr")
+/// ```
+public fun eprintln(_: String): Unit {
   __BUILT_IN_IMPLEMENTATION
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -195,21 +195,31 @@ pub(crate) enum StdoutJsonFormat {
     Playground,
 }
 
-/// How output from print() is handled.
+/// How output from `print()`, `println()`, `eprint()` and `eprintln()`
+/// is handled. Currently the same mode governs both stdout and stderr
+/// output from the running program.
 #[derive(Debug)]
 pub(crate) enum StdoutMode {
-    /// Write the string to stdout unmodified.
+    /// Write the string to stdout (or stderr for `eprint`/`eprintln`)
+    /// unmodified.
     WriteDirectly,
     /// Write the string to stdout in a JSON format, so we can can
     /// consume stdout in a REPL session or the playground backend
-    /// without getting confused.
+    /// without getting confused. `eprint`/`eprintln` output is sent
+    /// to stdout in this mode as a `printed_stderr` JSON response,
+    /// so the playground can display it alongside stdout.
     WriteJson(StdoutJsonFormat),
-    /// Append the string to the given buffer instead of writing it to
-    /// stdout. Used by the nREPL server to capture output and send it
-    /// back to the connected client.
-    WriteToBuffer(Arc<std::sync::Mutex<String>>),
-    /// Don't write anything to stdout when print() is called, treat
-    /// it as a no-op. This is used when running tests in a sandbox.
+    /// Append output to the given buffers instead of writing it
+    /// anywhere. Used by the nREPL server to capture output and send
+    /// it back to the connected client. `print`/`println` go to
+    /// `stdout_buf`; `eprint`/`eprintln` go to `stderr_buf`.
+    WriteToNReplBuffers {
+        stdout_buf: Arc<std::sync::Mutex<String>>,
+        stderr_buf: Arc<std::sync::Mutex<String>>,
+    },
+    /// Don't write anything when `print`/`println`/`eprint`/`eprintln`
+    /// are called, treat them as a no-op. This is used when running
+    /// tests in a sandbox.
     DoNotWrite,
 }
 
@@ -218,6 +228,8 @@ pub(crate) struct Session {
     pub(crate) interrupted: Arc<AtomicBool>,
     /// Whether `print()` should write to stdout directly, or if we
     /// should write a JSON message to stdout summarising the print.
+    /// Also governs how `eprint()`/`eprintln()` output to stderr is
+    /// handled.
     pub(crate) stdout_mode: StdoutMode,
     pub(crate) start_time: Instant,
     pub(crate) trace_exprs: bool,
@@ -2634,8 +2646,11 @@ fn eval_built_in_call(
                     // needs a test
                     print_as_json(&response, session.pretty_print_json);
                 }
-                StdoutMode::WriteToBuffer(buf) => {
-                    buf.lock().expect("stdout buffer poisoned").push_str(s);
+                StdoutMode::WriteToNReplBuffers { stdout_buf, .. } => {
+                    stdout_buf
+                        .lock()
+                        .expect("stdout buffer poisoned")
+                        .push_str(s);
                 }
                 StdoutMode::DoNotWrite => {}
             }
@@ -2683,8 +2698,107 @@ fn eval_built_in_call(
                     };
                     print_as_json(&response, session.pretty_print_json);
                 }
-                StdoutMode::WriteToBuffer(buf) => {
-                    let mut b = buf.lock().expect("stdout buffer poisoned");
+                StdoutMode::WriteToNReplBuffers { stdout_buf, .. } => {
+                    let mut b = stdout_buf.lock().expect("stdout buffer poisoned");
+                    b.push_str(s);
+                    b.push('\n');
+                }
+                StdoutMode::DoNotWrite => {}
+            }
+
+            if expr_value_is_used {
+                env.push_value(Value::unit());
+            }
+        }
+        BuiltInFunctionKind::PreludeEprint => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let mut saved_values = vec![];
+            for value in arg_values.iter().rev() {
+                saved_values.push(value.clone());
+            }
+            saved_values.push(receiver_value.clone());
+
+            let s = check_string(&arg_values[0], &arg_positions[0], saved_values, env)?;
+            match &session.stdout_mode {
+                StdoutMode::WriteDirectly => {
+                    eprint!("{s}");
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::ReplSession) => {
+                    let response = Response {
+                        kind: ResponseKind::PrintedStderr { s: s.clone() },
+                        position: None,
+                        id: None,
+                    };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::Playground) => {
+                    let response = ResponseKind::PrintedStderr { s: s.clone() };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteToNReplBuffers { stderr_buf, .. } => {
+                    stderr_buf
+                        .lock()
+                        .expect("stderr buffer poisoned")
+                        .push_str(s);
+                }
+                StdoutMode::DoNotWrite => {}
+            }
+
+            if expr_value_is_used {
+                env.push_value(Value::unit());
+            }
+        }
+        BuiltInFunctionKind::PreludeEprintln => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let mut saved_values = vec![];
+            for value in arg_values.iter().rev() {
+                saved_values.push(value.clone());
+            }
+            saved_values.push(receiver_value.clone());
+
+            let s = check_string(&arg_values[0], &arg_positions[0], saved_values, env)?;
+            match &session.stdout_mode {
+                StdoutMode::WriteDirectly => {
+                    eprintln!("{s}");
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::ReplSession) => {
+                    let response = Response {
+                        kind: ResponseKind::PrintedStderr {
+                            s: format!("{s}\n"),
+                        },
+                        position: None,
+                        id: None,
+                    };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::Playground) => {
+                    let response = ResponseKind::PrintedStderr {
+                        s: format!("{s}\n"),
+                    };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteToNReplBuffers { stderr_buf, .. } => {
+                    let mut b = stderr_buf.lock().expect("stderr buffer poisoned");
                     b.push_str(s);
                     b.push('\n');
                 }

--- a/src/json_session.rs
+++ b/src/json_session.rs
@@ -105,6 +105,9 @@ pub(crate) enum ResponseKind {
     Printed {
         s: String,
     },
+    PrintedStderr {
+        s: String,
+    },
     /// We received an interrupt request. The current (or next)
     /// evaluate request will return an error of "Interrupted".
     Interrupted {

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -133,11 +133,14 @@ fn handle_eval(
     env: &mut Env,
     session: &Session,
     stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
     base_msg: &HashMap<Vec<u8>, Value>,
 ) -> Vec<Value> {
     let ns = env.current_namespace();
     let path = (*ns.borrow().abs_path).clone();
-    eval_code_in_namespace(code, path, ns, env, session, stdout_buf, base_msg)
+    eval_code_in_namespace(
+        code, path, ns, env, session, stdout_buf, stderr_buf, base_msg,
+    )
 }
 
 /// Perform a single `load-file` request, returning the response
@@ -151,6 +154,7 @@ fn handle_load_file(
     env: &mut Env,
     session: &Session,
     stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
     base_msg: &HashMap<Vec<u8>, Value>,
 ) -> Vec<Value> {
     let path: PathBuf = match file_path {
@@ -158,7 +162,9 @@ fn handle_load_file(
         None => (*env.current_namespace().borrow().abs_path).clone(),
     };
     let ns = env.get_or_create_namespace(&path);
-    eval_code_in_namespace(code, path, ns, env, session, stdout_buf, base_msg)
+    eval_code_in_namespace(
+        code, path, ns, env, session, stdout_buf, stderr_buf, base_msg,
+    )
 }
 
 /// Parse `code`, load its top-level items into `namespace`, evaluate
@@ -170,6 +176,7 @@ fn eval_code_in_namespace(
     env: &mut Env,
     session: &Session,
     stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
     base_msg: &HashMap<Vec<u8>, Value>,
 ) -> Vec<Value> {
     let vfs_path = env.vfs.insert(Rc::new(vfs_path_buf), code.to_owned());
@@ -219,11 +226,18 @@ fn eval_code_in_namespace(
     let eval_result = eval_toplevel_exprs_then_stop(&items, env, session, namespace.clone());
     let eval_msec = eval_start.elapsed().as_millis() as i64;
 
-    let captured = std::mem::take(&mut *stdout_buf.lock().expect("stdout buffer poisoned"));
-    if !captured.is_empty() {
+    let captured_stdout = std::mem::take(&mut *stdout_buf.lock().expect("stdout buffer poisoned"));
+    if !captured_stdout.is_empty() {
         let mut out_msg = base_msg.clone();
-        out_msg.insert(b"out".to_vec(), bstr(captured));
+        out_msg.insert(b"out".to_vec(), bstr(captured_stdout));
         responses.push(Value::Dict(out_msg));
+    }
+
+    let captured_stderr = std::mem::take(&mut *stderr_buf.lock().expect("stderr buffer poisoned"));
+    if !captured_stderr.is_empty() {
+        let mut err_msg = base_msg.clone();
+        err_msg.insert(b"err".to_vec(), bstr(captured_stderr));
+        responses.push(Value::Dict(err_msg));
     }
 
     match eval_result {
@@ -599,18 +613,27 @@ fn session_worker(
         interrupted.store(false, Ordering::SeqCst);
 
         let stdout_buf = Arc::new(Mutex::new(String::new()));
+        let stderr_buf = Arc::new(Mutex::new(String::new()));
         let session = Session {
             interrupted: Arc::clone(&interrupted),
-            stdout_mode: StdoutMode::WriteToBuffer(Arc::clone(&stdout_buf)),
+            stdout_mode: StdoutMode::WriteToNReplBuffers {
+                stdout_buf: Arc::clone(&stdout_buf),
+                stderr_buf: Arc::clone(&stderr_buf),
+            },
             start_time: Instant::now(),
             trace_exprs: false,
             pretty_print_json: false,
         };
 
         let responses = match req {
-            SessionRequest::Eval { code, base_msg } => {
-                handle_eval(&code, &mut env, &session, &stdout_buf, &base_msg)
-            }
+            SessionRequest::Eval { code, base_msg } => handle_eval(
+                &code,
+                &mut env,
+                &session,
+                &stdout_buf,
+                &stderr_buf,
+                &base_msg,
+            ),
             SessionRequest::LoadFile {
                 code,
                 file_path,
@@ -621,6 +644,7 @@ fn session_worker(
                 &mut env,
                 &session,
                 &stdout_buf,
+                &stderr_buf,
                 &base_msg,
             ),
             SessionRequest::Completions { prefix, base_msg } => {

--- a/src/test_files/json_session/eprint.json
+++ b/src/test_files/json_session/eprint.json
@@ -1,0 +1,26 @@
+{ "method": "run", "input": "eprintln(\"hello stderr\")", "id": 42 }
+
+// args: reftest-json-session
+// expected stdout:
+// {
+//   "kind": {
+//     "printed_stderr": {
+//       "s": "hello stderr\n"
+//     }
+//   },
+//   "position": null
+// }
+// {
+//   "kind": {
+//     "evaluate": {
+//       "warnings": [],
+//       "value": {
+//         "Ok": "Unit"
+//       },
+//       "stack_frame_name": "__user.gdn"
+//     }
+//   },
+//   "position": null,
+//   "id": 42
+// }
+

--- a/src/test_files/nrepl/eval_with_eprintln.jsonl
+++ b/src/test_files/nrepl/eval_with_eprintln.jsonl
@@ -1,0 +1,28 @@
+{ "op": "clone" }
+{ "op": "eval", "session": "garden-1", "code": "eprintln(\"hello\")" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "new-session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "err": "hello\n",
+//   "session": "garden-1"
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "ns": "__user",
+//   "session": "garden-1",
+//   "value": "Unit"
+// }
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -13,7 +13,7 @@
 //   "info": {
 //     "arglists-str": "(_: String)",
 //     "column": 1,
-//     "doc": "Write a string to stdout, with a newline appended. See also `print()`.\n\n```\nprintln(\"hello world\")\n```",
+//     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
 //     "line": 882,
 //     "name": "println",

--- a/src/test_files/playground/eprint.gdn
+++ b/src/test_files/playground/eprint.gdn
@@ -1,0 +1,6 @@
+eprintln("hello stderr")
+
+// args: playground-run
+// expected stdout:
+// {"printed_stderr":{"s":"hello stderr\n"}}
+// {"error":null,"value":"Unit"}

--- a/src/test_files/runtime/eprint.gdn
+++ b/src/test_files/runtime/eprint.gdn
@@ -1,0 +1,10 @@
+{
+    eprint("hello ")
+    eprintln("stderr")
+    println("stdout")
+}
+
+// args: run
+// expected stderr: hello stderr
+
+// expected stdout: stdout

--- a/src/values.rs
+++ b/src/values.rs
@@ -388,6 +388,8 @@ pub(crate) fn type_representation(value: &Value) -> TypeName {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub(crate) enum BuiltInFunctionKind {
+    PreludeEprint,
+    PreludeEprintln,
     PreludePrint,
     PreludePrintln,
     PreludeReadLine,
@@ -431,6 +433,8 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::PreludeStringRepr
             | BuiltInFunctionKind::PreludePrint
             | BuiltInFunctionKind::PreludePrintln
+            | BuiltInFunctionKind::PreludeEprint
+            | BuiltInFunctionKind::PreludeEprintln
             | BuiltInFunctionKind::PreludeReadLine
             | BuiltInFunctionKind::PreludeSourceDirectory
             | BuiltInFunctionKind::PreludeShellArguments => PathBuf::from("__prelude.gdn"),
@@ -473,6 +477,8 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::PreludeStringRepr => "string_repr",
             BuiltInFunctionKind::PreludePrint => "print",
             BuiltInFunctionKind::PreludePrintln => "println",
+            BuiltInFunctionKind::PreludeEprint => "eprint",
+            BuiltInFunctionKind::PreludeEprintln => "eprintln",
             BuiltInFunctionKind::PreludeReadLine => "read_line",
             BuiltInFunctionKind::PreludeSourceDirectory => "source_directory",
             BuiltInFunctionKind::PreludeShellArguments => "shell_arguments",

--- a/website/static/package-lock.json
+++ b/website/static/package-lock.json
@@ -14,11 +14,13 @@
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.23.0",
         "@lezer/highlight": "^1.2.3",
+        "@types/escape-html": "^1.0.4",
         "chokidar-cli": "^3.0.0",
         "clean-css-cli": "^5.6.3",
         "codemirror": "^6.0.1",
         "concurrently": "^9.1.0",
         "esbuild": "^0.24.0",
+        "escape-html": "^1.0.3",
         "typescript": "^5.9.3"
       },
       "devDependencies": {
@@ -731,6 +733,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1580,6 +1588,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",

--- a/website/static/package.json
+++ b/website/static/package.json
@@ -21,11 +21,13 @@
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.0",
     "@lezer/highlight": "^1.2.3",
+    "@types/escape-html": "^1.0.4",
     "chokidar-cli": "^3.0.0",
     "clean-css-cli": "^5.6.3",
     "codemirror": "^6.0.1",
     "concurrently": "^9.1.0",
     "esbuild": "^0.24.0",
+    "escape-html": "^1.0.3",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -6,6 +6,7 @@ import { StreamLanguage } from "@codemirror/language";
 import { history, historyKeymap } from "@codemirror/commands";
 import { keymap, highlightActiveLine } from "@codemirror/view";
 import { defaultKeymap } from "@codemirror/commands";
+import escapeHtml from "escape-html";
 
 // Store EditorView instances for each snippet
 const editorViews = new WeakMap<Element, EditorView>();
@@ -104,7 +105,7 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
     .then((response) => response.json())
     .then((data: PlaygroundResponse) => {
       if (!data.success) {
-        snippetDiv.innerHTML = `Error: ${data.error || "Unknown error"}`;
+        snippetDiv.innerHTML = `Error: ${escapeHtml(data.error || "Unknown error")}`;
         return;
       }
 
@@ -120,22 +121,22 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
 
       for (const item of data.results) {
         if ("printed" in item) {
-          outputParts.push(item.printed.s);
+          outputParts.push(escapeHtml(item.printed.s));
         } else if ("printed_stderr" in item) {
           outputParts.push(
-            `<span class="stderr">${item.printed_stderr.s}</span>`,
+            `<span class="stderr">${escapeHtml(item.printed_stderr.s)}</span>`,
           );
         } else if ("error" in item || "value" in item) {
           const result = item;
 
           if (result.error) {
-            snippetDiv.innerHTML = `Error: ${result.error}`;
+            snippetDiv.innerHTML = `Error: ${escapeHtml(result.error)}`;
             hasError = true;
             break;
           }
 
           if (result.value) {
-            valueParts.push(result.value);
+            valueParts.push(escapeHtml(result.value));
           }
         }
       }
@@ -157,7 +158,7 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
     })
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      snippetDiv.innerHTML = `Fetch error: ${message}`;
+      snippetDiv.innerHTML = `Fetch error: ${escapeHtml(message)}`;
     });
 }
 

--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -65,6 +65,12 @@ type StdoutOutput = {
   };
 };
 
+type StderrOutput = {
+  printed_stderr: {
+    s: string;
+  };
+};
+
 type PlaygroundResult = {
   error: string | null;
   value: string | null;
@@ -72,7 +78,7 @@ type PlaygroundResult = {
 
 type PlaygroundResponse = {
   success: boolean;
-  results?: (StdoutOutput | PlaygroundResult)[];
+  results?: (StdoutOutput | StderrOutput | PlaygroundResult)[];
   error?: string;
   rawOutput?: string;
 };
@@ -107,19 +113,19 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
         return;
       }
 
-      // Iterate over all results
-      const stdoutParts: string[] = [];
+      // Iterate over all results, preserving stdout/stderr emission order.
+      const outputParts: string[] = [];
       const valueParts: string[] = [];
       let hasError = false;
 
       for (const item of data.results) {
-        // Check if this is a stdout object
         if ("printed" in item) {
-          const stdoutItem = item;
-          stdoutParts.push(stdoutItem.printed.s);
-        }
-        // Check if this is a result object
-        else if ("error" in item || "value" in item) {
+          outputParts.push(item.printed.s);
+        } else if ("printed_stderr" in item) {
+          outputParts.push(
+            `<span class="stderr">${item.printed_stderr.s}</span>`,
+          );
+        } else if ("error" in item || "value" in item) {
           const result = item;
 
           if (result.error) {
@@ -136,8 +142,8 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
 
       if (!hasError) {
         let output = "";
-        if (stdoutParts.length > 0) {
-          output = stdoutParts.join("");
+        if (outputParts.length > 0) {
+          output = outputParts.join("");
         }
         if (valueParts.length > 0) {
           if (output.length > 0) {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -284,6 +284,10 @@ textarea {
   border-top: 3px solid #00000030;
 }
 
+.snippet-output .stderr {
+  color: #910a0a;
+}
+
 .snippet {
   border: 3px solid #00000030;
   border-radius: 5px;

--- a/website/static/tsconfig.json
+++ b/website/static/tsconfig.json
@@ -31,6 +31,7 @@
 
     // Recommended Options
     "strict": true,
+    "esModuleInterop": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,


### PR DESCRIPTION
This PR adds two new built-in functions for writing to stderr: `eprint()` and `eprintln()`. These complement the existing `print()` and `println()` functions which write to stdout.

## Changes

- **Added `eprint()` function**: Writes a string to stderr without appending a newline
- **Added `eprintln()` function**: Writes a string to stderr with a newline appended
- **Implementation**: Both functions follow the same pattern as `print()` and `println()`, respecting the `stdout_mode` setting and returning `Unit`
- **Documentation**: Added docstrings with examples in the prelude
- **Test coverage**: Added `src/test_files/runtime/eprint.gdn` to verify both functions work correctly and output to the correct streams

## Implementation Details

- Added `PreludeEprint` and `PreludeEprintln` variants to `BuiltInFunctionKind` enum
- Implemented evaluation logic in `eval_built_in_call()` that mirrors the existing print functions but uses `eprint!()` and `eprintln!()` macros
- Both functions validate arity (1 argument), check that the argument is a string, and respect the session's `stdout_mode` setting

https://claude.ai/code/session_01X5uWvSiiQuEnJ8djPZTPFs