### PR TITLE
Add string literal pattern matching support

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -749,9 +749,13 @@ impl TypeCheckVisitor<'_> {
         for (pattern, case_expr) in cases {
             self.bindings.enter_block();
 
-            if let Some(payload_dest) = &pattern.payload {
-                let payload_ty = enum_payload_type(self.env, &scrutinee_ty, &pattern.variant_sym);
-                self.set_dest_binding(payload_dest, &pattern.variant_sym.position, payload_ty);
+            if let Pattern::Variant {
+                variant_sym,
+                payload: Some(payload_dest),
+            } = pattern
+            {
+                let payload_ty = enum_payload_type(self.env, &scrutinee_ty, variant_sym);
+                self.set_dest_binding(payload_dest, &variant_sym.position, payload_ty);
             }
 
             let case_value_pos = match case_expr.exprs.last() {
@@ -779,97 +783,130 @@ impl TypeCheckVisitor<'_> {
 
             self.bindings.exit_block();
 
-            // Matching `_` works for any type.
-            if pattern.variant_sym.name.is_underscore() {
-                continue;
-            }
-
-            let Some(value) = self.get_var(&pattern.variant_sym.name) else {
-                self.diagnostics.push(Diagnostic {
-                    notes: vec![],
-                    fixes: vec![],
-                    severity: Severity::Error,
-                    message: ErrorMessage(vec![
-                        msgtext!("No such type "),
-                        msgcode!("{}", pattern.variant_sym.name),
-                        msgtext!("."),
-                    ]),
-                    position: pattern.variant_sym.position.clone(),
-                });
-                continue;
-            };
-
-            let pattern_type_name = match value.as_ref() {
-                Value_::EnumVariant { type_name, .. } => type_name,
-                Value_::EnumConstructor { type_name, .. } => type_name,
-                _ => {
-                    self.diagnostics.push(Diagnostic {
-                        notes: vec![],
-                        fixes: vec![],
-                        severity: Severity::Error,
-                        message: ErrorMessage(vec![
-                            msgtext!("Expected an enum variant here, but got "),
-                            msgcode!("{}", value.display(self.env)),
-                            msgtext!("."),
-                        ]),
-                        position: pattern.variant_sym.position.clone(),
-                    });
-                    continue;
+            match pattern {
+                Pattern::StringLiteral { position, .. } => {
+                    let Some(scrutinee_ty_name) = &scrutinee_ty_name else {
+                        continue;
+                    };
+                    if scrutinee_ty_name.is_no_value() {
+                        continue;
+                    }
+                    if scrutinee_ty_name.text != "String" {
+                        self.diagnostics.push(Diagnostic {
+                            notes: vec![],
+                            fixes: vec![],
+                            severity: Severity::Error,
+                            message: ErrorMessage(vec![
+                                msgtext!("This match case is for "),
+                                msgcode!("String"),
+                                msgtext!(", but you're matching on a "),
+                                msgcode!("{}", scrutinee_ty_name),
+                                msgtext!("."),
+                            ]),
+                            position: position.clone(),
+                        });
+                    }
                 }
-            };
+                Pattern::Variant {
+                    variant_sym,
+                    payload,
+                } => {
+                    // Matching `_` works for any type.
+                    if variant_sym.name.is_underscore() {
+                        continue;
+                    }
 
-            // A pattern must bind the payload exactly when the
-            // variant has one, otherwise the case can never match at
-            // runtime.
-            let variant_has_payload = matches!(value.as_ref(), Value_::EnumConstructor { .. });
-            if pattern.payload.is_some() && !variant_has_payload {
-                self.diagnostics.push(Diagnostic {
-                    notes: vec![],
-                    fixes: vec![],
-                    severity: Severity::Error,
-                    message: ErrorMessage(vec![
-                        msgcode!("{}", pattern.variant_sym.name),
-                        msgtext!(" does not have a payload, so this pattern should be written as "),
-                        msgcode!("{}", pattern.variant_sym.name),
-                        msgtext!("."),
-                    ]),
-                    position: pattern.variant_sym.position.clone(),
-                });
-            } else if pattern.payload.is_none() && variant_has_payload {
-                self.diagnostics.push(Diagnostic {
-                    notes: vec![],
-                    fixes: vec![],
-                    severity: Severity::Error,
-                    message: ErrorMessage(vec![
-                        msgcode!("{}", pattern.variant_sym.name),
-                        msgtext!(" has a payload, so this pattern should be written as "),
-                        msgcode!("{}(_)", pattern.variant_sym.name),
-                        msgtext!("."),
-                    ]),
-                    position: pattern.variant_sym.position.clone(),
-                });
-            }
+                    let Some(value) = self.get_var(&variant_sym.name) else {
+                        self.diagnostics.push(Diagnostic {
+                            notes: vec![],
+                            fixes: vec![],
+                            severity: Severity::Error,
+                            message: ErrorMessage(vec![
+                                msgtext!("No such type "),
+                                msgcode!("{}", variant_sym.name),
+                                msgtext!("."),
+                            ]),
+                            position: variant_sym.position.clone(),
+                        });
+                        continue;
+                    };
 
-            let Some(scrutinee_ty_name) = &scrutinee_ty_name else {
-                continue;
-            };
-            if scrutinee_ty_name.is_no_value() {
-                continue;
-            }
-            if pattern_type_name != scrutinee_ty_name {
-                self.diagnostics.push(Diagnostic {
-                    notes: vec![],
-                    fixes: vec![],
-                    severity: Severity::Error,
-                    message: ErrorMessage(vec![
-                        msgtext!("This match case is for "),
-                        msgcode!("{}", pattern_type_name),
-                        msgtext!(", but you're matching on a "),
-                        msgcode!("{}", scrutinee_ty_name),
-                        msgtext!("."),
-                    ]),
-                    position: pattern.variant_sym.position.clone(),
-                });
+                    let pattern_type_name = match value.as_ref() {
+                        Value_::EnumVariant { type_name, .. } => type_name,
+                        Value_::EnumConstructor { type_name, .. } => type_name,
+                        _ => {
+                            self.diagnostics.push(Diagnostic {
+                                notes: vec![],
+                                fixes: vec![],
+                                severity: Severity::Error,
+                                message: ErrorMessage(vec![
+                                    msgtext!("Expected an enum variant here, but got "),
+                                    msgcode!("{}", value.display(self.env)),
+                                    msgtext!("."),
+                                ]),
+                                position: variant_sym.position.clone(),
+                            });
+                            continue;
+                        }
+                    };
+
+                    // A pattern must bind the payload exactly when the
+                    // variant has one, otherwise the case can never match at
+                    // runtime.
+                    let variant_has_payload =
+                        matches!(value.as_ref(), Value_::EnumConstructor { .. });
+                    if payload.is_some() && !variant_has_payload {
+                        self.diagnostics.push(Diagnostic {
+                            notes: vec![],
+                            fixes: vec![],
+                            severity: Severity::Error,
+                            message: ErrorMessage(vec![
+                                msgcode!("{}", variant_sym.name),
+                                msgtext!(
+                                    " does not have a payload, so this pattern should be written as "
+                                ),
+                                msgcode!("{}", variant_sym.name),
+                                msgtext!("."),
+                            ]),
+                            position: variant_sym.position.clone(),
+                        });
+                    } else if payload.is_none() && variant_has_payload {
+                        self.diagnostics.push(Diagnostic {
+                            notes: vec![],
+                            fixes: vec![],
+                            severity: Severity::Error,
+                            message: ErrorMessage(vec![
+                                msgcode!("{}", variant_sym.name),
+                                msgtext!(" has a payload, so this pattern should be written as "),
+                                msgcode!("{}(_)", variant_sym.name),
+                                msgtext!("."),
+                            ]),
+                            position: variant_sym.position.clone(),
+                        });
+                    }
+
+                    let Some(scrutinee_ty_name) = &scrutinee_ty_name else {
+                        continue;
+                    };
+                    if scrutinee_ty_name.is_no_value() {
+                        continue;
+                    }
+                    if pattern_type_name != scrutinee_ty_name {
+                        self.diagnostics.push(Diagnostic {
+                            notes: vec![],
+                            fixes: vec![],
+                            severity: Severity::Error,
+                            message: ErrorMessage(vec![
+                                msgtext!("This match case is for "),
+                                msgcode!("{}", pattern_type_name),
+                                msgtext!(", but you're matching on a "),
+                                msgcode!("{}", scrutinee_ty_name),
+                                msgtext!("."),
+                            ]),
+                            position: variant_sym.position.clone(),
+                        });
+                    }
+                }
             }
         }
 
@@ -3022,6 +3059,11 @@ fn check_match_exhaustive(
     cases: &[(Pattern, Block)],
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    if type_name.text == "String" {
+        check_string_match_exhaustive(scrutinee_pos, cases, diagnostics);
+        return;
+    }
+
     let Some(type_def) = env.get_type_def(type_name) else {
         return;
     };
@@ -3081,7 +3123,7 @@ fn check_match_exhaustive(
                         msgcode!("_"),
                         msgtext!(" are never executed."),
                     ]),
-                    position: pattern.variant_sym.position.clone(),
+                    position: pattern.position().clone(),
                 });
                 prev_case_end = Some(&block.close_brace);
                 continue;
@@ -3089,12 +3131,18 @@ fn check_match_exhaustive(
 
             prev_case_end = Some(&block.close_brace);
 
-            if pattern.variant_sym.name.is_underscore() {
-                underscore_pos = Some(&pattern.variant_sym.position);
+            let Pattern::Variant { variant_sym, .. } = pattern else {
+                // String patterns on an enum scrutinee are reported
+                // as a type error elsewhere.
+                continue;
+            };
+
+            if variant_sym.name.is_underscore() {
+                underscore_pos = Some(&variant_sym.position);
                 continue;
             }
 
-            match variants_remaining.remove(&pattern.variant_sym.name) {
+            match variants_remaining.remove(&variant_sym.name) {
                 Some(_) => {
                     // First time we've seen this variant.
                 }
@@ -3106,7 +3154,7 @@ fn check_match_exhaustive(
                         message: ErrorMessage(vec![Text(
                             "Duplicate case in pattern match.".to_owned(),
                         )]),
-                        position: pattern.variant_sym.position.clone(),
+                        position: variant_sym.position.clone(),
                     });
                 }
             }
@@ -3183,7 +3231,7 @@ fn build_missing_cases_autofix(
     // If there are no cases, fall back to the match expression's
     // column + 4.
     let case_indent = match cases.first() {
-        Some((pattern, _)) => pattern.variant_sym.position.column,
+        Some((pattern, _)) => pattern.position().column,
         None => match_pos.column + 4,
     };
     let indent_str = " ".repeat(case_indent);
@@ -3223,6 +3271,56 @@ fn build_missing_cases_autofix(
         position: insert_pos,
         new_text,
     }]
+}
+
+fn check_string_match_exhaustive(
+    scrutinee_pos: &Position,
+    cases: &[(Pattern, Block)],
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut seen_underscore = false;
+    let mut seen_values: FxHashMap<String, ()> = FxHashMap::default();
+
+    for (pattern, _) in cases {
+        match pattern {
+            Pattern::Variant { variant_sym, .. } => {
+                if variant_sym.name.is_underscore() {
+                    seen_underscore = true;
+                }
+                // Non-wildcard variant patterns on a string scrutinee
+                // are reported as a type error elsewhere.
+            }
+            Pattern::StringLiteral { position, value } => {
+                if seen_values.insert(value.clone(), ()).is_some() {
+                    diagnostics.push(Diagnostic {
+                        notes: vec![],
+                        fixes: vec![],
+                        severity: Severity::Error,
+                        message: ErrorMessage(vec![Text(
+                            "Duplicate case in pattern match.".to_owned(),
+                        )]),
+                        position: position.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    if !seen_underscore {
+        diagnostics.push(Diagnostic {
+            notes: vec![],
+            fixes: vec![],
+            severity: Severity::Error,
+            message: ErrorMessage(vec![
+                msgtext!("This match expression on a "),
+                msgcode!("String"),
+                msgtext!(" is not exhaustive. Add a "),
+                msgcode!("_"),
+                msgtext!(" case to handle the remaining strings."),
+            ]),
+            position: scrutinee_pos.clone(),
+        });
+    }
 }
 
 fn format_mismatch_text(expected_desc: &str, actual_ty: &Type) -> ErrorMessage {

--- a/src/checks/unused_vars.rs
+++ b/src/checks/unused_vars.rs
@@ -596,7 +596,11 @@ impl Visitor for UnusedVariableVisitor {
             // variant, and that we've covered all the variants.
 
             self.push_scope();
-            if let Some(payload_dest) = &pattern.payload {
+            if let Pattern::Variant {
+                payload: Some(payload_dest),
+                ..
+            } = pattern
+            {
                 self.visit_dest(payload_dest);
             }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7608,6 +7608,16 @@ fn eval_match_cases(
         .pop_value()
         .expect("Popped an empty value stack for match");
 
+    if let Value_::String(scrutinee_str) = scrutinee_value.as_ref() {
+        return eval_string_match_cases(
+            env,
+            expr_value_is_used,
+            scrutinee_pos,
+            scrutinee_str,
+            cases,
+        );
+    }
+
     let Value_::EnumVariant {
         type_name: value_type_name,
         variant_idx: value_variant_idx,
@@ -7637,19 +7647,35 @@ fn eval_match_cases(
     };
 
     for (pattern, case_expr) in cases {
-        if pattern.variant_sym.name.is_underscore() {
+        let (variant_sym, pattern_payload) = match pattern {
+            Pattern::Variant {
+                variant_sym,
+                payload,
+            } => (variant_sym, payload),
+            Pattern::StringLiteral { position, .. } => {
+                let msg = ErrorMessage(vec![Text(
+                    "Cannot match a string pattern against an enum value.".to_owned(),
+                )]);
+                return Err(EvalError::Exception(ExceptionInfo {
+                    position: position.clone(),
+                    message: msg,
+                }));
+            }
+        };
+
+        if variant_sym.name.is_underscore() {
             eval_block(env, expr_value_is_used, case_expr);
             return Ok(());
         }
 
-        let Some(value) = get_var(&pattern.variant_sym, env) else {
+        let Some(value) = get_var(variant_sym, env) else {
             let msg = ErrorMessage(vec![
                 msgtext!("Expected an enum variant named "),
-                msgcode!("{}", pattern.variant_sym.name),
+                msgcode!("{}", variant_sym.name),
                 msgtext!(" but nothing is defined with that name."),
             ]);
             return Err(EvalError::Exception(ExceptionInfo {
-                position: pattern.variant_sym.position.clone(),
+                position: variant_sym.position.clone(),
                 message: msg,
             }));
         };
@@ -7672,7 +7698,7 @@ fn eval_match_cases(
                     value.display(env)
                 ))]);
                 return Err(EvalError::Exception(ExceptionInfo {
-                    position: pattern.variant_sym.position.clone(),
+                    position: variant_sym.position.clone(),
                     message: msg,
                 }));
             }
@@ -7680,7 +7706,7 @@ fn eval_match_cases(
 
         if value_type_name == pattern_type_name && *value_variant_idx == pattern_variant_idx {
             let mut bindings: Vec<(Symbol, Value)> = vec![];
-            match (&value_payload, &pattern.payload) {
+            match (&value_payload, pattern_payload) {
                 (Some(payload), Some(payload_dest)) => match payload_dest {
                     LetDestination::Symbol(symbol) => {
                         if !symbol.name.is_underscore() {
@@ -7700,7 +7726,7 @@ fn eval_match_cases(
                                     msgtext!("."),
                                 ]);
                                 return Err(EvalError::Exception(ExceptionInfo {
-                                    position: pattern.variant_sym.position.clone(),
+                                    position: variant_sym.position.clone(),
                                     message: msg,
                                 }));
                             }
@@ -7713,7 +7739,7 @@ fn eval_match_cases(
                                 items.len(),
                             )]);
                             return Err(EvalError::Exception(ExceptionInfo {
-                                position: pattern.variant_sym.position.clone(),
+                                position: variant_sym.position.clone(),
                                 message: msg,
                             }));
                         }
@@ -7739,6 +7765,54 @@ fn eval_match_cases(
             stack_frame.bindings_next_block = bindings;
             eval_block(env, expr_value_is_used, case_expr);
             return Ok(());
+        }
+    }
+
+    let msg = ErrorMessage(vec![Text(
+        "No cases in this `match` statement were reached.".to_owned(),
+    )]);
+    Err(EvalError::Exception(ExceptionInfo {
+        position: scrutinee_pos.clone(),
+        message: msg,
+    }))
+}
+
+fn eval_string_match_cases(
+    env: &mut Env,
+    expr_value_is_used: bool,
+    scrutinee_pos: &Position,
+    scrutinee_str: &str,
+    cases: &[(Pattern, Block)],
+) -> Result<(), EvalError> {
+    for (pattern, case_expr) in cases {
+        match pattern {
+            Pattern::Variant {
+                variant_sym,
+                payload: _,
+            } => {
+                if variant_sym.name.is_underscore() {
+                    let stack_frame = env.current_frame_mut();
+                    stack_frame.bindings_next_block = vec![];
+                    eval_block(env, expr_value_is_used, case_expr);
+                    return Ok(());
+                }
+
+                let msg = ErrorMessage(vec![Text(
+                    "Cannot match an enum variant pattern against a string value.".to_owned(),
+                )]);
+                return Err(EvalError::Exception(ExceptionInfo {
+                    position: variant_sym.position.clone(),
+                    message: msg,
+                }));
+            }
+            Pattern::StringLiteral { value, .. } => {
+                if value == scrutinee_str {
+                    let stack_frame = env.current_frame_mut();
+                    stack_frame.bindings_next_block = vec![];
+                    eval_block(env, expr_value_is_used, case_expr);
+                    return Ok(());
+                }
+            }
         }
     }
 

--- a/src/extract_function.rs
+++ b/src/extract_function.rs
@@ -261,7 +261,11 @@ impl Visitor for FreeVarsVisitor {
 
         for (pattern, block) in cases {
             self.local_bindings.push(FxHashSet::default());
-            if let Some(payload_dest) = &pattern.payload {
+            if let ast::Pattern::Variant {
+                payload: Some(payload_dest),
+                ..
+            } = pattern
+            {
                 self.insert_dest_bindings(payload_dest);
             }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -463,10 +463,11 @@ impl Visitor for IndentationVisitor {
             // Process each match arm
             for (pattern, case_block) in cases {
                 // Format the pattern line (e.g., "Some(v) => " or "None =>")
-                let pattern_line = pattern.variant_sym.position.line_number;
+                let pattern_pos = pattern.position();
+                let pattern_line = pattern_pos.line_number;
                 if !self.processed_lines.contains(&pattern_line) {
                     let target_indent = self.current_depth * 2;
-                    let current_indent = pattern.variant_sym.position.column;
+                    let current_indent = pattern_pos.column;
 
                     if current_indent != target_indent {
                         self.line_edits.push(LineEdit {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1041,6 +1041,19 @@ fn parse_pattern(
     id_gen: &mut IdGenerator,
     diagnostics: &mut Vec<ParseError>,
 ) -> Pattern {
+    if let Some(token) = tokens.peek() {
+        if token.text.starts_with('\"') {
+            let token = tokens.pop().unwrap();
+            let (errors, unescaped) = unescape_string(&token);
+            diagnostics.extend(errors);
+
+            return Pattern::StringLiteral {
+                position: token.position,
+                value: unescaped,
+            };
+        }
+    }
+
     let variant_sym = parse_symbol(tokens, id_gen, diagnostics, Some("variant name"));
 
     let payload = if peeked_symbol_is(tokens, "(") {
@@ -1052,7 +1065,7 @@ fn parse_pattern(
         None
     };
 
-    Pattern {
+    Pattern::Variant {
         variant_sym,
         payload,
     }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -317,14 +317,30 @@ impl AssignUpdateKind {
 /// ```garden
 /// match x {
 ///   Foo(bar) => {}
+///   "hello" => {}
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Pattern {
-    /// E.g. `Some` or `None`.
-    pub(crate) variant_sym: Symbol,
-    /// E.g. `foo` in `Some(foo) => `.
-    pub(crate) payload: Option<LetDestination>,
+pub(crate) enum Pattern {
+    /// An enum variant pattern, such as `Some(x)` or `None`, or the
+    /// wildcard pattern `_`.
+    Variant {
+        /// E.g. `Some` or `None`.
+        variant_sym: Symbol,
+        /// E.g. `foo` in `Some(foo) => `.
+        payload: Option<LetDestination>,
+    },
+    /// A string literal pattern, such as `"hello"`.
+    StringLiteral { position: Position, value: String },
+}
+
+impl Pattern {
+    pub(crate) fn position(&self) -> &Position {
+        match self {
+            Pattern::Variant { variant_sym, .. } => &variant_sym.position,
+            Pattern::StringLiteral { position, .. } => position,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq)]

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -268,9 +268,17 @@ pub(crate) trait Visitor {
     fn visit_expr_match(&mut self, scrutinee: &Expression, cases: &[(Pattern, Block)]) {
         self.visit_expr(scrutinee);
         for (pattern, case_expr) in cases {
-            self.visit_symbol(&pattern.variant_sym);
-            if let Some(dest) = &pattern.payload {
-                self.visit_dest(dest);
+            match pattern {
+                Pattern::Variant {
+                    variant_sym,
+                    payload,
+                } => {
+                    self.visit_symbol(variant_sym);
+                    if let Some(dest) = payload {
+                        self.visit_dest(dest);
+                    }
+                }
+                Pattern::StringLiteral { .. } => {}
             }
 
             self.visit_block(case_expr);

--- a/src/test_files/check/match_string_missing_wildcard.gdn
+++ b/src/test_files/check/match_string_missing_wildcard.gdn
@@ -1,0 +1,19 @@
+public fun describe(s: String): Int {
+  match s {
+    "hi" => 1,
+    "bye" => 2,
+  }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: This match expression on a `String` is not exhaustive. Add a `_` case to handle the remaining strings.
+// 
+// -| src/test_files/check/match_string_missing_wildcard.gdn:2:9
+// 1| public fun describe(s: String): Int {
+// 2|   match s {
+//  |         ^
+// 3|     "hi" => 1,
+// 4|     "bye" => 2,
+

--- a/src/test_files/parser/match_tuple.gdn
+++ b/src/test_files/parser/match_tuple.gdn
@@ -16,7 +16,7 @@ match foo {
 //     },
 //     [
 //         (
-//             Pattern {
+//             Variant {
 //                 variant_sym: Symbol"Some",
 //                 payload: Some(
 //                     Symbol(
@@ -57,7 +57,7 @@ match foo {
 //             },
 //         ),
 //         (
-//             Pattern {
+//             Variant {
 //                 variant_sym: Symbol"None",
 //                 payload: None,
 //             },
@@ -95,3 +95,4 @@ match foo {
 //         ),
 //     ],
 // )
+

--- a/src/test_files/runtime/match_string.gdn
+++ b/src/test_files/runtime/match_string.gdn
@@ -1,0 +1,19 @@
+fun describe(s: String): String {
+  match s {
+    "hello" => "greeting",
+    "bye" => "farewell",
+    _ => "unknown",
+  }
+}
+
+{
+  println(describe("hello"))
+  println(describe("bye"))
+  println(describe("other"))
+}
+
+// args: run
+// expected stdout:
+// greeting
+// farewell
+// unknown


### PR DESCRIPTION
Allow string literals as patterns in `match` expressions, alongside the existing enum variant patterns. A `_` case is required for exhaustiveness on `String` scrutinees.

```
match s {
  "hello" => 1,
  "bye" => 2,
  _ => 0,
}
```