### PR TITLE
Add check for let bindings with Unit type values

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -7,6 +7,7 @@ mod same_literal_returns;
 mod self_assign_compare;
 mod struct_fields;
 pub mod type_checker;
+mod unit_let;
 mod unnecessary_let;
 mod unnecessary_return;
 mod unreachable;
@@ -28,6 +29,7 @@ use recursion_variable::check_recursion_variables;
 use repeated_bool::check_repeated_bool;
 use same_literal_returns::check_same_literal_returns;
 use self_assign_compare::check_self_assign_compare;
+use unit_let::check_unit_let;
 use unnecessary_let::check_unnecessary_let;
 use unnecessary_return::check_unnecessary_return;
 use unreachable::check_unreachable;
@@ -74,6 +76,7 @@ pub(crate) fn check_toplevel_items_in_env(
 
     let summary = check_types(vfs_path, items, env, namespace);
     diagnostics.extend(check_unused_defs(items, &summary));
+    diagnostics.extend(check_unit_let(items, &summary));
 
     diagnostics.extend(summary.diagnostics);
     diagnostics.extend(check_duplicates(items, env));

--- a/src/checks/unit_let.rs
+++ b/src/checks/unit_let.rs
@@ -1,0 +1,50 @@
+//! Check for `let` bindings whose right-hand side has type `Unit`.
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::parser::ast::{Expression, Expression_, ToplevelItem};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::visitor::Visitor;
+use crate::{msgcode, msgtext};
+
+use super::type_checker::TCSummary;
+
+struct UnitLetVisitor<'a> {
+    summary: &'a TCSummary,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl Visitor for UnitLetVisitor<'_> {
+    fn visit_expr(&mut self, expr: &Expression) {
+        if let Expression_::Let(_, _, rhs) = &expr.expr_ {
+            if let Some(ty) = self.summary.id_to_ty.get(&rhs.id) {
+                if ty.is_unit() {
+                    self.diagnostics.push(Diagnostic {
+                        message: ErrorMessage(vec![
+                            msgtext!("Binding a value of type "),
+                            msgcode!("Unit"),
+                            msgtext!(" to a variable is rarely useful."),
+                        ]),
+                        position: rhs.position.clone(),
+                        notes: vec![],
+                        severity: Severity::Warning,
+                        fixes: vec![],
+                    });
+                }
+            }
+        }
+
+        self.visit_expr_(&expr.expr_);
+    }
+}
+
+pub(crate) fn check_unit_let(items: &[ToplevelItem], summary: &TCSummary) -> Vec<Diagnostic> {
+    let mut visitor = UnitLetVisitor {
+        summary,
+        diagnostics: vec![],
+    };
+
+    for item in items {
+        visitor.visit_toplevel_item(item);
+    }
+    visitor.diagnostics
+}

--- a/src/test_files/check/let_unit_value.gdn
+++ b/src/test_files/check/let_unit_value.gdn
@@ -1,0 +1,32 @@
+public fun greet(): Unit {
+    println("hi")
+}
+
+public fun foo(): Unit {
+    let x = greet()
+    let _ = println("hello")
+    println(string_repr(x))
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: Binding a value of type `Unit` to a variable is rarely useful.
+// 
+// -| src/test_files/check/let_unit_value.gdn:6:13
+// 5| public fun foo(): Unit {
+// 6|     let x = greet()
+//  |             ^^^^^^^
+// 7|     let _ = println("hello")
+// 8|     println(string_repr(x))
+// 
+// Warning: Binding a value of type `Unit` to a variable is rarely useful.
+// 
+// -| src/test_files/check/let_unit_value.gdn:7:13
+// 5| public fun foo(): Unit {
+// 6|     let x = greet()
+// 7|     let _ = println("hello")
+//  |             ^^^^^^^^^^^^^^^^
+// 8|     println(string_repr(x))
+// 9| }
+


### PR DESCRIPTION
Adds a new static analysis check that warns when a variable is bound to a value of type `Unit`, which is rarely useful since `Unit` values carry no information.

## Changes

- Added `src/checks/unit_let.rs` with a new `UnitLetVisitor` that traverses the AST and detects `let` bindings where the right-hand side has type `Unit`
- Registered the check in `src/checks.rs` to run as part of `check_toplevel_items_in_env()`
- Added test file `src/test_files/check/let_unit_value.gdn` demonstrating the check in action

## Implementation Details

The check uses the type information from `TCSummary` (populated by the type checker) to identify when a `let` binding's right-hand side expression has type `Unit`. When detected, it emits a warning diagnostic at the position of the right-hand side expression. The check correctly handles both explicit bindings (e.g., `let x = greet()`) and underscore bindings (e.g., `let _ = println("hello")`), warning in both cases since binding `Unit` values is rarely intentional.

https://claude.ai/code/session_013TgpKy3PjA7KMxifcd2iAk