### PR TITLE
Implement dbg() built-in to write debug output to stderr

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -40,7 +40,8 @@ enum Result<T, E> {
   Err(E),
 }
 
-/// Write an arbitrary value to stdout, along with debugging metadata.
+/// Write an arbitrary value to stderr, along with the source file
+/// name and line number.
 ///
 /// Returns the input, so you can use `dbg` in larger expressions
 /// `foo(dbg(bar()))`.
@@ -49,8 +50,7 @@ enum Result<T, E> {
 /// dbg([1, 2])
 /// ```
 public fun dbg<T>(value: T): T {
-  println(string_repr(value))
-  value
+  __BUILT_IN_IMPLEMENTATION
 }
 
 /// Throw an exception because you haven't written this code yet.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2970,6 +2970,62 @@ fn eval_built_in_call(
                 env.push_value(Value::new(Value_::String(arg_values[0].display(env))));
             }
         }
+        BuiltInFunctionKind::PreludeDbg => {
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let rel_path =
+                crate::parser::vfs::to_project_relative(&position.path, &env.project_root);
+            let value_repr = arg_values[0].display(env);
+            let arg_src = env.vfs.pos_src(&arg_positions[0]).unwrap_or("").to_owned();
+
+            let header = format!(
+                "[{}:{}:{}]",
+                rel_path.display(),
+                position.line_number + 1,
+                position.column + 1,
+            );
+            let line = if arg_src.is_empty() {
+                format!("{header} //-> {value_repr}\n")
+            } else {
+                format!("{header} {arg_src} //-> {value_repr}\n")
+            };
+
+            match &session.stdout_mode {
+                StdoutMode::WriteDirectly => {
+                    eprint!("{line}");
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::ReplSession) => {
+                    let response = Response {
+                        kind: ResponseKind::PrintedStderr { s: line.clone() },
+                        position: None,
+                        id: None,
+                    };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteJson(StdoutJsonFormat::Playground) => {
+                    let response = ResponseKind::PrintedStderr { s: line.clone() };
+                    print_as_json(&response, session.pretty_print_json);
+                }
+                StdoutMode::WriteToNReplBuffers { stderr_buf, .. } => {
+                    let mut b = stderr_buf.lock().expect("stderr buffer poisoned");
+                    b.push_str(&line);
+                }
+                StdoutMode::DoNotWrite => {}
+            }
+
+            if expr_value_is_used {
+                env.push_value(arg_values[0].clone());
+            }
+        }
         BuiltInFunctionKind::ReflectNamespaceFunctions => {
             check_arity(
                 &SymbolName {

--- a/src/test_files/json_session/call_in_context.json
+++ b/src/test_files/json_session/call_in_context.json
@@ -71,8 +71,8 @@
 // }
 // {
 //   "kind": {
-//     "printed": {
-//       "s": "1\n"
+//     "printed_stderr": {
+//       "s": "[__user.gdn:1:1] x //-> 1\n"
 //     }
 //   },
 //   "position": null

--- a/src/test_files/runtime/add_assign.gdn
+++ b/src/test_files/runtime/add_assign.gdn
@@ -5,4 +5,4 @@
 }
 
 // args: run
-// expected stdout: 11
+// expected stderr: [src/test_files/runtime/add_assign.gdn:4:3] i //-> 11

--- a/src/test_files/runtime/assign_closure_to_local.gdn
+++ b/src/test_files/runtime/assign_closure_to_local.gdn
@@ -24,4 +24,4 @@ fun stuff() {
 stuff()
 
 // args: run
-// expected stdout: 5
+// expected stderr: [src/test_files/runtime/assign_closure_to_local.gdn:21:3] f(2, 3) //-> 5

--- a/src/test_files/runtime/check_snippet.gdn
+++ b/src/test_files/runtime/check_snippet.gdn
@@ -5,4 +5,6 @@ import "__reflect.gdn" as reflect
 }
 
 // args: run
-// expected stdout: Ok(Unit)
+// expected stderr:
+// [src/test_files/runtime/check_snippet.gdn:4:3] reflect::check_snippet("True", Path{ p: "__snippet.gdn" }) //-> Ok(Unit)
+

--- a/src/test_files/runtime/dict_duplicate_keys.gdn
+++ b/src/test_files/runtime/dict_duplicate_keys.gdn
@@ -1,4 +1,6 @@
 dbg(Dict["a" => "hello", "a" => "world"])
 
 // args: run
-// expected stdout: Dict["a" => "world"]
+// expected stderr:
+// [src/test_files/runtime/dict_duplicate_keys.gdn:1:1] Dict["a" => "hello", "a" => "world"] //-> Dict["a" => "world"]
+

--- a/src/test_files/runtime/dict_literal.gdn
+++ b/src/test_files/runtime/dict_literal.gdn
@@ -6,4 +6,6 @@ fun get_dict(): Dict<String> {
 dbg(get_dict())
 
 // args: run
-// expected stdout: Dict["a" => "hello", "bc" => "world", "z" => ""]
+// expected stderr:
+// [src/test_files/runtime/dict_literal.gdn:6:1] get_dict() //-> Dict["a" => "hello", "bc" => "world", "z" => ""]
+

--- a/src/test_files/runtime/dict_methods.gdn
+++ b/src/test_files/runtime/dict_methods.gdn
@@ -19,10 +19,11 @@ dbg(d.items())
 print_dict(d.remove("x"))
 
 // args: run
-// expected stdout:
-// Some(1)
-// None
-// Dict["x" => 1, "y" => 42]
-// Dict["x" => 1, "y" => 43]
-// [("x", 1), ("y", 43)]
-// Dict["y" => 43]
+// expected stderr:
+// [src/test_files/runtime/dict_methods.gdn:8:1] d.get("x") //-> Some(1)
+// [src/test_files/runtime/dict_methods.gdn:9:1] d.get("y") //-> None
+// [src/test_files/runtime/dict_methods.gdn:3:3] d //-> Dict["x" => 1, "y" => 42]
+// [src/test_files/runtime/dict_methods.gdn:3:3] d //-> Dict["x" => 1, "y" => 43]
+// [src/test_files/runtime/dict_methods.gdn:17:1] d.items() //-> [("x", 1), ("y", 43)]
+// [src/test_files/runtime/dict_methods.gdn:3:3] d //-> Dict["y" => 43]
+

--- a/src/test_files/runtime/exponent.gdn
+++ b/src/test_files/runtime/exponent.gdn
@@ -3,4 +3,4 @@
 }
 
 // args: run
-// expected stdout: 1024
+// expected stderr: [src/test_files/runtime/exponent.gdn:2:3] 2 ** 10 //-> 1024

--- a/src/test_files/runtime/float_arithmetic.gdn
+++ b/src/test_files/runtime/float_arithmetic.gdn
@@ -6,8 +6,9 @@
 }
 
 // args: run
-// expected stdout:
-// 1.75
-// -1.25
-// 5.1
-// 0.3333333333333333
+// expected stderr:
+// [src/test_files/runtime/float_arithmetic.gdn:2:3] 0.25 +. 1.5 //-> 1.75
+// [src/test_files/runtime/float_arithmetic.gdn:3:3] 0.25 -. 1.5 //-> -1.25
+// [src/test_files/runtime/float_arithmetic.gdn:4:3] 0.5 *. 10.2 //-> 5.1
+// [src/test_files/runtime/float_arithmetic.gdn:5:3] 1.0 /. 3.0 //-> 0.3333333333333333
+

--- a/src/test_files/runtime/float_rounding.gdn
+++ b/src/test_files/runtime/float_rounding.gdn
@@ -7,8 +7,9 @@
 }
 
 // args: run
-// expected stdout:
-// 1
-// 2
-// -1
-// -2
+// expected stderr:
+// [src/test_files/runtime/float_rounding.gdn:2:3] 1.2.floor() //-> 1
+// [src/test_files/runtime/float_rounding.gdn:3:3] 1.2.ceil() //-> 2
+// [src/test_files/runtime/float_rounding.gdn:5:3] -1.2.ceil() //-> -1
+// [src/test_files/runtime/float_rounding.gdn:6:3] -1.2.floor() //-> -2
+

--- a/src/test_files/runtime/float_whole_number_repr.gdn
+++ b/src/test_files/runtime/float_whole_number_repr.gdn
@@ -4,6 +4,7 @@
 }
 
 // args: run
