### PR TITLE
Change shell() to return tuple of (stdout, stderr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 **Goal: Offer actions when runtime errors occur.**
 **Goal: Fix precedence of `2 + 1 * 3.**
 
+## Standard Library
+
+`shell()` now returns a tuple `(stdout, stderr)` on success, instead
+of stdout and stderr concatenated together.
+
 ## Tooling
 
 Added a `--trace` CLI flag that enables expression tracing when

--- a/sample_programs/git_fuzzy_branch.gdn
+++ b/sample_programs/git_fuzzy_branch.gdn
@@ -6,7 +6,8 @@ fun in_git_repo(): Bool {
 }
 
 fun check_out(branch_name: String): Unit {
-  print(shell("git", ["checkout", branch_name]).or_throw())
+  let (stdout, _) = shell("git", ["checkout", branch_name]).or_throw()
+  print(stdout)
 }
 
 {
@@ -22,9 +23,9 @@ fun check_out(branch_name: String): Unit {
     return
   }
 
-  let all_branches = shell("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
+  let (branches_output, _) = shell("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
     .or_throw()
-    .lines()
+  let all_branches = branches_output.lines()
   if all_branches.contains(needle) {
     // If there's a branch with this name exactly, use it.
     check_out(needle)

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -904,13 +904,13 @@ public fun read_line(): Result<String, String> {
   __BUILT_IN_IMPLEMENTATION
 }
 
-/// Execute the given string as a shell command, and return stdout
-/// concatenated with stderr.
+/// Execute the given string as a shell command, and return a tuple
+/// of stdout and stderr.
 ///
 /// ```
 /// shell("ls", ["-l", "/"])
 /// ```
-public fun shell(command: String, args: List<String>): Result<String, String> {
+public fun shell(command: String, args: List<String>): Result<(String, String), String> {
   __BUILT_IN_IMPLEMENTATION
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2740,17 +2740,25 @@ fn eval_built_in_call(
 
                     let v = match command.output() {
                         Ok(output) => {
-                            let mut s = String::new();
-
                             // TODO: complain if output is not UTF-8.
-                            s.write_str(&String::from_utf8_lossy(&output.stdout))
-                                .unwrap();
-                            s.write_str(&String::from_utf8_lossy(&output.stderr))
-                                .unwrap();
-
                             if output.status.success() {
-                                Value::ok(Value::new(Value_::String(s)))
+                                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+                                let tuple = Value::new(Value_::Tuple {
+                                    items: vec![
+                                        Value::new(Value_::String(stdout)),
+                                        Value::new(Value_::String(stderr)),
+                                    ],
+                                    item_types: vec![Type::string(), Type::string()],
+                                });
+                                Value::ok(tuple)
                             } else {
+                                let mut s = String::new();
+                                s.write_str(&String::from_utf8_lossy(&output.stdout))
+                                    .unwrap();
+                                s.write_str(&String::from_utf8_lossy(&output.stderr))
+                                    .unwrap();
                                 Value::err(Value::new(Value_::String(s)))
                             }
                         }

--- a/src/test_files/runtime/shell_tuple.gdn
+++ b/src/test_files/runtime/shell_tuple.gdn
@@ -1,0 +1,10 @@
+{
+    let (stdout, stderr) = shell("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
+    dbg(stdout)
+    dbg(stderr)
+}
+
+// args: run
+// expected stdout:
+// "out\n"
+// "err\n"


### PR DESCRIPTION
## Summary
Modified the `shell()` built-in function to return a tuple of `(String, String)` containing stdout and stderr separately, instead of concatenating them into a single string. This provides better separation of concerns and allows callers to handle output streams independently.

## Key Changes
- **Runtime behavior**: Updated `eval_built_in_call()` in `src/eval.rs` to construct a `Value::Tuple` containing separate stdout and stderr strings on success, while maintaining the concatenated format for error cases
- **Type signature**: Changed `shell()` return type from `Result<String, String>` to `Result<(String, String), String>` in `src/__prelude.gdn`
- **Documentation**: Updated the docstring to reflect that the function returns a tuple of stdout and stderr
- **Sample program**: Updated `sample_programs/git_fuzzy_branch.gdn` to destructure the tuple and use stdout appropriately
- **Test coverage**: Added `src/test_files/runtime/shell_tuple.gdn` to verify the tuple return behavior

## Implementation Details
- On successful command execution, stdout and stderr are converted to owned strings and wrapped in a tuple value with proper type annotations
- On command failure, the error case still concatenates stdout and stderr into a single string (preserving existing error behavior)
- The change maintains backward compatibility at the error level while improving the success case API

https://claude.ai/code/session_01LeowUdza1T74QML8zTZT4T