### PR TITLE
Add --check flag to format command and enforce formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Check TS formatting
         run: npx prettier --check "website/**/*.ts"
 
+      - name: Build Garden
+        run: cargo build
+
+      - name: Check Garden formatting
+        run: |
+          status=0
+          while IFS= read -r -d '' f; do
+            if ! ./target/debug/garden format --check "$f"; then
+              status=1
+            fi
+          done < <(find src website sample_programs benchmarks -name '*.gdn' -not -path '*/test_files/*' -not -path '*/unit_test_files/*' -print0)
+          exit "$status"
+
   typos:
     name: Check spelling
     runs-on: ubuntu-24.04

--- a/benchmarks/fun_call.gdn
+++ b/benchmarks/fun_call.gdn
@@ -2,13 +2,13 @@ fun noop() {}
 
 fun main() {
   let count = get_env("COUNT").or_throw().as_int().or_throw()
-  
+
   println("start")
-  
+
   for _ in range(0, count) {
     noop()
   }
-  
+
   println("finish")
 }
 

--- a/benchmarks/loop.gdn
+++ b/benchmarks/loop.gdn
@@ -1,10 +1,10 @@
 fun main() {
   let count = get_env("COUNT").or_throw().as_int().or_throw()
-  
+
   println("start")
-  
+
   for _ in range(0, count) {}
-  
+
   println("finish")
 }
 

--- a/sample_programs/bad_type_indirect.gdn
+++ b/sample_programs/bad_type_indirect.gdn
@@ -1,14 +1,14 @@
 // TODO: Loading these one-by-one into REPL stops us getting positions
 fun two(b) {
-    if b {}
+  if b {}
 }
 
 fun one(x) {
-    two(x)
+  two(x)
 }
 
 fun call_g() { two("a string") }
 
 public fun foo() {
-    one("not bool")
+  one("not bool")
 }

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -285,7 +285,6 @@ test trim {
   assert("a  ".trim() == "a")
 }
 
-
 /// Returns this string without the suffix specified. If this string
 /// does not end with the suffix, return the string unchanged.
 ///

--- a/src/format.rs
+++ b/src/format.rs
@@ -154,6 +154,25 @@ impl IndentationVisitor {
         }
     }
 
+    /// Visit each argument expression in a call, increasing depth only
+    /// while visiting nested expressions that don't carry their own
+    /// block. A function literal argument's body is a `Block`, and
+    /// `visit_block` already increases depth for its contents, so
+    /// incrementing here too would over-indent the lambda body by an
+    /// extra level.
+    fn visit_call_arguments(&mut self, arguments: &[crate::parser::ast::ExpressionWithComma]) {
+        for arg in arguments {
+            let bumps_own_depth = matches!(arg.expr.expr_, Expression_::FunLiteral(_));
+            if !bumps_own_depth {
+                self.current_depth += 1;
+            }
+            self.visit_expr(&arg.expr);
+            if !bumps_own_depth {
+                self.current_depth -= 1;
+            }
+        }
+    }
+
     /// Fix indentation of function call arguments that span multiple lines.
     /// Arguments on lines after the opening parenthesis are indented one level
     /// deeper than the call expression itself.
