### PR TITLE
Add try/catch expression parsing and AST support

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -901,6 +901,11 @@ impl TypeCheckVisitor<'_> {
 
                 Type::unit()
             }
+            Expression_::Try(try_body, _catch_sym, catch_body) => {
+                self.infer_block(try_body, type_bindings, expected_return_ty);
+                self.infer_block(catch_body, type_bindings, expected_return_ty);
+                Type::unit()
+            }
             Expression_::Break | Expression_::Continue => {
                 // As with `return`, these never produce a value, they
                 // jump elsewhere. `let x = break` will never assign

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5950,6 +5950,17 @@ fn eval_expr(
                 }
             }
         }
+        Expression_::Try(_, _, _) => {
+            return Err((
+                RestoreValues(vec![]),
+                EvalError::Exception(ExceptionInfo {
+                    position: expr_position,
+                    message: ErrorMessage(vec![msgtext!(
+                        "try/catch is not yet implemented at runtime."
+                    )]),
+                }),
+            ));
+        }
         Expression_::Return(expr) => {
             if expr_state.done_children() {
                 // No more expressions to evaluate in this function, we're returning.

--- a/src/format.rs
+++ b/src/format.rs
@@ -414,6 +414,9 @@ impl Visitor for IndentationVisitor {
                 Expression_::ForIn(sym, expr, body) => {
                     self.visit_expr_for_in(sym, expr, body);
                 }
+                Expression_::Try(try_body, catch_sym, catch_body) => {
+                    self.visit_expr_try(try_body, catch_sym, catch_body);
+                }
                 Expression_::Break => {}
                 Expression_::Continue => {}
                 Expression_::Assign(sym, expr) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -609,6 +609,29 @@ fn parse_while(
     )
 }
 
+fn parse_try(
+    tokens: &mut TokenStream,
+    id_gen: &mut IdGenerator,
+    diagnostics: &mut Vec<ParseError>,
+) -> Expression {
+    let try_token = require_token(tokens, diagnostics, "try");
+
+    let try_body = parse_block(tokens, id_gen, diagnostics, false);
+
+    require_token(tokens, diagnostics, "catch");
+    require_token(tokens, diagnostics, "(");
+    let catch_sym = parse_symbol(tokens, id_gen, diagnostics, Some("catch variable name"));
+    require_token(tokens, diagnostics, ")");
+
+    let catch_body = parse_block(tokens, id_gen, diagnostics, false);
+
+    Expression::new(
+        Position::merge(&try_token.position, &catch_body.close_brace),
+        Expression_::Try(try_body, catch_sym, catch_body),
+        id_gen.next(),
+    )
+}
+
 fn parse_for_in(
     tokens: &mut TokenStream,
     id_gen: &mut IdGenerator,
@@ -1407,6 +1430,9 @@ fn parse_expression_no_trailing(
         }
         if token.text == "match" {
             return parse_match(tokens, id_gen, diagnostics);
+        }
+        if token.text == "try" {
+            return parse_try(tokens, id_gen, diagnostics);
         }
     }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -438,6 +438,10 @@ pub(crate) enum Expression_ {
     /// ```
     ForIn(LetDestination, Rc<Expression>, Block),
     /// ```garden
+    /// try { x } catch (e) { y }
+    /// ```
+    Try(Block, Symbol, Block),
+    /// ```garden
     /// break
     /// ```
     Break,

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -158,6 +158,9 @@ pub(crate) trait Visitor {
             Expression_::ForIn(sym, expr, body) => {
                 self.visit_expr_for_in(sym, expr, body);
             }
+            Expression_::Try(try_body, catch_sym, catch_body) => {
+                self.visit_expr_try(try_body, catch_sym, catch_body);
+            }
             Expression_::Break => {}
             Expression_::Continue => {}
             Expression_::Assign(sym, expr) => {
@@ -291,6 +294,12 @@ pub(crate) trait Visitor {
         self.visit_dest(dest);
         self.visit_expr(expr);
         self.visit_block(body);
+    }
+
+    fn visit_expr_try(&mut self, try_body: &Block, catch_sym: &Symbol, catch_body: &Block) {
+        self.visit_block(try_body);
+        self.visit_symbol(catch_sym);
+        self.visit_block(catch_body);
     }
 
     fn visit_expr_variable(&mut self, symbol: &Symbol) {

--- a/src/test_files/parser/try_catch.gdn
+++ b/src/test_files/parser/try_catch.gdn
@@ -1,0 +1,35 @@
+try { 1 } catch (e) { 2 }
+
+// args: reftest-ast
+// expected stdout:
+// Try(
+//     Block {
+//         open_brace: Position { ... },
+//         exprs: [
+//             Expression {
+//                 position: Position { ... },
+//                 expr_: IntLiteral(
+//                     1,
+//                 ),
+//                 value_is_used: true,
+//                 id: SyntaxId(0),
+//             },
+//         ],
+//         close_brace: Position { ... },
+//     },
+//     Symbol"e",
+//     Block {
+//         open_brace: Position { ... },
+//         exprs: [
+//             Expression {
+//                 position: Position { ... },
+//                 expr_: IntLiteral(
+//                     2,
+//                 ),
+//                 value_is_used: true,
+//                 id: SyntaxId(2),
+//             },
+//         ],
+//         close_brace: Position { ... },
+//     },
+// )


### PR DESCRIPTION
Add parsing and AST representation for try/catch expressions in Garden.

## Summary
This change introduces try/catch expression support to the Garden language. The parser now recognizes `try { ... } catch (e) { ... }` syntax and constructs the appropriate AST nodes. Runtime evaluation and type checking are stubbed out for future implementation.

## Changes
- **Parser**: Added `parse_try()` function to handle try/catch syntax with a catch variable binding
- **AST**: Added `Try(Block, Symbol, Block)` variant to `Expression_` enum to represent try/catch expressions
- **Visitor**: Implemented `visit_expr_try()` method to traverse try/catch nodes during AST walks
- **Type Checker**: Added type inference for try/catch (currently returns `unit()` type)
- **Formatter**: Added indentation visitor support for try/catch expressions
- **Runtime**: Added error stub for try/catch evaluation with a "not yet implemented" message
- **Tests**: Added reftest file demonstrating try/catch parsing and expected AST output

## Implementation Details
- The catch variable is parsed as a symbol and stored in the AST
- Both try and catch blocks are parsed as regular blocks
- Type checking currently treats try/catch as a unit-returning expression
- Runtime evaluation is not yet implemented and will return an error if executed

https://claude.ai/code/session_01KUAqF5Rj6Sm2ANWce3V5Zk