### PR TITLE
Add try and catch keywords to Garden

### DIFF
--- a/editors/garden-mode.el
+++ b/editors/garden-mode.el
@@ -695,7 +695,7 @@ With a prefix argument, also save the stringified result to the kill ring."
          "import" "internal" "external" "public" "shared"
          "if" "else" "while" "return" "test" "match"
          "break" "continue" "for" "in" "assert"
-         "as" "method")
+         "as" "method" "try" "catch")
        'symbols)
      . font-lock-keyword-face)
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2560,7 +2560,7 @@ fn parse_function_(
 
 pub(crate) const KEYWORDS: &[&str] = &[
     "let", "fun", "enum", "struct", "import", "if", "else", "while", "return", "test", "match",
-    "break", "continue", "for", "in", "assert", "as", "method", "public", "shared",
+    "break", "continue", "for", "in", "assert", "as", "method", "public", "shared", "try", "catch",
 ];
 
 pub(crate) fn placeholder_symbol(position: Position, id_gen: &mut IdGenerator) -> Symbol {


### PR DESCRIPTION
Add `try` and `catch` as recognized keywords in both the parser and the Emacs editor mode.

**Changes:**
- Updated `src/parser.rs` to include `"try"` and `"catch"` in the `KEYWORDS` constant
- Updated `editors/garden-mode.el` to highlight `"try"` and `"catch"` as keywords in the Emacs syntax highlighter

These keywords are now recognized by the language parser and will be properly syntax-highlighted in the Emacs editor.

https://claude.ai/code/session_01ArDQKNUiNLNJesjnWjfYZn