### PR TITLE
Add sort_nums function to prelude

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -769,6 +769,31 @@ test list_enumerate {
   assert(["a", "b"].enumerate() == [(0, "a"), (1, "b")])
 }
 
+/// Return a new list of these integers sorted in ascending order.
+///
+/// ```
+/// sort_nums([3, 1, 2]) //-> [1, 2, 3]
+/// ```
+public fun sort_nums(items: List<Int>): List<Int> {
+  match items.first() {
+    None => [],
+    Some(pivot) => {
+      let rest = items.slice(1, items.len())
+      let smaller = rest.filter(fun(x: Int) { x < pivot })
+      let larger = rest.filter(fun(x: Int) { x >= pivot })
+      sort_nums(smaller).concat([pivot]).concat(sort_nums(larger))
+    },
+  }
+}
+
+test sort_nums {
+  assert(sort_nums([]) == [])
+  assert(sort_nums([1]) == [1])
+  assert(sort_nums([3, 1, 2]) == [1, 2, 3])
+  assert(sort_nums([2, 1, 2, 1]) == [1, 1, 2, 2])
+  assert(sort_nums([-1, 5, 0, -3, 10]) == [-3, -1, 0, 5, 10])
+}
+
 /// The option type. Use this when you might have a value, but might
 /// not.
 enum Option<T> {

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 882,
+//     "line": 907,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,6 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:882>
+// <fun println __prelude.gdn:907>
 // <closure string_repr_of_fun.gdn:6>
 


### PR DESCRIPTION
Adds a new `sort_nums` function to the Garden prelude that sorts a list of integers in ascending order using a quicksort-style recursive algorithm.

## Changes

- Added `sort_nums(items: List<Int>): List<Int>` function that implements sorting by partitioning around a pivot element
- Includes comprehensive test coverage with edge cases (empty list, single element, duplicates, negative numbers)
- Updated line number references in test files to reflect the new function's position in `__prelude.gdn`

## Implementation Details

The function uses a recursive approach that:
1. Handles the base case of an empty list
2. Selects the first element as a pivot
3. Partitions remaining elements into smaller and larger sublists
4. Recursively sorts each partition and concatenates the results

https://claude.ai/code/session_01VGsYViYRmWQ3kM5NrShduF