### PR TITLE
Add Path.info() method

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -1112,6 +1112,35 @@ test path_read_bytes {
   }
 }
 
+/// Metadata about a filesystem path, returned by `Path.info`.
+///
+/// `is_symlink` is True when this path is itself a symbolic link.
+/// `size` is the size of the file in bytes. For symbolic links, `size`
+/// is the length of the link target rather than the size of the file
+/// it points to.
+struct PathInfo {
+  is_file: Bool,
+  is_directory: Bool,
+  is_symlink: Bool,
+  size: Int,
+}
+
+/// Return metadata about this path without following symbolic links.
+///
+/// ```
+/// Path{ p: "/" }.info()
+/// ```
+public method info(this: Path): Result<PathInfo, String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+test path_info {
+  match Path{ p: "/" }.info() {
+    Ok(info) => { assert(info.is_directory) }
+    Err(_) => { assert(False) }
+  }
+}
+
 /// Get the arguments passed when this program was run.
 ///
 /// For example, if the shell command was `garden run my_program.gdn

--- a/src/env.rs
+++ b/src/env.rs
@@ -518,6 +518,7 @@ fn fresh_prelude(env: &mut Env, prelude_vfs_path: &VfsPathBuf) -> Rc<RefCell<Nam
                 ("exists", BuiltInMethodKind::PathExists),
                 ("read", BuiltInMethodKind::PathRead),
                 ("read_bytes", BuiltInMethodKind::PathReadBytes),
+                ("info", BuiltInMethodKind::PathInfo),
             ],
         ),
         (

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5651,6 +5651,114 @@ fn eval_built_in_method_call(
                 env.push_value(v);
             }
         }
+        BuiltInMethodKind::PathInfo => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: "Path::info".to_owned(),
+                },
+                receiver_value,
+                receiver_pos,
+                0,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(receiver_value, env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: receiver_pos.clone(),
+                            message: msg,
+                        }),
+                    ));
+                }
+            };
+
+            let orig_path = PathBuf::from(path_s.clone());
+            let path = if orig_path.is_relative() {
+                env.working_directory.join(&orig_path)
+            } else {
+                orig_path.clone()
+            };
+
+            let v = match std::fs::symlink_metadata(&path) {
+                Ok(metadata) => {
+                    let file_type = metadata.file_type();
+                    let fields = vec![
+                        (
+                            SymbolName::from("is_file"),
+                            Value::bool(file_type.is_file()),
+                        ),
+                        (
+                            SymbolName::from("is_directory"),
+                            Value::bool(file_type.is_dir()),
+                        ),
+                        (
+                            SymbolName::from("is_symlink"),
+                            Value::bool(file_type.is_symlink()),
+                        ),
+                        (
+                            SymbolName::from("size"),
+                            Value::new(Value_::Int(metadata.len() as i64)),
+                        ),
+                    ];
+                    let info = Value::new(Value_::Struct {
+                        type_name: TypeName {
+                            text: "PathInfo".to_owned(),
+                        },
+                        fields,
+                        runtime_type: Type::UserDefined {
+                            kind: TypeDefKind::Struct,
+                            name: TypeName {
+                                text: "PathInfo".to_owned(),
+                            },
+                            args: vec![],
+                        },
+                    });
+                    Value::ok(info)
+                }
+                Err(e) => {
+                    let reason = match e.kind() {
+                        std::io::ErrorKind::NotFound => "No such file or directory".to_owned(),
+                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
+                        kind => format!("{kind}"),
+                    };
+                    let msg = if orig_path.is_relative() {
+                        format!(
+                            "Could not read info for `{path_s}` (relative to `{}`). {reason}.",
+                            env.working_directory.display()
+                        )
+                    } else {
+                        format!("Could not read info for `{path_s}`. {reason}.")
+                    };
+                    Value::err(Value::new(Value_::String(msg)))
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(v);
+            }
+        }
         BuiltInMethodKind::StringAsInt => {
             check_arity(
                 &SymbolName {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -953,6 +953,7 @@ pub(crate) enum BuiltInMethodKind {
     PathExists,
     PathRead,
     PathReadBytes,
+    PathInfo,
     StringAsInt,
     StringChars,
     StringIndexOf,

--- a/src/test_files/runtime/path_info.gdn
+++ b/src/test_files/runtime/path_info.gdn
@@ -1,0 +1,25 @@
+import "__fs.gdn" as fs
+
+{
+  fs::write_file("Hi\n", Path{ p: "/tmp/garden_path_info_reftest.txt" })
+  let file_info = Path{ p: "/tmp/garden_path_info_reftest.txt" }.info().or_throw()
+  dbg(file_info.is_file)
+  dbg(file_info.is_directory)
+  dbg(file_info.is_symlink)
+  dbg(file_info.size)
+  fs::remove_file(Path{ p: "/tmp/garden_path_info_reftest.txt" })
+
+  let dir_info = Path{ p: "/" }.info().or_throw()
+  dbg(dir_info.is_directory)
+
+  dbg(Path{ p: "/no_such_file_garden_path_info" }.info())
+}
+
+// args: run
+// expected stderr:
+// [src/test_files/runtime/path_info.gdn:6:3] file_info.is_file //-> True
+// [src/test_files/runtime/path_info.gdn:7:3] file_info.is_directory //-> False
+// [src/test_files/runtime/path_info.gdn:8:3] file_info.is_symlink //-> False
+// [src/test_files/runtime/path_info.gdn:9:3] file_info.size //-> 3
+// [src/test_files/runtime/path_info.gdn:13:3] dir_info.is_directory //-> True
+// [src/test_files/runtime/path_info.gdn:15:3] Path{ p: "/no_such_file_garden_path_info" }.info() //-> Err("Could not read info for `/no_such_file_garden_path_info`. No such file or directory.")


### PR DESCRIPTION
Adds a `Path.info()` method that returns metadata about a filesystem path without following symbolic links.

## Changes
- New `PathInfo` struct in `src/__prelude.gdn` with `is_file`, `is_directory`, `is_symlink`, and `size` fields. For symlinks, `size` is the length of the link target.
- New `public method info(this: Path): Result<PathInfo, String>` stub in the prelude.
- `BuiltInMethodKind::PathInfo` variant in `src/parser/ast.rs`, registered on `Path` in `src/env.rs`.
- Implementation in `src/eval.rs` using `std::fs::symlink_metadata`, with sandbox enforcement and relative-path resolution against the working directory.
- Reftest at `src/test_files/runtime/path_info.gdn` covering files, directories, and the missing-path error.

## Test plan
- [x] `cargo test reftest`
- [x] `./target/debug/garden test src/__prelude.gdn` (includes new `path_info` test)
- [x] `cargo clippy` clean
- [x] `cargo fmt`