-// expected stdout:
-// 1.0
-// -1.01
+// expected stderr:
+// [src/test_files/runtime/float_whole_number_repr.gdn:2:3] 1.0 //-> 1.0
+// [src/test_files/runtime/float_whole_number_repr.gdn:3:3] -1.010 //-> -1.01
+

--- a/src/test_files/runtime/for.gdn
+++ b/src/test_files/runtime/for.gdn
@@ -27,9 +27,10 @@ fun foo(): String { "abc" }
 }
 
 // args: run
-// expected stdout:
-// 1
-// 2
-// 3
-// 2
-// 12
+// expected stderr:
+// [src/test_files/runtime/for.gdn:16:5] item //-> 1
+// [src/test_files/runtime/for.gdn:16:5] item //-> 2
+// [src/test_files/runtime/for.gdn:16:5] item //-> 3
+// [src/test_files/runtime/for.gdn:25:5] x * y //-> 2
+// [src/test_files/runtime/for.gdn:25:5] x * y //-> 12
+

--- a/src/test_files/runtime/for_continue.gdn
+++ b/src/test_files/runtime/for_continue.gdn
@@ -10,8 +10,9 @@
 }
 
 // args: run
-// expected stdout:
-// 1
-// 2
-// 4
-// 5
+// expected stderr:
+// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 1
+// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 2
+// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 4
+// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 5
+

