### PR TITLE
If expressions without else always evaluate to Unit

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1978,7 +1978,7 @@ impl TypeCheckVisitor<'_> {
                 }
             }
             None => {
-                self.verify_block(&Type::unit(), then_block, type_bindings, expected_return_ty);
+                self.infer_block(then_block, type_bindings, expected_return_ty);
                 Type::unit()
             }
         }
@@ -2411,12 +2411,7 @@ impl TypeCheckVisitor<'_> {
                         expected_ty.clone()
                     }
                     None => {
-                        self.verify_block(
-                            &Type::unit(),
-                            then_block,
-                            type_bindings,
-                            expected_return_ty,
-                        );
+                        self.infer_block(then_block, type_bindings, expected_return_ty);
                         Type::unit()
                     }
                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1579,19 +1579,19 @@ fn eval_if(
         .expect("Popped an empty value stack for if condition");
 
     if let Some(b) = condition_value.as_rust_bool() {
-        if b {
-            eval_block(env, expr_value_is_used, then_body);
-        } else {
-            if let Some(else_body) = else_body {
-                eval_block(env, expr_value_is_used, else_body);
-            } else {
-                // Ensure we always push a bindings block.
-                env.current_frame_mut().bindings.push_block();
+        // When there's no else, the if always evaluates to Unit
+        // regardless of the then block's type, so the branch's value
+        // is not used. The Unit is pushed by the if's
+        // EvaluatedAllSubexpressions continuation.
+        let branch_value_used = expr_value_is_used && else_body.is_some();
 
-                if expr_value_is_used {
-                    env.push_value(Value::unit());
-                }
-            }
+        if b {
+            eval_block(env, branch_value_used, then_body);
+        } else if let Some(else_body) = else_body {
+            eval_block(env, branch_value_used, else_body);
+        } else {
+            // Ensure we always push a bindings block.
+            env.current_frame_mut().bindings.push_block();
         }
     } else {
         return Err((
@@ -5742,6 +5742,10 @@ fn eval_expr(
             }
             ExpressionState::EvaluatedAllSubexpressions => {
                 env.current_frame_mut().bindings.pop_block();
+
+                if expr_value_is_used && else_body.is_none() {
+                    env.push_value(Value::unit());
+                }
             }
         },
         Expression_::While(condition, ref body) => {

--- a/src/test_files/check/if_without_else_non_unit.gdn
+++ b/src/test_files/check/if_without_else_non_unit.gdn
@@ -1,0 +1,9 @@
+public fun foo(b: Bool) {
+    if b {
+        string_repr(123)
+    }
+}
+
+// args: check
+// expected exit status: 0
+// expected stdout:

--- a/src/test_files/check/type_error_if_without_else.gdn
+++ b/src/test_files/check/type_error_if_without_else.gdn
@@ -16,15 +16,6 @@ public fun foo(b: Bool): Int {
 // 4|     }   ^^^
 // 5| }
 // 
-// Error: Expected `Unit` but got an `Int`.
-// 
-// -| src/test_files/check/type_error_if_without_else.gdn:3:9
-// 1| public fun foo(b: Bool): Int {
-// 2|     if b {
-// 3|         123
-// 4|     }   ^^^
-// 5| }
-// 
 // Error: Expected an `Int` but got `Unit`.
 // 
 // -| src/test_files/check/type_error_if_without_else.gdn:2:5

--- a/src/test_files/runtime/if_without_else_returns_unit.gdn
+++ b/src/test_files/runtime/if_without_else_returns_unit.gdn
@@ -1,0 +1,18 @@
+// An if without else always evaluates to Unit, regardless of the type
+// of the then block.
+fun take_unit(_: Unit) {}
+
+{
+    take_unit(if True { 1 })
+    take_unit(if False { 1 })
+
+    let x = if True { "hello" }
+    println(string_repr(x))
+
+    let y = if False { "hello" }
+    println(string_repr(y))
+}
+
+// args: run
+// expected stdout: Unit
+// Unit


### PR DESCRIPTION
Changes the semantics of `if` expressions without an `else` clause to always evaluate to `Unit`, regardless of the type of the `then` block.

## Summary

Previously, an `if` expression without an `else` clause would evaluate to the type of its `then` block, which created type inconsistency issues. Now, such expressions consistently evaluate to `Unit`, matching the behavior when the condition is false and no `else` clause exists.

## Key Changes

- **Runtime evaluation** (`src/eval.rs`): Modified `eval_if` to compute `branch_value_used` based on whether an `else` clause exists. When there's no `else`, the branch value is not used, and `Unit` is pushed during the `EvaluatedAllSubexpressions` continuation instead.

- **Type checking** (`src/checks/type_checker.rs`): Changed from `verify_block` (which enforced the `then` block to return `Unit`) to `infer_block` (which allows the `then` block to have any type). The function now always returns `Type::unit()` for `if` expressions without `else`.

- **Tests**: Added `if_without_else_returns_unit.gdn` to verify the runtime behavior and `if_without_else_non_unit.gdn` to confirm type checking accepts non-unit `then` blocks. Updated `type_error_if_without_else.gdn` to reflect the new error (only the return type mismatch, not the block type mismatch).

## Implementation Details

The key insight is that `branch_value_used` is now determined at the start of condition evaluation, allowing both branches to use the same flag. When no `else` exists, the flag is `false`, so the `then` block's value is discarded. The `Unit` value is pushed later during the continuation, ensuring consistent behavior regardless of which branch executes.

https://claude.ai/code/session_01JxRLXu3X7XhTQG781jDphv