### PR TITLE
Add concat method to List type

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -543,6 +543,28 @@ public method append<T>(this: List<T>, value: T): List<T> {
   __BUILT_IN_IMPLEMENTATION
 }
 
+/// Return a new list with all the items from `this`, followed by all
+/// the items from `other`.
+///
+/// ```
+/// [1, 2].concat([3, 4]) //-> [1, 2, 3, 4]
+/// ```
+public method concat<T>(this: List<T>, other: List<T>): List<T> {
+  let result: List<T> = this
+  for item in other {
+    result = result.append(item)
+  }
+
+  result
+}
+
+test list_concat {
+  assert([].concat([]) == [])
+  assert([1, 2].concat([]) == [1, 2])
+  assert([].concat([1, 2]) == [1, 2])
+  assert([1, 2].concat([3, 4]) == [1, 2, 3, 4])
+}
+
 /// Does this list contain `item`?
 ///
 /// ```

--- a/src/test_files/complete/list.gdn
+++ b/src/test_files/complete/list.gdn
@@ -7,6 +7,7 @@ fun foo() {
 // args: reftest-complete
 // expected stdout:
 // {"label":"append","kind":2,"detail":"(T): List<T>","insertText":"append($0)","insertTextFormat":2}
+// {"label":"concat","kind":2,"detail":"(List<T>): List<T>","insertText":"concat($0)","insertTextFormat":2}
 // {"label":"contains","kind":2,"detail":"(T): Bool","insertText":"contains($0)","insertTextFormat":2}
 // {"label":"enumerate()","kind":2,"detail":"(): List<(Int, T)>","insertText":"enumerate()","insertTextFormat":2}
 // {"label":"filter","kind":2,"detail":"(Fun<(T), Bool>): List<T>","insertText":"filter($0)","insertTextFormat":2}
@@ -19,3 +20,4 @@ fun foo() {
 // {"label":"len()","kind":2,"detail":"(): Int","insertText":"len()","insertTextFormat":2}
 // {"label":"map","kind":2,"detail":"(Fun<(T), U>): List<U>","insertText":"map($0)","insertTextFormat":2}
 // {"label":"slice","kind":2,"detail":"(Int, Int): List<T>","insertText":"slice($0)","insertTextFormat":2}
+

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 861,
+//     "line": 883,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,5 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff() string_repr_of_fun.gdn:1>
-// <fun println() __prelude.gdn:861>
+// <fun println() __prelude.gdn:883>
 // <closure string_repr_of_fun.gdn:6>
+


### PR DESCRIPTION
## Summary
Add a new `concat` method to the `List` type that combines two lists into a single list containing all elements from both.

## Changes
- **New method**: `concat<T>(this: List<T>, other: List<T>): List<T>` in `src/__prelude.gdn`
  - Returns a new list with all items from `this` followed by all items from `other`
  - Implemented by iterating through `other` and appending each item to a copy of `this`
  - Includes comprehensive documentation with example usage

- **Unit tests**: Added `list_concat` test with four test cases covering:
  - Concatenating two empty lists
  - Concatenating a non-empty list with an empty list
  - Concatenating an empty list with a non-empty list
  - Concatenating two non-empty lists

- **Test file updates**: Updated line number references in test files to account for the new method:
  - `src/test_files/runtime/string_repr_of_fun.gdn`: Updated `println` function line reference from 861 to 883
  - `src/test_files/complete/list.gdn`: Added expected completion entry for `concat` method
  - `src/test_files/nrepl/lookup_prelude.jsonl`: Updated `println` line reference from 861 to 883

## Implementation Details
The `concat` method follows the existing pattern of list operations in the prelude, using a simple loop with `append` to build the result. This approach is straightforward and maintains consistency with other list manipulation methods.

https://claude.ai/code/session_014poFnBL6sW5uvZ6U1f9AbS