--- a/src/test_files/runtime/import.gdn
+++ b/src/test_files/runtime/import.gdn
@@ -5,4 +5,4 @@ import "./lib.gdn"
 }
 
 // args: run
-// expected stdout: 42
+// expected stderr: [src/test_files/runtime/import.gdn:4:3] foo() //-> 42

--- a/src/test_files/runtime/import_as.gdn
+++ b/src/test_files/runtime/import_as.gdn
@@ -5,4 +5,4 @@ import "./lib.gdn" as f
 }
 
 // args: run
-// expected stdout: 42
+// expected stderr: [src/test_files/runtime/import_as.gdn:4:3] f::foo() //-> 42

--- a/src/test_files/runtime/int_as_float.gdn
+++ b/src/test_files/runtime/int_as_float.gdn
@@ -5,7 +5,8 @@
 }
 
 // args: run
-// expected stdout:
-// 1.0
-// 0.0
-// -3.0
+// expected stderr:
+// [src/test_files/runtime/int_as_float.gdn:2:3] 1.as_float() //-> 1.0
+// [src/test_files/runtime/int_as_float.gdn:3:3] 0.as_float() //-> 0.0
+// [src/test_files/runtime/int_as_float.gdn:4:3] (-3).as_float() //-> -3.0
+

--- a/src/test_files/runtime/integer_underscores.gdn
+++ b/src/test_files/runtime/integer_underscores.gdn
@@ -4,4 +4,4 @@
 }
 
 // args: run
-// expected stdout: 1000
+// expected stderr: [src/test_files/runtime/integer_underscores.gdn:3:3] i //-> 1000

--- a/src/test_files/runtime/list_get.gdn
+++ b/src/test_files/runtime/list_get.gdn
@@ -5,10 +5,10 @@ dbg(items.get(0))
 dbg(items.get("oh no wrong type"))
 
 // args: run
-// expected stdout: Some("hello")
-
 // expected stderr:
+// [src/test_files/runtime/list_get.gdn:3:1] items.get(0) //-> Some("hello")
 // Exception: Expected `Int` but `"oh no wrong type"` has type `String`.
 // -| src/test_files/runtime/list_get.gdn:5:15	 __toplevel__
 // 5| dbg(items.get("oh no wrong type"))
 //  |               ^^^^^^^^^^^^^^^^^^
+

--- a/src/test_files/runtime/list_literal_and_appended.gdn
+++ b/src/test_files/runtime/list_literal_and_appended.gdn
@@ -9,4 +9,6 @@
 }
 
 // args: run
