### PR TITLE
Add is_tty() function to shell module

### DIFF
--- a/src/__shell.gdn
+++ b/src/__shell.gdn
@@ -30,3 +30,14 @@ test get_env {
   let nonexistent = get_env("THIS_VARIABLE_SHOULD_NOT_EXIST_12345")
   assert(nonexistent.is_none())
 }
+
+/// Return `True` if stdout is connected to a terminal (TTY), or
+/// `False` if stdout has been redirected to a file or pipe.
+///
+/// ```
+/// import "__shell.gdn" as shell
+/// shell::is_tty()
+/// ```
+public fun is_tty(): Bool {
+  __BUILT_IN_IMPLEMENTATION
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3210,6 +3210,23 @@ fn eval_built_in_call(
                 env.push_value(value);
             }
         }
+        BuiltInFunctionKind::ShellIsTty => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                0,
+                arg_positions,
+                arg_values,
+            )?;
+
+            if expr_value_is_used {
+                use std::io::IsTerminal as _;
+                env.push_value(Value::bool(std::io::stdout().is_terminal()));
+            }
+        }
         BuiltInFunctionKind::ReflectKeywords => {
             check_arity(
                 &SymbolName {

--- a/src/values.rs
+++ b/src/values.rs
@@ -399,6 +399,7 @@ pub(crate) enum BuiltInFunctionKind {
     PreludeThrow,
 
     ShellGetEnv,
+    ShellIsTty,
     ShellRun,
 
     FsCopyFile,
@@ -438,9 +439,9 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::PreludeReadLine
             | BuiltInFunctionKind::PreludeSourceDirectory
             | BuiltInFunctionKind::PreludeShellArguments => PathBuf::from("__prelude.gdn"),
-            BuiltInFunctionKind::ShellRun | BuiltInFunctionKind::ShellGetEnv => {
-                PathBuf::from("__shell.gdn")
-            }
+            BuiltInFunctionKind::ShellRun
+            | BuiltInFunctionKind::ShellGetEnv
+            | BuiltInFunctionKind::ShellIsTty => PathBuf::from("__shell.gdn"),
             BuiltInFunctionKind::FsWriteFile
             | BuiltInFunctionKind::FsListDirectory
             | BuiltInFunctionKind::FsWorkingDirectory
@@ -497,6 +498,7 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::ReflectNamespaceFunctions => "namespace_functions",
             BuiltInFunctionKind::ReflectMethodsForType => "methods_for_type",
             BuiltInFunctionKind::ShellGetEnv => "get_env",
+            BuiltInFunctionKind::ShellIsTty => "is_tty",
             BuiltInFunctionKind::ReflectKeywords => "keywords",
             BuiltInFunctionKind::RandomRandomInt => "int",
             BuiltInFunctionKind::FsCreateDir => "create_dir",


### PR DESCRIPTION
Add a new `is_tty()` function to the `__shell` module that detects whether stdout is connected to a terminal.

## Changes

- Added `ShellIsTty` variant to `BuiltInFunctionKind` enum
- Implemented evaluation logic using Rust's `std::io::IsTerminal` trait to check if stdout is a TTY
- Added public `is_tty()` function to `__shell.gdn` with documentation and usage example
- Updated the built-in function kind display and module path mappings

## Implementation Details

The function returns a `Bool` indicating whether stdout is connected to a terminal (true) or has been redirected to a file or pipe (false). The implementation uses Rust's standard library `IsTerminal` trait for cross-platform TTY detection.

https://claude.ai/code/session_01BksZQ5xDGrQQ38aVyfSxTK