### PR TITLE
Change shell::run error type to include exit code

### DIFF
--- a/src/__shell.gdn
+++ b/src/__shell.gdn
@@ -1,11 +1,15 @@
 /// Execute the given string as a shell command, and return a tuple
 /// of stdout and stderr.
 ///
+/// On failure, returns a tuple of the exit code and the combined
+/// stdout and stderr output. The exit code is `-1` if the command
+/// could not be spawned or was terminated by a signal.
+///
 /// ```
 /// import "__shell.gdn" as shell
 /// shell::run("ls", ["-l", "/"])
 /// ```
-public fun run(command: String, args: List<String>): Result<(String, String), String> {
+public fun run(command: String, args: List<String>): Result<(String, String), (Int, String)> {
   __BUILT_IN_IMPLEMENTATION
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2903,12 +2903,26 @@ fn eval_built_in_call(
                                     .unwrap();
                                 s.write_str(&String::from_utf8_lossy(&output.stderr))
                                     .unwrap();
-                                Value::err(Value::new(Value_::String(s)))
+                                let exit_code = output.status.code().unwrap_or(-1);
+                                let tuple = Value::new(Value_::Tuple {
+                                    items: vec![
+                                        Value::new(Value_::Int(exit_code as i64)),
+                                        Value::new(Value_::String(s)),
+                                    ],
+                                    item_types: vec![Type::int(), Type::string()],
+                                });
+                                Value::err(tuple)
                             }
                         }
                         Err(e) => {
-                            let s = Value::new(Value_::String(format!("{e}")));
-                            Value::err(s)
+                            let tuple = Value::new(Value_::Tuple {
+                                items: vec![
+                                    Value::new(Value_::Int(-1)),
+                                    Value::new(Value_::String(format!("{e}"))),
+                                ],
+                                item_types: vec![Type::int(), Type::string()],
+                            });
+                            Value::err(tuple)
                         }
                     };
 

--- a/src/test_files/runtime/shell_invalid_command.gdn
+++ b/src/test_files/runtime/shell_invalid_command.gdn
@@ -5,4 +5,4 @@ import "__shell.gdn" as shell
 }
 
 // args: run
-// expected stdout: Err("No such file or directory (os error 2)")
+// expected stdout: Err((-1, "No such file or directory (os error 2)"))


### PR DESCRIPTION
The `shell::run()` function now returns error information as a tuple of `(Int, String)` instead of just a `String`. This allows callers to distinguish between different failure modes: a non-zero exit code from a successfully spawned command, versus a failure to spawn the command at all (represented as exit code `-1`).

**Key changes:**

- Updated the error return value in `eval_built_in_call()` to construct a tuple containing the exit code and combined stdout/stderr output
- For successful command execution with non-zero exit code: returns the actual exit code from `output.status.code()`
- For command spawn failures or signal termination: returns exit code `-1`
- Updated the function signature in `__shell.gdn` to reflect the new error type: `Result<(String, String), (Int, String)>`
- Updated the corresponding test expectation to match the new tuple format

This change provides more granular error information to callers without requiring them to parse error messages to determine what went wrong.

https://claude.ai/code/session_015Z4qdH8x1XFAew9FGwqWNv