-// expected stdout: True
+// expected stderr:
+// [src/test_files/runtime/list_literal_and_appended.gdn:8:5] literal == changed //-> True
+

--- a/src/test_files/runtime/loop_break.gdn
+++ b/src/test_files/runtime/loop_break.gdn
@@ -12,4 +12,4 @@
 }
 
 // args: run
-// expected stdout: 10
+// expected stderr: [src/test_files/runtime/loop_break.gdn:11:5] i //-> 10

--- a/src/test_files/runtime/loop_continue.gdn
+++ b/src/test_files/runtime/loop_continue.gdn
@@ -14,9 +14,10 @@
 }
 
 // args: run
-// expected stdout:
-// 1
-// 2
-// 4
-// 5
-// "done"
+// expected stderr:
+// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 1
+// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 2
+// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 4
+// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 5
+// [src/test_files/runtime/loop_continue.gdn:13:5] "done" //-> "done"
+

--- a/src/test_files/runtime/match_destructure.gdn
+++ b/src/test_files/runtime/match_destructure.gdn
@@ -17,10 +17,10 @@
 }
 
 // args: run
-// expected stdout: 3
-
 // expected stderr:
+// [src/test_files/runtime/match_destructure.gdn:5:7] x + y //-> 3
 // Exception: Expected a tuple of 2 items, but got `String`.
 // --| src/test_files/runtime/match_destructure.gdn:12:5	 __toplevel__
 // 12|     Some((_, _)) => {
 //   |     ^^^^
+

--- a/src/test_files/runtime/match_variant_no_payload.gdn
+++ b/src/test_files/runtime/match_variant_no_payload.gdn
@@ -11,4 +11,6 @@ fun takes_opt(v: Option<Int>): Int {
 }
 
 // args: run
-// expected stdout: 123
+// expected stderr:
+// [src/test_files/runtime/match_variant_no_payload.gdn:9:5] takes_opt(None) //-> 123
+

--- a/src/test_files/runtime/modulo.gdn
+++ b/src/test_files/runtime/modulo.gdn
@@ -5,12 +5,11 @@
 }
 
 // args: run
-// expected stdout:
-// 1
-// 2
-
 // expected stderr:
+// [src/test_files/runtime/modulo.gdn:2:3] 11 % 5 //-> 1
+// [src/test_files/runtime/modulo.gdn:3:3] -4 % 3 //-> 2
 // Exception: Tried to calculate the remainder of dividing 10 by zero.
 // -| src/test_files/runtime/modulo.gdn:4:3	 __toplevel__
 // 4|   10 % 0
 //  |   ^^^^^^
+

--- a/src/test_files/runtime/read_missing_file_relative.gdn
+++ b/src/test_files/runtime/read_missing_file_relative.gdn
@@ -10,4 +10,6 @@ import "__fs.gdn" as fs
 }
 
 // args: run
-// expected stdout: Err("Could not read `no_such_file_garden.txt` (relative to `/tmp`). No such file.")
+// expected stderr:
+// [src/test_files/runtime/read_missing_file_relative.gdn:9:3] Path{ p: "no_such_file_garden.txt" }.read() //-> Err("Could not read `no_such_file_garden.txt` (relative to `/tmp`). No such file.")
+

--- a/src/test_files/runtime/redefine_type.gdn
+++ b/src/test_files/runtime/redefine_type.gdn
@@ -17,4 +17,6 @@ struct Foo {
 }
 
 // args: run
-// expected stdout: 123
+// expected stderr:
+// [src/test_files/runtime/redefine_type.gdn:16:3] Foo{ name: "" }.do_stuff() //-> 123
+

--- a/src/test_files/runtime/return_generic.gdn
+++ b/src/test_files/runtime/return_generic.gdn
@@ -7,4 +7,6 @@ fun option_identity<T>(value: Option<T>): Option<T> {
 }
 
 // args: run
-// expected stdout: Some(1)
+// expected stderr:
+// [src/test_files/runtime/return_generic.gdn:6:5] option_identity(Some(1)) //-> Some(1)
+

