### PR TITLE
Add exit() built-in function to stop program execution

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -893,6 +893,19 @@ public fun throw(message: String): NoValue {
   __BUILT_IN_IMPLEMENTATION
 }
 
+/// Stop the program immediately, with the given exit code.
+///
+/// Use 0 to indicate success and a non-zero value to indicate
+/// failure. See also `throw()` for terminating with an error
+/// message.
+///
+/// ```garden nocheck
+/// exit(0)
+/// ```
+public fun exit(code: Int): NoValue {
+  __BUILT_IN_IMPLEMENTATION
+}
+
 /// Write a string to stdout. See also `println()` and `eprint()`.
 ///
 /// ```

--- a/src/cli_session.rs
+++ b/src/cli_session.rs
@@ -256,6 +256,13 @@ pub(crate) fn repl(interrupted: Arc<AtomicBool>, trace_exprs: bool) {
                 );
                 is_stopped = false;
             }
+            Err(EvalError::Exited(pos, code)) => {
+                println!(
+                    "{}: Code called `exit({code})`.",
+                    pos.as_ide_string(&env.project_root)
+                );
+                is_stopped = false;
+            }
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -284,6 +284,8 @@ pub(crate) enum EvalError {
     /// Tried to execute a function that isn't permitted in the
     /// sandbox.
     ForbiddenInSandbox(Position),
+    /// User code called `exit()`.
+    Exited(Position, i64),
 }
 
 #[derive(Debug)]
@@ -903,7 +905,7 @@ pub(crate) fn eval_tests(
                 }
 
                 tests.push((test.name_sym.clone(), Some(e.clone()), test_body_err_pos));
-                if matches!(e, EvalError::Interrupted) {
+                if matches!(e, EvalError::Interrupted | EvalError::Exited(..)) {
                     break;
                 }
             }
@@ -2627,6 +2629,43 @@ fn eval_built_in_call(
                     position: position.clone(),
                     message,
                 }),
+            ));
+        }
+        BuiltInFunctionKind::PreludeExit => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let mut saved_values = vec![receiver_value.clone()];
+            for value in arg_values.iter().rev() {
+                saved_values.push(value.clone());
+            }
+
+            let code = match arg_values[0].as_ref() {
+                Value_::Int(i) => *i,
+                _ => {
+                    let message =
+                        format_type_error(&TypeName { text: "Int".into() }, &arg_values[0], env);
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: arg_positions[0].clone(),
+                            message,
+                        }),
+                    ));
+                }
+            };
+
+            return Err((
+                RestoreValues(saved_values),
+                EvalError::Exited(position.clone(), code),
             ));
         }
         BuiltInFunctionKind::PreludePrint => {

--- a/src/json_session.rs
+++ b/src/json_session.rs
@@ -471,6 +471,19 @@ fn err_to_response(e: EvalError, env: &Env, id: Option<RequestId>) -> Response {
             position: None,
             id,
         },
+        EvalError::Exited(position, code) => Response {
+            kind: ResponseKind::Evaluate {
+                warnings: vec![],
+                value: Err(vec![ResponseError {
+                    position: Some(position.clone()),
+                    message: format!("Code called `exit({code})`."),
+                    stack: None,
+                }]),
+                stack_frame_name: Some(env.top_frame_name()),
+            },
+            position: Some(position),
+            id,
+        },
     }
 }
 
@@ -859,6 +872,19 @@ fn eval_to_response(env: &mut Env, session: &Session) -> Response {
                 stack_frame_name: Some(env.top_frame_name()),
             },
             position: None,
+            id: None,
+        },
+        Err(EvalError::Exited(position, code)) => Response {
+            kind: ResponseKind::Evaluate {
+                warnings: vec![],
+                value: Err(vec![ResponseError {
+                    position: Some(position.clone()),
+                    message: format!("Code called `exit({code})`."),
+                    stack: None,
+                }]),
+                stack_frame_name: Some(env.top_frame_name()),
+            },
+            position: Some(position),
             id: None,
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -764,6 +764,7 @@ fn reftest_eval_up_to(
             EvalError::ForbiddenInSandbox(_) => {
                 eprintln!("Tried to execute unsafe code in sandboxed mode.")
             }
+            EvalError::Exited(_, code) => eprintln!("Code called `exit({code})`."),
         }
         return;
     }
@@ -786,6 +787,7 @@ fn reftest_eval_up_to(
             EvalError::ForbiddenInSandbox(_) => {
                 eprintln!("Tried to execute unsafe code in sandboxed mode.")
             }
+            EvalError::Exited(_, code) => eprintln!("Code called `exit({code})`."),
         },
         Err(EvalUpToErr::NoExpressionFound) => eprintln!("Could not find anything to execute"),
         Err(EvalUpToErr::NoValueAvailable) => {
@@ -990,6 +992,9 @@ fn run_file(
                 "{}: Tried to execute unsafe code in sandboxed mode.",
                 position.as_ide_string(&env.project_root)
             );
+        }
+        Err(EvalError::Exited(_, code)) => {
+            std::process::exit(code.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
         }
     }
 }

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -659,6 +659,7 @@ fn format_eval_error(e: &EvalError, env: &Env) -> (String, Option<&'static str>)
             "Tried to execute unsafe code in sandboxed mode.".to_owned(),
             Some("sandbox"),
         ),
