### PR TITLE
Add Int::as_float() method to convert integers to floats

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -859,6 +859,15 @@ struct Int {
   __BUILT_IN_IMPLEMENTATION: NoValue,
 }
 
+/// Convert this integer to a floating point value.
+///
+/// ```
+/// 1.as_float() //-> 1.0
+/// ```
+public method as_float(this: Int): Float {
+  __BUILT_IN_IMPLEMENTATION
+}
+
 /// A 64-bit floating point number, such as `1.5` or `-1_000.00`.
 struct Float {
   __BUILT_IN_IMPLEMENTATION: NoValue,

--- a/src/env.rs
+++ b/src/env.rs
@@ -502,6 +502,7 @@ fn fresh_prelude(env: &mut Env, prelude_vfs_path: &VfsPathBuf) -> Rc<RefCell<Nam
                 ("floor", BuiltInMethodKind::FloatFloor),
             ],
         ),
+        ("Int", vec![("as_float", BuiltInMethodKind::IntAsFloat)]),
         (
             "List",
             vec![

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5122,6 +5122,45 @@ fn eval_built_in_method_call(
                 }
             }
         }
+        BuiltInMethodKind::IntAsFloat => {
+            check_arity(
+                &SymbolName {
+                    text: "Int::as_float".to_owned(),
+                },
+                receiver_value,
+                receiver_pos,
+                0,
+                arg_positions,
+                arg_values,
+            )?;
+
+            match receiver_value.as_ref() {
+                Value_::Int(i) => {
+                    if expr_value_is_used {
+                        env.push_value(Value::new(Value_::Float(*i as f64)));
+                    }
+                }
+                _ => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                    }
+                    saved_values.push(receiver_value.clone());
+
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: arg_positions[0].clone(),
+                            message: format_type_error(
+                                &TypeName { text: "Int".into() },
+                                receiver_value,
+                                env,
+                            ),
+                        }),
+                    ));
+                }
+            }
+        }
         BuiltInMethodKind::ListAppend => {
             check_arity(
                 &SymbolName {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -945,6 +945,7 @@ pub(crate) enum BuiltInMethodKind {
     DictSet,
     FloatCeil,
     FloatFloor,
+    IntAsFloat,
     ListAppend,
     ListContains,
     ListGet,

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 907,
+//     "line": 916,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/int_as_float.gdn
+++ b/src/test_files/runtime/int_as_float.gdn
@@ -1,0 +1,11 @@
+{
+  dbg(1.as_float())
+  dbg(0.as_float())
+  dbg((-3).as_float())
+}
+
+// args: run
+// expected stdout:
+// 1.0
+// 0.0
+// -3.0

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,6 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:907>
+// <fun println __prelude.gdn:916>
 // <closure string_repr_of_fun.gdn:6>
 


### PR DESCRIPTION
Adds a new built-in method `as_float()` to the `Int` type that converts an integer value to its floating point equivalent.

## Changes

- Added `IntAsFloat` variant to `BuiltInMethodKind` enum in `src/parser/ast.rs`
- Implemented the conversion logic in `eval_built_in_method_call()` in `src/eval.rs`, which casts the integer to `f64` and returns a `Float` value
- Registered the method in the prelude's `Int` struct in `src/__prelude.gdn` with documentation
- Added the method to the built-in method registry in `src/env.rs`
- Added a test case in `src/test_files/runtime/int_as_float.gdn` demonstrating conversion of positive, zero, and negative integers
- Updated line number references in `src/test_files/nrepl/lookup_prelude.jsonl` and `src/test_files/runtime/string_repr_of_fun.gdn` due to prelude changes

## Implementation Details

The method follows the standard pattern for built-in methods:
- Validates arity (expects 0 arguments)
- Matches on the receiver value type
- Casts `Int` to `f64` and wraps in a `Float` value
- Returns a type error if called on a non-integer value

https://claude.ai/code/session_01Uko23hmY7dzCZNimdAeT2M