--- a/src/test_files/runtime/shell_arguments.gdn
+++ b/src/test_files/runtime/shell_arguments.gdn
@@ -6,4 +6,4 @@
 }
 
 // args: run
-// expected stdout: []
+// expected stderr: [src/test_files/runtime/shell_arguments.gdn:4:3] shell_arguments() //-> []

--- a/src/test_files/runtime/shell_invalid_command.gdn
+++ b/src/test_files/runtime/shell_invalid_command.gdn
@@ -5,4 +5,5 @@ import "__shell.gdn" as shell
 }
 
 // args: run
-// expected stdout: Err((-1, "No such file or directory (os error 2)"))
+// expected stderr:
+// [src/test_files/runtime/shell_invalid_command.gdn:4:5] shell::run("no_such_command", []) //-> Err((-1, "No such file or directory (os error 2)"))

--- a/src/test_files/runtime/shell_tuple.gdn
+++ b/src/test_files/runtime/shell_tuple.gdn
@@ -7,6 +7,7 @@ import "__shell.gdn" as shell
 }
 
 // args: run
-// expected stdout:
-// "out\n"
-// "err\n"
+// expected stderr:
+// [src/test_files/runtime/shell_tuple.gdn:5:5] stdout //-> "out\n"
+// [src/test_files/runtime/shell_tuple.gdn:6:5] stderr //-> "err\n"
+

--- a/src/test_files/runtime/source_directory.gdn
+++ b/src/test_files/runtime/source_directory.gdn
@@ -3,4 +3,6 @@
 }
 
 // args: run
-// expected stdout: Some("source_directory.gdn")
+// expected stderr:
+// [src/test_files/runtime/source_directory.gdn:2:3] source_directory().or_throw().file_name() //-> Some("source_directory.gdn")
+

--- a/src/test_files/runtime/string_concat_operator.gdn
+++ b/src/test_files/runtime/string_concat_operator.gdn
@@ -3,4 +3,4 @@
 }
 
 // args: run
-// expected stdout: "abcd"
+// expected stderr: [src/test_files/runtime/string_concat_operator.gdn:2:5] "ab" ^ "cd" //-> "abcd"

--- a/src/test_files/runtime/struct_access.gdn
+++ b/src/test_files/runtime/struct_access.gdn
@@ -12,4 +12,4 @@ fun get_x(foo: Foo): Int {
 }
 
 // args: run
-// expected stdout: 3
+// expected stderr: [src/test_files/runtime/struct_access.gdn:10:5] get_x(Foo{ x: 1 + 2 }) //-> 3

--- a/src/test_files/runtime/struct_create.gdn
+++ b/src/test_files/runtime/struct_create.gdn
@@ -9,4 +9,6 @@ struct Foo {
 }
 
 // args: run
-// expected stdout: Foo{ x: 3, y: "abc" }
+// expected stderr:
+// [src/test_files/runtime/struct_create.gdn:7:5] Foo{ x: 1 + 2, y: "abc" } //-> Foo{ x: 3, y: "abc" }
+

--- a/src/test_files/runtime/struct_method.gdn
+++ b/src/test_files/runtime/struct_method.gdn
@@ -12,4 +12,4 @@ method get_x(this: Foo): Int {
 }
 
 // args: run
-// expected stdout: 123
+// expected stderr: [src/test_files/runtime/struct_method.gdn:11:3] f.get_x() //-> 123

--- a/src/test_files/runtime/tuple.gdn
+++ b/src/test_files/runtime/tuple.gdn
@@ -10,6 +10,7 @@ fun return_tuple(): (Int, String) {
 }
 
 // args: run
-// expected stdout:
-// (123, "foo")
-// 123
+// expected stderr:
+// [src/test_files/runtime/tuple.gdn:7:5] v //-> (123, "foo")
+// [src/test_files/runtime/tuple.gdn:9:5] i //-> 123
+

--- a/src/test_files/runtime/working_directory.gdn
+++ b/src/test_files/runtime/working_directory.gdn
@@ -6,4 +6,6 @@ import "__fs.gdn" as fs
 }
 
 // args: run