@@ -372,23 +391,13 @@ impl Visitor for IndentationVisitor {
             self.visit_expr(recv);
             self.fix_function_argument_indentation(paren_args);
 
-            // Increase depth while visiting arguments so nested calls are indented correctly
-            self.current_depth += 1;
-            for arg in &paren_args.arguments {
-                self.visit_expr(&arg.expr);
-            }
-            self.current_depth -= 1;
+            self.visit_call_arguments(&paren_args.arguments);
         } else if let Expression_::MethodCall(recv, meth_name, paren_args) = expr_ {
             self.visit_symbol(meth_name);
             self.visit_expr(recv);
             self.fix_function_argument_indentation(paren_args);
 
-            // Increase depth while visiting arguments so nested calls are indented correctly
-            self.current_depth += 1;
-            for arg in &paren_args.arguments {
-                self.visit_expr(&arg.expr);
-            }
-            self.current_depth -= 1;
+            self.visit_call_arguments(&paren_args.arguments);
         } else {
             // For all other expression types, delegate to the visitor's default behavior
             // which handles recursion into nested expressions

--- a/src/format.rs
+++ b/src/format.rs
@@ -650,8 +650,14 @@ fn normalize_blank_lines(src: &str, toplevel_start_lines: &[usize]) -> String {
         i += 1;
 
         // Check if the next line (after any blanks) starts a new toplevel definition
-        // If so, we need exactly one blank line between them
-        if i < lines.len() && !lines[i].trim().is_empty() && toplevel_lines.contains(&i) {
+        // If so, we need exactly one blank line between them. Doc comments
+        // (lines starting with `//`) on the previous line are considered
+        // attached to the following item, so no blank line is inserted.
+        if i < lines.len()
+            && !lines[i].trim().is_empty()
+            && toplevel_lines.contains(&i)
+            && !line.trim_start().starts_with("//")
+        {
             // Next non-blank line is a toplevel definition, but there's no blank line
             // Insert one blank line
             result.push('\n');

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,14 @@ enum CliCommands {
         override_path: Option<PathBuf>,
     },
     /// Format a Garden file and print the re-indented source code.
-    Format { path: PathBuf },
+    Format {
+        path: PathBuf,
+        /// Check if the file is already formatted. Exits with a
+        /// non-zero status if formatting would change the file, and
+        /// does not print the formatted output.
+        #[clap(long, action)]
+        check: bool,
+    },
     /// Check the Garden program at the path specified for issues.
     Check {
         path: PathBuf,
@@ -544,12 +551,19 @@ fn main() {
                 }
             }
         }
-        CliCommands::Format { path } => {
+        CliCommands::Format { path, check } => {
             let abs_path = to_abs_path(&path);
             let mut src = read_utf8_or_die(&abs_path);
             src = remove_testing_footer(&src);
             let formatted = format::format(&src, &abs_path);
-            print!("{formatted}");
+            if check {
+                if src != formatted {
+                    eprintln!("{}: not formatted", path.display());
+                    std::process::exit(1);
+                }
+            } else {
+                print!("{formatted}");
+            }
         }
         CliCommands::PlaygroundRun { path } => {
             let abs_path = to_abs_path(&path);

--- a/src/test_files/format/lambda_in_call.gdn
+++ b/src/test_files/format/lambda_in_call.gdn
@@ -1,0 +1,41 @@
+fun map_call(items: List<Int>): List<Int> {
+  items.map(fun(x: Int) {
+x + 1
+  })
+}
+
+fun regular_call(xs: List<Int>): List<Int> {
+  some_call(fun(x: Int) {
+x * 2
+  })
+}
+
+fun nested_lambdas(xs: List<Int>): List<List<Int>> {
+  xs.map(fun(x: Int) {
+    xs.map(fun(y: Int) {
+x + y
+    })
+  })
+}
+
+// args: format
+// expected stdout:
+// fun map_call(items: List<Int>): List<Int> {
+//   items.map(fun(x: Int) {
+//     x + 1
+//   })
+// }
+// 
+// fun regular_call(xs: List<Int>): List<Int> {
+//   some_call(fun(x: Int) {
+//     x * 2
+//   })
+// }
+// 
+// fun nested_lambdas(xs: List<Int>): List<List<Int>> {
+//   xs.map(fun(x: Int) {
+//     xs.map(fun(y: Int) {
+//       x + y
+//     })
+//   })
+// }

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 883,
+//     "line": 882,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,6 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:883>
+// <fun println __prelude.gdn:882>
 // <closure string_repr_of_fun.gdn:6>
 

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -34,7 +34,13 @@ fun drop_leading_comments(src: String): String {
   "\n".join(lines.slice(first_code_line, lines.len()))
 }
 
-fun write_fun_page(ns_name: String, ns: Namespace, fun_name: String, out_dir: Path, base_tmpl_src: String): Unit {
+fun write_fun_page(
+  ns_name: String,
+  ns: Namespace,
+  fun_name: String,
+  out_dir: Path,
+  base_tmpl_src: String,
+): Unit {
   let qualified_name = "::".join([ns_name, fun_name])
 
   match reflect::doc_comment(ns, fun_name) {
@@ -63,7 +69,12 @@ fun write_fun_page(ns_name: String, ns: Namespace, fun_name: String, out_dir: Pa
   }
 }
 
-fun write_method_page(type_name: String, method_name: String, out_dir: Path, base_tmpl_src: String): Unit {
+fun write_method_page(
+  type_name: String,
+  method_name: String,
+  out_dir: Path,
+  base_tmpl_src: String,
+): Unit {
   let qualified_name = type_name ^ "::" ^ method_name
 
   match reflect::doc_comment_for_method(type_name, method_name) {
@@ -107,14 +118,21 @@ fun render_doc_comment(
   markdown::render(md_src, file, self_url)
 }
 
-fun render_type_doc_comment(heading: String, doc_comment: String, src: String, methods: List<String>, type_name: String, self_url: Option<String>): String {
+fun render_type_doc_comment(
+  heading: String,
+  doc_comment: String,
+  src: String,
+  methods: List<String>,
+  type_name: String,
+  self_url: Option<String>,
+): String {
   let src = "```garden nocheck title:\"Source Code\"\n" ^ drop_leading_comments(src) ^ "\n```"
 
   let methods_section = if methods.is_empty() {
     ""
   } else {
     let method_list = methods.map(fun(m: String) {
-      "* [`" ^ m ^ "()`](/method:" ^ type_name ^ "::" ^ m ^ ".html)"
+        "* [`" ^ m ^ "()`](/method:" ^ type_name ^ "::" ^ m ^ ".html)"
     })
     "\n\n## Methods\n\n" ^ "\n".join(method_list)
   }
@@ -170,7 +188,7 @@ fun write_markdown_page(
     substitute_shorthand(website_dir, page_src_md),
     Some(md_path),
     Some(self_url))
-  
+
   write_website_page(base_tmpl_string, page_src, out_path, title)
 }
 
@@ -420,46 +438,46 @@ fun code_link(text: String, url: String): String {
 /// Replace all __FOO strings in markdown `src` with runtime values.
 fun substitute_shorthand(website_dir: Path, src: String): String {
   let keyword_links = reflect::keywords().map(fun(keyword: String) {
-    code_link(keyword, "./keyword:" ^ keyword ^ ".html")
+      code_link(keyword, "./keyword:" ^ keyword ^ ".html")
   })
 
   let keyword_links = join_with_commas_and(keyword_links)
 
   let operator_links = reflect::operators().map(fun(operator: String) {
-    let page_name = ops::url_safe_name(operator)
-    code_link(operator, "./operator:" ^ page_name ^ ".html")
+      let page_name = ops::url_safe_name(operator)
+      code_link(operator, "./operator:" ^ page_name ^ ".html")
   })
 
   let operator_links = join_with_commas_and(operator_links)
 
   let type_links = reflect::prelude_types().map(fun(name: String) {
-    code_link(name, "./type:" ^ name ^ ".html")
+      code_link(name, "./type:" ^ name ^ ".html")
   })
 
   let type_links = join_with_commas_and(type_links)
 
   let prelude_funs = reflect::namespace_functions(prelude).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
+      code_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
   })
   let prelude_funs = join_with_commas_and(prelude_funs)
 
   let fs_funs = reflect::namespace_functions(fs).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
+      code_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
   })
   let fs_funs = join_with_commas_and(fs_funs)
 
   let random_funs = reflect::namespace_functions(random).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
+      code_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
   })
   let random_funs = join_with_commas_and(random_funs)
 
   let reflect_funs = reflect::namespace_functions(reflect).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
+      code_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
   })
   let reflect_funs = join_with_commas_and(reflect_funs)
 
   let time_funs = reflect::namespace_functions(time).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
+      code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
   })
   let time_funs = join_with_commas_and(time_funs)
 

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -132,7 +132,7 @@ fun render_type_doc_comment(
     ""
   } else {
     let method_list = methods.map(fun(m: String) {
-        "* [`" ^ m ^ "()`](/method:" ^ type_name ^ "::" ^ m ^ ".html)"
+      "* [`" ^ m ^ "()`](/method:" ^ type_name ^ "::" ^ m ^ ".html)"
     })
     "\n\n## Methods\n\n" ^ "\n".join(method_list)
   }
@@ -438,46 +438,46 @@ fun code_link(text: String, url: String): String {
 /// Replace all __FOO strings in markdown `src` with runtime values.
 fun substitute_shorthand(website_dir: Path, src: String): String {
   let keyword_links = reflect::keywords().map(fun(keyword: String) {
-      code_link(keyword, "./keyword:" ^ keyword ^ ".html")
+    code_link(keyword, "./keyword:" ^ keyword ^ ".html")
   })
 
   let keyword_links = join_with_commas_and(keyword_links)
 
   let operator_links = reflect::operators().map(fun(operator: String) {
-      let page_name = ops::url_safe_name(operator)
-      code_link(operator, "./operator:" ^ page_name ^ ".html")
+    let page_name = ops::url_safe_name(operator)
+    code_link(operator, "./operator:" ^ page_name ^ ".html")
   })
 
   let operator_links = join_with_commas_and(operator_links)
 
   let type_links = reflect::prelude_types().map(fun(name: String) {
-      code_link(name, "./type:" ^ name ^ ".html")
+    code_link(name, "./type:" ^ name ^ ".html")
   })
 
   let type_links = join_with_commas_and(type_links)
 
   let prelude_funs = reflect::namespace_functions(prelude).map(fun(name: String) {
-      code_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
+    code_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
   })
   let prelude_funs = join_with_commas_and(prelude_funs)
 
   let fs_funs = reflect::namespace_functions(fs).map(fun(name: String) {
-      code_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
+    code_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
   })
   let fs_funs = join_with_commas_and(fs_funs)
 
   let random_funs = reflect::namespace_functions(random).map(fun(name: String) {
-      code_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
+    code_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
   })
   let random_funs = join_with_commas_and(random_funs)
 
   let reflect_funs = reflect::namespace_functions(reflect).map(fun(name: String) {
-      code_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
+    code_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
   })
   let reflect_funs = join_with_commas_and(reflect_funs)
 
   let time_funs = reflect::namespace_functions(time).map(fun(name: String) {
-      code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
+    code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
   })
   let time_funs = join_with_commas_and(time_funs)
 

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -687,8 +687,8 @@ fun render_paragraph(src: String, self_url: Option<String>): String {
 
 fun render_bullets(items: List<String>, self_url: Option<String>): String {
   let rendered_items = items.map(fun(item: String) {
-    let rendered_item = render_inline(item.strip_prefix("*").trim_left(), self_url)
-    "<li>" ^ rendered_item ^ "</li>"
+      let rendered_item = render_inline(item.strip_prefix("*").trim_left(), self_url)
+      "<li>" ^ rendered_item ^ "</li>"
   })
 
   "<ul>\n" ^ "\n".join(rendered_items) ^ "\n</ul>"

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -687,8 +687,8 @@ fun render_paragraph(src: String, self_url: Option<String>): String {
 
 fun render_bullets(items: List<String>, self_url: Option<String>): String {
   let rendered_items = items.map(fun(item: String) {
-      let rendered_item = render_inline(item.strip_prefix("*").trim_left(), self_url)
-      "<li>" ^ rendered_item ^ "</li>"
+    let rendered_item = render_inline(item.strip_prefix("*").trim_left(), self_url)
+    "<li>" ^ rendered_item ^ "</li>"
   })
 
   "<ul>\n" ^ "\n".join(rendered_items) ^ "\n</ul>"


### PR DESCRIPTION
Add a `--check` flag to the `garden format` command that verifies whether a file is already formatted without printing the output. This enables automated formatting checks in CI/CD pipelines.

## Changes

- **CLI enhancement**: Added `--check` flag to the `Format` command in `src/main.rs`. When enabled, the command exits with status 1 if the file would be reformatted, and does not print output.

- **CI integration**: Updated `.github/workflows/test.yml` to build Garden and run formatting checks on all `.gdn` files in the repository (excluding test files).

- **Formatter improvement**: Fixed `src/format.rs` to not insert blank lines before toplevel definitions that are preceded by doc comments (lines starting with `//`). Doc comments are now correctly treated as attached to the following item.

- **Code formatting**: Applied consistent formatting throughout the codebase:
  - Reformatted multi-parameter function signatures to place each parameter on its own line
  - Fixed indentation in lambda expressions and map/filter chains
  - Removed trailing whitespace
  - Removed unnecessary blank lines in `src/__prelude.gdn`

- **Test updates**: Updated line number references in test files to reflect changes from the blank line normalization fix.

https://claude.ai/code/session_012aPjYkvdvCqYGVsz94mbF5