### PR TITLE
Remove parentheses from function string representation

### DIFF
--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -8,7 +8,7 @@ fun do_stuff() {}
 
 // args: run
 // expected stdout:
-// <fun do_stuff() string_repr_of_fun.gdn:1>
-// <fun println() __prelude.gdn:883>
+// <fun do_stuff string_repr_of_fun.gdn:1>
+// <fun println __prelude.gdn:883>
 // <closure string_repr_of_fun.gdn:6>
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -534,7 +534,7 @@ impl Value {
                 };
 
                 format!(
-                    "<fun {}() {}:{}>",
+                    "<fun {} {}:{}>",
                     name_sym.name,
                     file_name,
                     fun_info.pos.line_number + 1
@@ -557,12 +557,7 @@ impl Value {
                         None => format!("{}", pos_path.display()),
                     };
 
-                    format!(
-                        "<fun {}() {}:{}>",
-                        kind,
-                        file_name,
-                        info.pos.line_number + 1
-                    )
+                    format!("<fun {} {}:{}>", kind, file_name, info.pos.line_number + 1)
                 }
                 None => format!("{kind}"),
             },


### PR DESCRIPTION
## Summary
Updated the string representation of functions to remove the empty parentheses `()` that were previously displayed after function names.

## Changes
- Modified `src/values.rs` to change the format string from `<fun {}() {}:{}>` to `<fun {} {}:{}>` in two locations where function values are converted to strings
- Updated the corresponding test expectations in `src/test_files/runtime/string_repr_of_fun.gdn` to match the new format

## Details
The change affects how function values are displayed when converted to strings. Previously, functions would be shown as `<fun do_stuff() string_repr_of_fun.gdn:1>`, but now they display as `<fun do_stuff string_repr_of_fun.gdn:1>`. This applies to both named functions and built-in functions like `println`.

https://claude.ai/code/session_01P9Hcko27NRUCkvD6WjRhpr