+        EvalError::Exited(_, code) => (format!("Code called `exit({code})`."), Some("exited")),
     }
 }
 

--- a/src/sandboxed_playground.rs
+++ b/src/sandboxed_playground.rs
@@ -104,6 +104,10 @@ pub(crate) fn run_sandboxed_playground(
             error: Some("Tried to execute unsafe code in sandboxed mode".to_owned()),
             value: None,
         }],
+        Err(EvalError::Exited(_, code)) => vec![PlaygroundResponse {
+            error: Some(format!("Code called `exit({code})`")),
+            value: None,
+        }],
     };
 
     for response in responses {

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 905,
+//     "line": 918,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/exit.gdn
+++ b/src/test_files/runtime/exit.gdn
@@ -1,0 +1,12 @@
+fun bail() {
+  println("about to exit")
+  exit(0)
+  println("unreachable")
+}
+
+bail()
+println("also unreachable")
+
+// args: run
+// expected stdout:
+// about to exit

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,5 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:905>
+// <fun println __prelude.gdn:918>
 // <closure string_repr_of_fun.gdn:6>
+

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -123,6 +123,10 @@ fn sandboxed_tests_summary(
                 num_sandboxed += 1;
                 "sandboxed".to_owned()
             }
+            Some(EvalError::Exited(_, code)) => {
+                num_errored += 1;
+                format!("exited with code {code}")
+            }
             None => {
                 num_passed += 1;
                 "passed".to_owned()
@@ -240,6 +244,7 @@ pub(crate) fn describe_tests(env: &Env, summary: &ToplevelEvalSummary) -> String
                 EvalError::ReachedTickLimit(position) => (Some(position), None),
                 EvalError::ReachedStackLimit(position) => (Some(position), None),
                 EvalError::ForbiddenInSandbox(position) => (Some(position), None),
+                EvalError::Exited(position, _) => (Some(position), None),
             };
 
             match (pos, msg) {

--- a/src/values.rs
+++ b/src/values.rs
@@ -414,6 +414,7 @@ pub(crate) enum BuiltInFunctionKind {
     PreludeDbg,
     PreludeEprint,
     PreludeEprintln,
+    PreludeExit,
     PreludePrint,
     PreludePrintln,
     PreludeReadLine,
@@ -458,6 +459,7 @@ impl BuiltInFunctionKind {
     pub(crate) fn namespace_path(&self) -> PathBuf {
         match self {
             BuiltInFunctionKind::PreludeThrow
+            | BuiltInFunctionKind::PreludeExit
             | BuiltInFunctionKind::PreludeStringRepr
             | BuiltInFunctionKind::PreludeDbg
             | BuiltInFunctionKind::PreludePrint
@@ -504,6 +506,7 @@ impl Display for BuiltInFunctionKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
             BuiltInFunctionKind::PreludeThrow => "throw",
+            BuiltInFunctionKind::PreludeExit => "exit",
             BuiltInFunctionKind::FsListDirectory => "list_directory",
             BuiltInFunctionKind::ShellRun => "run",
             BuiltInFunctionKind::PreludeStringRepr => "string_repr",


### PR DESCRIPTION
## Summary
This PR adds a new `exit()` built-in function that allows Garden programs to terminate immediately with a specified exit code. This is useful for indicating success (exit code 0) or failure (non-zero codes) to the calling process.

## Key Changes
- **New `EvalError::Exited(i64)` variant** to represent program termination via `exit()`
- **`exit(code: Int): NoValue` function** added to the prelude that accepts an integer exit code
- **Error handling updates** across all evaluation contexts:
  - `eval.rs`: Handles `Exited` errors in test evaluation (breaks test loop like `Interrupted`)
  - `main.rs`: Converts `Exited` errors to actual process exit codes
  - `cli_session.rs`: Displays exit message in REPL without stopping the session
  - `json_session.rs`: Returns exit code as an error response
  - `nrepl.rs`: Formats exit errors with "exited" error type
  - `sandboxed_playground.rs`: Reports exit as an error in sandboxed mode
  - `test_runner.rs`: Tracks exited tests in test summaries
- **Test file** `exit.gdn` demonstrating that code after `exit()` is not executed

## Implementation Details
- The `exit()` function validates that its argument is an `Int` and returns a type error otherwise
- Exit errors are treated similarly to `Interrupted` errors in test evaluation (they break the test loop)
- The exit code is converted from `i64` to `i32` when calling `std::process::exit()`
- In interactive contexts (REPL, JSON session), the exit is reported as an error but doesn't terminate the session itself

https://claude.ai/code/session_01H3gwqUgftqTxGizYu719az