-// expected stdout: Path{ p: "/tmp" }
+// expected stderr:
+// [src/test_files/runtime/working_directory.gdn:5:3] fs::working_directory() //-> Path{ p: "/tmp" }
+

--- a/src/test_files/runtime/write_file_missing_directory.gdn
+++ b/src/test_files/runtime/write_file_missing_directory.gdn
@@ -9,7 +9,8 @@ dbg(Path{ p: "/tmp/no_such_dir_garden/foo.txt" }.read())
 dbg(fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }))
 
 // args: run
-// expected stdout:
-// Err("Could not read directory `/tmp/no_such_dir_garden/`. No such file or directory (os error 2)")
-// Err("Could not read `/tmp/no_such_dir_garden/foo.txt`. No such file.")
-// Err("Could not write `/tmp/no_such_dir_garden/bar.txt`. No such file or directory (os error 2)")
+// expected stderr:
+// [src/test_files/runtime/write_file_missing_directory.gdn:5:1] fs::list_directory(Path{ p: "/tmp/no_such_dir_garden/" }) //-> Err("Could not read directory `/tmp/no_such_dir_garden/`. No such file or directory (os error 2)")
+// [src/test_files/runtime/write_file_missing_directory.gdn:7:1] Path{ p: "/tmp/no_such_dir_garden/foo.txt" }.read() //-> Err("Could not read `/tmp/no_such_dir_garden/foo.txt`. No such file.")
+// [src/test_files/runtime/write_file_missing_directory.gdn:9:1] fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }) //-> Err("Could not write `/tmp/no_such_dir_garden/bar.txt`. No such file or directory (os error 2)")
+

--- a/src/values.rs
+++ b/src/values.rs
@@ -388,6 +388,7 @@ pub(crate) fn type_representation(value: &Value) -> TypeName {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub(crate) enum BuiltInFunctionKind {
+    PreludeDbg,
     PreludeEprint,
     PreludeEprintln,
     PreludePrint,
@@ -432,6 +433,7 @@ impl BuiltInFunctionKind {
         match self {
             BuiltInFunctionKind::PreludeThrow
             | BuiltInFunctionKind::PreludeStringRepr
+            | BuiltInFunctionKind::PreludeDbg
             | BuiltInFunctionKind::PreludePrint
             | BuiltInFunctionKind::PreludePrintln
             | BuiltInFunctionKind::PreludeEprint
@@ -476,6 +478,7 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::FsListDirectory => "list_directory",
             BuiltInFunctionKind::ShellRun => "run",
             BuiltInFunctionKind::PreludeStringRepr => "string_repr",
+            BuiltInFunctionKind::PreludeDbg => "dbg",
             BuiltInFunctionKind::PreludePrint => "print",
             BuiltInFunctionKind::PreludePrintln => "println",
             BuiltInFunctionKind::PreludeEprint => "eprint",


### PR DESCRIPTION
Implement the `dbg()` built-in function as a proper built-in with special handling, rather than a simple wrapper around `println()`. The function now writes debug output to stderr with source location information (file, line, and column) and the source code of the expression being debugged.

## Key Changes

- Added `PreludeDbg` variant to `BuiltInFunctionKind` enum in `src/values.rs`
- Implemented `dbg()` evaluation in `src/eval.rs` with:
  - Source location tracking (file path, line number, column)
  - Source code extraction from the debugged expression
  - Formatted output: `[file:line:col] source = value`
  - Support for all stdout modes (direct write, JSON REPL, JSON Playground, nREPL buffers)
  - Return value passthrough (returns the input value unchanged)
- Updated `__prelude.gdn` to mark `dbg()` as a built-in implementation with updated documentation
- Updated all runtime test files to expect stderr output instead of stdout, reflecting the new behavior where `dbg()` writes to stderr with full source location context

## Implementation Details

The `dbg()` function now:
- Extracts the project-relative file path for cleaner output
- Retrieves the source code of the debugged expression from the VFS
- Formats output with file location and optional source code
- Respects the session's stdout mode configuration for different output contexts
- Maintains the expression's value for use in larger expressions (e.g., `foo(dbg(bar()))`)

https://claude.ai/code/session_01Jyhbf5VwY6pA5skzXYE1i8