### PR TITLE
Add static code checking to playground

### DIFF
--- a/playground/index.js
+++ b/playground/index.js
@@ -65,6 +65,13 @@ app.get('/', (req, res) => {
           src: 'Garden source code to execute (string, required)'
         },
         returns: 'JSON object with success status and execution results or error'
+      },
+      'POST /check': {
+        description: 'Statically check Garden code for issues without running it',
+        parameters: {
+          src: 'Garden source code to check (string, required)'
+        },
+        returns: 'JSON object with success status and a list of diagnostics'
       }
     }
   });
@@ -137,6 +144,69 @@ app.post('/run', (req, res) => {
           runCache.set(src, response);
         }
         res.json(response);
+      } catch (parseError) {
+        return res.json({
+          success: false,
+          error: `Failed to parse Garden output: ${parseError.message}`,
+          rawOutput: stdout
+        });
+      }
+    });
+  });
+});
+
+app.post('/check', (req, res) => {
+  const { src } = req.body;
+
+  if (src === undefined || src === null) {
+    return res.status(400).json({
+      success: false,
+      error: 'src parameter is required'
+    });
+  }
+
+  const codePreview = src.length > 200 ? src.substring(0, 200) + '...' : src;
+  logger.info({
+    codeLength: src.length,
+    codePreview
+  }, 'Checking code');
+
+  const tmpFile = path.join(os.tmpdir(), `garden-check-${Date.now()}-${Math.random().toString(36).substr(2, 9)}.gdn`);
+
+  fs.writeFile(tmpFile, src, (writeError) => {
+    if (writeError) {
+      return res.json({
+        success: false,
+        error: writeError.message
+      });
+    }
+
+    exec(`garden check --json "${tmpFile}"`, (execError, stdout, stderr) => {
+      fs.unlink(tmpFile, (unlinkError) => {
+        if (unlinkError) {
+          logger.error({ error: unlinkError.message, tmpFile }, 'Failed to delete temp file');
+        }
+      });
+
+      // `garden check` exits non-zero when there are diagnostics, so
+      // we don't treat that as a failure here — only a real spawn
+      // error counts. `execError.code` is the process exit code; any
+      // other error (e.g. ENOENT) means the binary couldn't be run.
+      if (execError && execError.code === undefined) {
+        return res.json({
+          success: false,
+          error: `Check failed: ${execError.message}`,
+          stderr: stderr
+        });
+      }
+
+      try {
+        const lines = stdout.split('\n').filter(line => line.length > 0);
+        const diagnostics = lines.map(line => JSON.parse(line));
+        res.json({
+          success: true,
+          diagnostics: diagnostics
+        });
       } catch (parseError) {
         return res.json({
           success: false,

--- a/website/playground.md
+++ b/website/playground.md
@@ -1,6 +1,6 @@
 # Playground
 
-<div id="playground-wrapper"><textarea rows="5" id="playground-editor">println("Hello World!")</textarea><button id="playground-run">Run</button><div id="playground-output" hidden></div></div>
+<div id="playground-wrapper"><textarea rows="5" id="playground-editor">println("Hello World!")</textarea><button id="playground-run">Run</button><button id="playground-check">Check</button><div id="playground-output" hidden></div></div>
 
 
 

--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -84,6 +84,22 @@ type PlaygroundResponse = {
   rawOutput?: string;
 };
 
+type CheckDiagnostic = {
+  line_number: number;
+  end_line_number: number;
+  column: number;
+  end_column: number;
+  message: string;
+  severity: "error" | "warning";
+};
+
+type CheckResponse = {
+  success: boolean;
+  diagnostics?: CheckDiagnostic[];
+  error?: string;
+  rawOutput?: string;
+};
+
 function evalSnippet(src: string, snippetDiv: HTMLElement): void {
   snippetDiv.hidden = false;
 
@@ -155,6 +171,48 @@ function evalSnippet(src: string, snippetDiv: HTMLElement): void {
 
         snippetDiv.innerHTML = output;
       }
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      snippetDiv.innerHTML = `Fetch error: ${escapeHtml(message)}`;
+    });
+}
+
+function checkSnippet(src: string, snippetDiv: HTMLElement): void {
+  snippetDiv.hidden = false;
+
+  snippetDiv.innerHTML = '<div class="spinner"></div>';
+
+  fetch("https://playground.garden-lang.org/check", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ src }),
+  })
+    .then((response) => response.json())
+    .then((data: CheckResponse) => {
+      if (!data.success) {
+        snippetDiv.innerHTML = `Error: ${escapeHtml(data.error || "Unknown error")}`;
+        return;
+      }
+
+      const diagnostics = data.diagnostics || [];
+      if (diagnostics.length === 0) {
+        snippetDiv.innerHTML = "No issues found.";
+        return;
+      }
+
+      const lines = diagnostics.map((d) => {
+        const label = d.severity === "error" ? "Error" : "Warning";
+        const cls = d.severity === "error" ? "stderr" : "";
+        const prefix = `${label} at line ${d.line_number}, column ${d.column}: `;
+        const text = `${prefix}${d.message}`;
+        return cls
+          ? `<span class="${cls}">${escapeHtml(text)}</span>`
+          : escapeHtml(text);
+      });
+      snippetDiv.innerHTML = lines.join("\n");
     })
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -276,6 +334,7 @@ function setupSnippetButtons(): void {
 
 function setupPlayground(): void {
   const playgroundRunButton = document.querySelector("#playground-run");
+  const playgroundCheckButton = document.querySelector("#playground-check");
   const playgroundEditor = document.querySelector("#playground-editor");
   const playgroundOutput = document.querySelector("#playground-output");
   if (
@@ -312,6 +371,13 @@ function setupPlayground(): void {
       const src = editorView.state.sliceDoc();
       evalSnippet(src, playgroundOutput);
     });
+
+    if (playgroundCheckButton) {
+      playgroundCheckButton.addEventListener("click", () => {
+        const src = editorView.state.sliceDoc();
+        checkSnippet(src, playgroundOutput);
+      });
+    }
 
     editorView.focus();
   }

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -261,8 +261,13 @@ header a {
   margin: 10px;
 }
 
-#playground-run {
+#playground-run,
+#playground-check {
   margin-top: 10px;
+}
+
+#playground-check {
+  margin-left: 5px;
 }
 
 textarea {


### PR DESCRIPTION
Add a new `/check` endpoint to the playground that performs static analysis on Garden code without executing it, and expose this functionality through a "Check" button in the web interface.

## Changes

- **Backend (`playground/index.js`)**: Added `POST /check` endpoint that invokes `garden check --json` on submitted code and returns diagnostics (errors and warnings) with line/column information
- **Frontend (`website/static/playground.ts`)**: 
  - Added `CheckResponse` and `CheckDiagnostic` types to match the backend output
  - Implemented `checkSnippet()` function to call the check endpoint and display results
  - Wired up the check button to invoke the check functionality
- **UI (`website/playground.md`, `website/static/style.css`)**: Added "Check" button next to the existing "Run" button with appropriate styling

The check endpoint follows the same pattern as the existing `/run` endpoint: it writes code to a temporary file, executes the Garden CLI tool, cleans up, and returns results as JSON. Diagnostics are displayed with severity labels (Error/Warning) and location information.

https://claude.ai/code/session_0199DuSf7UGLMjjRpDZzNz9H