### PR TITLE
Add Path::read_bytes method

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -1094,6 +1094,24 @@ test path_read {
   assert(Path{ p: "/dev/null" }.read() == Ok(""))
 }
 
+/// Read the contents of `path` as a list of bytes.
+///
+/// Each byte is returned as an `Int` in the range 0 to 255.
+///
+/// ```
+/// Path{ p: "/tmp/foo.txt" }.read_bytes()
+/// ```
+public method read_bytes(this: Path): Result<List<Int>, String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+test path_read_bytes {
+  match Path{ p: "/dev/null" }.read_bytes() {
+    Ok(bs) => { assert(bs.len() == 0) }
+    Err(_) => { assert(False) }
+  }
+}
+
 /// Get the arguments passed when this program was run.
 ///
 /// For example, if the shell command was `garden run my_program.gdn

--- a/src/env.rs
+++ b/src/env.rs
@@ -517,6 +517,7 @@ fn fresh_prelude(env: &mut Env, prelude_vfs_path: &VfsPathBuf) -> Rc<RefCell<Nam
             vec![
                 ("exists", BuiltInMethodKind::PathExists),
                 ("read", BuiltInMethodKind::PathRead),
+                ("read_bytes", BuiltInMethodKind::PathReadBytes),
             ],
         ),
         (

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5567,6 +5567,90 @@ fn eval_built_in_method_call(
                 env.push_value(v);
             }
         }
+        BuiltInMethodKind::PathReadBytes => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: "Path::read_bytes".to_owned(),
+                },
+                receiver_value,
+                receiver_pos,
+                0,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(receiver_value, env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: receiver_pos.clone(),
+                            message: msg,
+                        }),
+                    ));
+                }
+            };
+
+            let orig_path = PathBuf::from(path_s.clone());
+            let path = if orig_path.is_relative() {
+                env.working_directory.join(&orig_path)
+            } else {
+                orig_path.clone()
+            };
+
+            let v = match std::fs::read(&path) {
+                Ok(bytes) => {
+                    let items = bytes
+                        .into_iter()
+                        .map(|b| Value::new(Value_::Int(b as i64)))
+                        .collect();
+                    Value::ok(Value::new(Value_::List {
+                        items,
+                        elem_type: Type::int(),
+                    }))
+                }
+                Err(e) => {
+                    let reason = match e.kind() {
+                        std::io::ErrorKind::NotFound => "No such file".to_owned(),
+                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
+                        std::io::ErrorKind::IsADirectory => "Is a directory".to_owned(),
+                        kind => format!("{kind}"),
+                    };
+                    let msg = if orig_path.is_relative() {
+                        format!(
+                            "Could not read `{path_s}` (relative to `{}`). {reason}.",
+                            env.working_directory.display()
+                        )
+                    } else {
+                        format!("Could not read `{path_s}`. {reason}.")
+                    };
+                    Value::err(Value::new(Value_::String(msg)))
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(v);
+            }
+        }
         BuiltInMethodKind::StringAsInt => {
             check_arity(
                 &SymbolName {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -952,6 +952,7 @@ pub(crate) enum BuiltInMethodKind {
     ListLen,
     PathExists,
     PathRead,
+    PathReadBytes,
     StringAsInt,
     StringChars,
     StringIndexOf,

--- a/src/test_files/runtime/read_bytes.gdn
+++ b/src/test_files/runtime/read_bytes.gdn
@@ -1,0 +1,14 @@
+import "__fs.gdn" as fs
+
+{
+  fs::write_file("Hi\n", Path{ p: "/tmp/garden_read_bytes_reftest.txt" })
+  dbg(Path{ p: "/tmp/garden_read_bytes_reftest.txt" }.read_bytes())
+  fs::remove_file(Path{ p: "/tmp/garden_read_bytes_reftest.txt" })
+
+  dbg(Path{ p: "/no_such_file_garden_read_bytes" }.read_bytes())
+}
+
+// args: run
+// expected stderr:
+// [src/test_files/runtime/read_bytes.gdn:5:3] Path{ p: "/tmp/garden_read_bytes_reftest.txt" }.read_bytes() //-> Ok([72, 105, 10])
+// [src/test_files/runtime/read_bytes.gdn:8:3] Path{ p: "/no_such_file_garden_read_bytes" }.read_bytes() //-> Err("Could not read `/no_such_file_garden_read_bytes`. No such file.")


### PR DESCRIPTION
Adds a `read_bytes` method on `Path` returning `Result<List<Int>, String>`, where each byte is an `Int` in 0–255.

Mirrors the existing `Path::read`: resolves relative paths against the working directory, forbidden in sandbox mode, and uses the same error message format (`No such file`, `Permission denied`, `Is a directory`, ...).

Covered by a unit test in the prelude and a runtime reftest in `src/test_files/runtime/read_bytes.gdn`.