### PR TITLE
Move shell functions to dedicated __shell.gdn namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 `shell()` now returns a tuple `(stdout, stderr)` on success, instead
 of stdout and stderr concatenated together.
 
+Moved `shell()` and `get_env()` from the prelude to a new `__shell.gdn`
+built-in namespace. `shell()` has been renamed to `run()`.
+
+```
+import "__shell.gdn" as shell
+
+shell::run("ls", ["-l", "/"])
+shell::get_env("HOME")
+```
+
 ## Tooling
 
 Added a `--trace` CLI flag that enables expression tracing when

--- a/benchmarks/fun_call.gdn
+++ b/benchmarks/fun_call.gdn
@@ -1,7 +1,9 @@
+import "__shell.gdn" as shell
+
 fun noop() {}
 
 fun main() {
-  let count = get_env("COUNT").or_throw().as_int().or_throw()
+  let count = shell::get_env("COUNT").or_throw().as_int().or_throw()
 
   println("start")
 

--- a/benchmarks/loop.gdn
+++ b/benchmarks/loop.gdn
@@ -1,5 +1,7 @@
+import "__shell.gdn" as shell
+
 fun main() {
-  let count = get_env("COUNT").or_throw().as_int().or_throw()
+  let count = shell::get_env("COUNT").or_throw().as_int().or_throw()
 
   println("start")
 

--- a/sample_programs/git_fuzzy_branch.gdn
+++ b/sample_programs/git_fuzzy_branch.gdn
@@ -1,12 +1,14 @@
 #!/usr/bin/env -S garden run
 
+import "__shell.gdn" as shell
+
 fun in_git_repo(): Bool {
   let git_dir_path = working_directory() ^ "/.git"
   path_exists(git_dir_path)
 }
 
 fun check_out(branch_name: String): Unit {
-  let (stdout, _) = shell("git", ["checkout", branch_name]).or_throw()
+  let (stdout, _) = shell::run("git", ["checkout", branch_name]).or_throw()
   print(stdout)
 }
 
@@ -23,7 +25,7 @@ fun check_out(branch_name: String): Unit {
     return
   }
 
-  let (branches_output, _) = shell("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
+  let (branches_output, _) = shell::run("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
     .or_throw()
   let all_branches = branches_output.lines()
   if all_branches.contains(needle) {

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -903,16 +903,6 @@ public fun read_line(): Result<String, String> {
   __BUILT_IN_IMPLEMENTATION
 }
 
-/// Execute the given string as a shell command, and return a tuple
-/// of stdout and stderr.
-///
-/// ```
-/// shell("ls", ["-l", "/"])
-/// ```
-public fun shell(command: String, args: List<String>): Result<(String, String), String> {
-  __BUILT_IN_IMPLEMENTATION
-}
-
 /// Return the pretty-printed string representation of this value.
 ///
 /// ```
@@ -1058,27 +1048,6 @@ test path_read {
 /// --foo`, then this function will return `["--foo"]`.
 public fun shell_arguments(): List<String> {
   __BUILT_IN_IMPLEMENTATION
-}
-
-/// Get the value of an environment variable.
-///
-/// Returns `Some(value)` if the environment variable is set, or `None`
-/// if it is not set.
-///
-/// ```
-/// get_env("HOME") // Some("/home/user")
-/// get_env("NO_SUCH_VAR") // None
-/// ```
-public fun get_env(name: String): Option<String> {
-  __BUILT_IN_IMPLEMENTATION
-}
-
-test get_env {
-  let path = get_env("PATH")
-  assert(path.is_some())
-
-  let nonexistent = get_env("THIS_VARIABLE_SHOULD_NOT_EXIST_12345")
-  assert(nonexistent.is_none())
 }
 
 /// A collection of functions and types from importing a file.

--- a/src/__shell.gdn
+++ b/src/__shell.gdn
@@ -1,0 +1,32 @@
+/// Execute the given string as a shell command, and return a tuple
+/// of stdout and stderr.
+///
+/// ```
+/// import "__shell.gdn" as shell
+/// shell::run("ls", ["-l", "/"])
+/// ```
+public fun run(command: String, args: List<String>): Result<(String, String), String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+/// Get the value of an environment variable.
+///
+/// Returns `Some(value)` if the environment variable is set, or `None`
+/// if it is not set.
+///
+/// ```
+/// import "__shell.gdn" as shell
+/// shell::get_env("HOME") // Some("/home/user")
+/// shell::get_env("NO_SUCH_VAR") // None
+/// ```
+public fun get_env(name: String): Option<String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+test get_env {
+  let path = get_env("PATH")
+  assert(path.is_some())
+
+  let nonexistent = get_env("THIS_VARIABLE_SHOULD_NOT_EXIST_12345")
+  assert(nonexistent.is_none())
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -622,6 +622,7 @@ pub(crate) const BUILT_IN_FILES: &[(&str, &str)] = &[
     ("__fs.gdn", include_str!("__fs.gdn")),
     ("__random.gdn", include_str!("__random.gdn")),
     ("__reflect.gdn", include_str!("__reflect.gdn")),
+    ("__shell.gdn", include_str!("__shell.gdn")),
     ("__time.gdn", include_str!("__time.gdn")),
 ];
 
@@ -2728,7 +2729,7 @@ fn eval_built_in_call(
                 env.push_value(v);
             }
         }
-        BuiltInFunctionKind::PreludeShell => {
+        BuiltInFunctionKind::ShellRun => {
             if env.enforce_sandbox {
                 let mut saved_values = vec![];
                 for value in arg_values.iter().rev() {
@@ -3066,7 +3067,7 @@ fn eval_built_in_call(
                 }));
             }
         }
-        BuiltInFunctionKind::PreludeGetEnv => {
+        BuiltInFunctionKind::ShellGetEnv => {
             check_arity(
                 &SymbolName {
                     text: format!("{kind}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1014,7 +1014,8 @@ mod tests {
             .arg("src/__prelude.gdn")
             .arg("src/__fs.gdn")
             .arg("src/__random.gdn")
-            .arg("src/__reflect.gdn");
+            .arg("src/__reflect.gdn")
+            .arg("src/__shell.gdn");
         cmd.assert().success();
     }
 

--- a/src/test_files/playground/shell.gdn
+++ b/src/test_files/playground/shell.gdn
@@ -1,4 +1,6 @@
-dbg(shell("ls", ["-l", "/"]))
+import "__shell.gdn" as shell
+
+dbg(shell::run("ls", ["-l", "/"]))
 
 // args: playground-run
 // expected stdout: {"error":"Tried to execute unsafe code in sandboxed mode","value":null}

--- a/src/test_files/runtime/shell_invalid_command.gdn
+++ b/src/test_files/runtime/shell_invalid_command.gdn
@@ -1,5 +1,7 @@
+import "__shell.gdn" as shell
+
 {
-    dbg(shell("no_such_command", []))
+    dbg(shell::run("no_such_command", []))
 }
 
 // args: run

--- a/src/test_files/runtime/shell_tuple.gdn
+++ b/src/test_files/runtime/shell_tuple.gdn
@@ -1,5 +1,7 @@
+import "__shell.gdn" as shell
+
 {
-    let (stdout, stderr) = shell("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
+    let (stdout, stderr) = shell::run("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
     dbg(stdout)
     dbg(stderr)
 }

--- a/src/test_files/sandboxed_test/shell.gdn
+++ b/src/test_files/sandboxed_test/shell.gdn
@@ -1,5 +1,7 @@
+import "__shell.gdn" as shell
+
 test shell_is_unsafe {
-    shell("ls", ["/"])
+    shell::run("ls", ["/"])
     // ^
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -388,18 +388,16 @@ pub(crate) fn type_representation(value: &Value) -> TypeName {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub(crate) enum BuiltInFunctionKind {
-    PreludeGetEnv,
     PreludePrint,
     PreludePrintln,
     PreludeReadLine,
-    PreludeShell,
-    // TODO: It's a little confusing that we have both shell() and
-    // shell_arguments(), these should go in separate namespaces once
-    // we have namespaces.
     PreludeShellArguments,
     PreludeSourceDirectory,
     PreludeStringRepr,
     PreludeThrow,
+
+    ShellGetEnv,
+    ShellRun,
 
     FsCopyFile,
     FsCreateDir,
@@ -430,14 +428,15 @@ impl BuiltInFunctionKind {
     pub(crate) fn namespace_path(&self) -> PathBuf {
         match self {
             BuiltInFunctionKind::PreludeThrow
-            | BuiltInFunctionKind::PreludeShell
             | BuiltInFunctionKind::PreludeStringRepr
             | BuiltInFunctionKind::PreludePrint
             | BuiltInFunctionKind::PreludePrintln
             | BuiltInFunctionKind::PreludeReadLine
             | BuiltInFunctionKind::PreludeSourceDirectory
-            | BuiltInFunctionKind::PreludeShellArguments
-            | BuiltInFunctionKind::PreludeGetEnv => PathBuf::from("__prelude.gdn"),
+            | BuiltInFunctionKind::PreludeShellArguments => PathBuf::from("__prelude.gdn"),
+            BuiltInFunctionKind::ShellRun | BuiltInFunctionKind::ShellGetEnv => {
+                PathBuf::from("__shell.gdn")
+            }
             BuiltInFunctionKind::FsWriteFile
             | BuiltInFunctionKind::FsListDirectory
             | BuiltInFunctionKind::FsWorkingDirectory
@@ -470,7 +469,7 @@ impl Display for BuiltInFunctionKind {
         let name = match self {
             BuiltInFunctionKind::PreludeThrow => "throw",
             BuiltInFunctionKind::FsListDirectory => "list_directory",
-            BuiltInFunctionKind::PreludeShell => "shell",
+            BuiltInFunctionKind::ShellRun => "run",
             BuiltInFunctionKind::PreludeStringRepr => "string_repr",
             BuiltInFunctionKind::PreludePrint => "print",
             BuiltInFunctionKind::PreludePrintln => "println",
@@ -491,7 +490,7 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::ReflectPreludeTypes => "prelude_types",
             BuiltInFunctionKind::ReflectNamespaceFunctions => "namespace_functions",
             BuiltInFunctionKind::ReflectMethodsForType => "methods_for_type",
-            BuiltInFunctionKind::PreludeGetEnv => "get_env",
+            BuiltInFunctionKind::ShellGetEnv => "get_env",
             BuiltInFunctionKind::ReflectKeywords => "keywords",
             BuiltInFunctionKind::RandomRandomInt => "int",
             BuiltInFunctionKind::FsCreateDir => "create_dir",


### PR DESCRIPTION
Moves `shell()` and `get_env()` functions from the prelude to a new built-in `__shell.gdn` namespace, and renames `shell()` to `run()` for clarity.

## Changes

- Created new `src/__shell.gdn` built-in file containing:
  - `run(command: String, args: List<String>)` — executes shell commands (formerly `shell()`)
  - `get_env(name: String)` — retrieves environment variables
  - Unit test for `get_env()`

- Removed `shell()` and `get_env()` from `src/__prelude.gdn`

- Updated `src/values.rs` to:
  - Replace `PreludeShell` and `PreludeGetEnv` enum variants with `ShellRun` and `ShellGetEnv`
  - Map new variants to `__shell.gdn` namespace path
  - Update function name display for `ShellRun` to "run"

- Updated `src/eval.rs` to register `__shell.gdn` in `BUILT_IN_FILES`

- Updated all sample programs and test files to import and use the new namespace:
  - `sample_programs/git_fuzzy_branch.gdn`
  - `benchmarks/fun_call.gdn`
  - `benchmarks/loop.gdn`
  - `src/test_files/playground/shell.gdn`
  - `src/test_files/runtime/shell_invalid_command.gdn`
  - `src/test_files/runtime/shell_tuple.gdn`
  - `src/test_files/sandboxed_test/shell.gdn`

- Updated `src/main.rs` to include `__shell.gdn` in formatting checks

## Implementation Details

This change follows the existing pattern of built-in namespaces like `__fs`, `__random`, and `__reflect`. The rename from `shell()` to `run()` avoids naming confusion with `shell_arguments()` which remains in the prelude.

https://claude.ai/code/session_01HsftdZfW5vjMRuoSquN5Wu