### PR TITLE
Write built-in files to disk for LSP and nREPL navigation

### DIFF
--- a/src/built_in_files.rs
+++ b/src/built_in_files.rs
@@ -1,0 +1,91 @@
+//! On-disk temporary copies of the built-in Garden files
+//! (`__prelude.gdn`, `__fs.gdn`, ...).
+//!
+//! The LSP and nREPL servers write the built-ins into a temporary
+//! directory on startup so that editors can navigate to them via
+//! go-to-def or `lookup`. The directory is removed when the value is
+//! dropped.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use rustc_hash::FxHashMap;
+
+use crate::eval::BUILT_IN_FILES;
+
+/// On-disk copies of the built-in Garden files, written into a
+/// temporary directory. The directory is removed when this value is
+/// dropped.
+pub(crate) struct BuiltInFiles {
+    dir: PathBuf,
+    paths: FxHashMap<PathBuf, PathBuf>,
+}
+
+impl BuiltInFiles {
+    /// Write the built-in files into a fresh directory inside the
+    /// system temp directory, named with `prefix` and the current
+    /// process ID.
+    pub(crate) fn new(prefix: &str) -> io::Result<Self> {
+        let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir)?;
+
+        let mut paths = FxHashMap::default();
+        for (name, content) in BUILT_IN_FILES {
+            let temp_path = dir.join(name);
+            std::fs::write(&temp_path, content)?;
+
+            if let Ok(meta) = std::fs::metadata(&temp_path) {
+                let mut perms = meta.permissions();
+                perms.set_readonly(true);
+                let _ = std::fs::set_permissions(&temp_path, perms);
+            }
+
+            paths.insert(PathBuf::from(name), temp_path);
+        }
+
+        Ok(Self { dir, paths })
+    }
+
+    /// If `path` refers to a built-in file, return the on-disk path of
+    /// the temporary copy.
+    pub(crate) fn resolve(&self, path: &Path) -> Option<PathBuf> {
+        self.paths.get(path).cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl Drop for BuiltInFiles {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_built_in_and_cleans_up() {
+        let dir_path;
+        {
+            let built_ins = BuiltInFiles::new("garden-built-in-files-test").unwrap();
+            dir_path = built_ins.dir().to_path_buf();
+            assert!(dir_path.is_dir());
+
+            let resolved = built_ins
+                .resolve(&PathBuf::from("__prelude.gdn"))
+                .expect("__prelude.gdn should resolve");
+            assert!(resolved.is_file());
+
+            assert!(built_ins
+                .resolve(&PathBuf::from("not_a_builtin.gdn"))
+                .is_none());
+        }
+        assert!(!dir_path.exists());
+    }
+}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -20,7 +20,6 @@ use url::Url;
 /// Storage for open document contents, keyed by file path.
 type DocumentStore = FxHashMap<PathBuf, String>;
 
-use crate::built_in_files::BuiltInFiles;
 use crate::checks::check_toplevel_items_in_env;
 use crate::checks::type_checker::check_types;
 use crate::completions;
@@ -35,6 +34,7 @@ use crate::parser::position::Position as GardenPosition;
 use crate::parser::vfs::Vfs;
 use crate::parser::{parse_toplevel_items, ParseError};
 use crate::pos_to_id::find_item_at;
+use crate::temp_built_in_files::TempBuiltInFiles;
 
 #[derive(Debug, Deserialize)]
 struct Message {
@@ -509,7 +509,7 @@ fn handle_definition(
     id: serde_json::Value,
     params: DefinitionParams,
     documents: &DocumentStore,
-    built_in_files: Option<&BuiltInFiles>,
+    temp_built_in_files: Option<&TempBuiltInFiles>,
 ) -> JsonRpcResponse<Option<Location>> {
     let uri = &params.text_document_position_params.text_document.uri;
     let position = params.text_document_position_params.position;
@@ -541,7 +541,7 @@ fn handle_definition(
     // Definitions in built-in files have relative paths like
     // `__prelude.gdn`. Redirect those to the temporary on-disk copy so
     // the editor can open them.
-    let def_path = built_in_files
+    let def_path = temp_built_in_files
         .and_then(|b| b.resolve(&def_pos.path))
         .unwrap_or_else(|| (*def_pos.path).clone());
 
@@ -931,7 +931,7 @@ pub(crate) fn run_lsp() {
     let mut should_exit = false;
     let mut documents: DocumentStore = FxHashMap::default();
 
-    let built_in_files = match BuiltInFiles::new("garden-lsp") {
+    let temp_built_in_files = match TempBuiltInFiles::new("garden-lsp") {
         Ok(b) => Some(b),
         Err(e) => {
             error!("Could not write built-in files to a temporary directory: {e}");
@@ -1014,7 +1014,7 @@ pub(crate) fn run_lsp() {
                         }
                     };
                     let response =
-                        handle_definition(id, params, &documents, built_in_files.as_ref());
+                        handle_definition(id, params, &documents, temp_built_in_files.as_ref());
                     if let Err(e) = write_message(&response) {
                         error!("Error writing response: {e}");
                     }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -26,7 +26,7 @@ use crate::completions;
 use crate::destructure::destructure;
 use crate::diagnostics::{Autofix, Diagnostic as GardenDiagnostic, Severity};
 use crate::env::Env;
-use crate::eval::load_toplevel_items;
+use crate::eval::{load_toplevel_items, BUILT_IN_FILES};
 use crate::extract_function::extract_function;
 use crate::highlight::highlight_occurrences;
 use crate::parser::ast::IdGenerator;
@@ -34,6 +34,51 @@ use crate::parser::position::Position as GardenPosition;
 use crate::parser::vfs::Vfs;
 use crate::parser::{parse_toplevel_items, ParseError};
 use crate::pos_to_id::find_item_at;
+
+/// On-disk copies of the built-in Garden files (`__prelude.gdn`,
+/// `__fs.gdn`, etc.) so the editor can navigate to them via go-to-def.
+///
+/// The directory is removed when this value is dropped.
+struct BuiltInFiles {
+    dir: PathBuf,
+    paths: FxHashMap<PathBuf, PathBuf>,
+}
+
+impl BuiltInFiles {
+    fn new() -> io::Result<Self> {
+        let dir = std::env::temp_dir().join(format!("garden-lsp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir)?;
+
+        let mut paths = FxHashMap::default();
+        for (name, content) in BUILT_IN_FILES {
+            let temp_path = dir.join(name);
+            std::fs::write(&temp_path, content)?;
+
+            if let Ok(meta) = std::fs::metadata(&temp_path) {
+                let mut perms = meta.permissions();
+                perms.set_readonly(true);
+                let _ = std::fs::set_permissions(&temp_path, perms);
+            }
+
+            paths.insert(PathBuf::from(name), temp_path);
+        }
+
+        Ok(Self { dir, paths })
+    }
+
+    /// If `path` refers to a built-in file, return the on-disk path of
+    /// the temporary copy.
+    fn resolve(&self, path: &Path) -> Option<PathBuf> {
+        self.paths.get(path).cloned()
+    }
+}
+
+impl Drop for BuiltInFiles {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct Message {
@@ -508,6 +553,7 @@ fn handle_definition(
     id: serde_json::Value,
     params: DefinitionParams,
     documents: &DocumentStore,
+    built_in_files: Option<&BuiltInFiles>,
 ) -> JsonRpcResponse<Option<Location>> {
     let uri = &params.text_document_position_params.text_document.uri;
     let position = params.text_document_position_params.position;
@@ -536,9 +582,16 @@ fn handle_definition(
         None => return JsonRpcResponse::new(id, None),
     };
 
+    // Definitions in built-in files have relative paths like
+    // `__prelude.gdn`. Redirect those to the temporary on-disk copy so
+    // the editor can open them.
+    let def_path = built_in_files
+        .and_then(|b| b.resolve(&def_pos.path))
+        .unwrap_or_else(|| (*def_pos.path).clone());
+
     // Convert to LSP Location format
     let location = Location {
-        uri: path_to_uri(&def_pos.path),
+        uri: path_to_uri(&def_path),
         range: garden_pos_to_lsp_range(&def_pos),
     };
 
@@ -922,6 +975,14 @@ pub(crate) fn run_lsp() {
     let mut should_exit = false;
     let mut documents: DocumentStore = FxHashMap::default();
 
+    let built_in_files = match BuiltInFiles::new() {
+        Ok(b) => Some(b),
+        Err(e) => {
+            error!("Could not write built-in files to a temporary directory: {e}");
+            None
+        }
+    };
+
     loop {
         let message = match read_message() {
             Ok(Some(msg)) => msg,
@@ -996,7 +1057,8 @@ pub(crate) fn run_lsp() {
                             continue;
                         }
                     };
-                    let response = handle_definition(id, params, &documents);
+                    let response =
+                        handle_definition(id, params, &documents, built_in_files.as_ref());
                     if let Err(e) = write_message(&response) {
                         error!("Error writing response: {e}");
                     }
@@ -1147,5 +1209,23 @@ mod tests {
         assert_eq!(line_char_to_offset(src, 1, 2), 21);
         // Line 1, character 3 is '.'
         assert_eq!(line_char_to_offset(src, 1, 3), 22);
+    }
+
+    #[test]
+    fn test_built_in_files_resolve_and_cleanup() {
+        let dir_path;
+        {
+            let built_ins = BuiltInFiles::new().unwrap();
+            dir_path = built_ins.dir.clone();
+            assert!(dir_path.is_dir());
+
+            let resolved = built_ins
+                .resolve(&PathBuf::from("__prelude.gdn"))
+                .expect("__prelude.gdn should resolve");
+            assert!(resolved.is_file());
+
+            assert!(built_ins.resolve(&PathBuf::from("not_a_builtin.gdn")).is_none());
+        }
+        assert!(!dir_path.exists());
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -20,13 +20,14 @@ use url::Url;
 /// Storage for open document contents, keyed by file path.
 type DocumentStore = FxHashMap<PathBuf, String>;
 
+use crate::built_in_files::BuiltInFiles;
 use crate::checks::check_toplevel_items_in_env;
 use crate::checks::type_checker::check_types;
 use crate::completions;
 use crate::destructure::destructure;
 use crate::diagnostics::{Autofix, Diagnostic as GardenDiagnostic, Severity};
 use crate::env::Env;
-use crate::eval::{load_toplevel_items, BUILT_IN_FILES};
+use crate::eval::load_toplevel_items;
 use crate::extract_function::extract_function;
 use crate::highlight::highlight_occurrences;
 use crate::parser::ast::IdGenerator;
@@ -34,51 +35,6 @@ use crate::parser::position::Position as GardenPosition;
 use crate::parser::vfs::Vfs;
 use crate::parser::{parse_toplevel_items, ParseError};
 use crate::pos_to_id::find_item_at;
-
-/// On-disk copies of the built-in Garden files (`__prelude.gdn`,
-/// `__fs.gdn`, etc.) so the editor can navigate to them via go-to-def.
-///
-/// The directory is removed when this value is dropped.
-struct BuiltInFiles {
-    dir: PathBuf,
-    paths: FxHashMap<PathBuf, PathBuf>,
-}
-
-impl BuiltInFiles {
-    fn new() -> io::Result<Self> {
-        let dir = std::env::temp_dir().join(format!("garden-lsp-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir)?;
-
-        let mut paths = FxHashMap::default();
-        for (name, content) in BUILT_IN_FILES {
-            let temp_path = dir.join(name);
-            std::fs::write(&temp_path, content)?;
-
-            if let Ok(meta) = std::fs::metadata(&temp_path) {
-                let mut perms = meta.permissions();
-                perms.set_readonly(true);
-                let _ = std::fs::set_permissions(&temp_path, perms);
-            }
-
-            paths.insert(PathBuf::from(name), temp_path);
-        }
-
-        Ok(Self { dir, paths })
-    }
-
-    /// If `path` refers to a built-in file, return the on-disk path of
-    /// the temporary copy.
-    fn resolve(&self, path: &Path) -> Option<PathBuf> {
-        self.paths.get(path).cloned()
-    }
-}
-
-impl Drop for BuiltInFiles {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.dir);
-    }
-}
 
 #[derive(Debug, Deserialize)]
 struct Message {
@@ -975,7 +931,7 @@ pub(crate) fn run_lsp() {
     let mut should_exit = false;
     let mut documents: DocumentStore = FxHashMap::default();
 
-    let built_in_files = match BuiltInFiles::new() {
+    let built_in_files = match BuiltInFiles::new("garden-lsp") {
         Ok(b) => Some(b),
         Err(e) => {
             error!("Could not write built-in files to a temporary directory: {e}");
@@ -1209,23 +1165,5 @@ mod tests {
         assert_eq!(line_char_to_offset(src, 1, 2), 21);
         // Line 1, character 3 is '.'
         assert_eq!(line_char_to_offset(src, 1, 3), 22);
-    }
-
-    #[test]
-    fn test_built_in_files_resolve_and_cleanup() {
-        let dir_path;
-        {
-            let built_ins = BuiltInFiles::new().unwrap();
-            dir_path = built_ins.dir.clone();
-            assert!(dir_path.is_dir());
-
-            let resolved = built_ins
-                .resolve(&PathBuf::from("__prelude.gdn"))
-                .expect("__prelude.gdn should resolve");
-            assert!(resolved.is_file());
-
-            assert!(built_ins.resolve(&PathBuf::from("not_a_builtin.gdn")).is_none());
-        }
-        assert!(!dir_path.exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@
 // compile.
 #![allow(clippy::cmp_owned)]
 
+mod built_in_files;
 mod caret_finder;
 mod checks;
 mod cli_session;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@
 // compile.
 #![allow(clippy::cmp_owned)]
 
-mod built_in_files;
 mod caret_finder;
 mod checks;
 mod cli_session;
@@ -67,6 +66,7 @@ mod run_code_blocks;
 mod sandboxed_playground;
 mod syntax_check;
 mod syntax_highlighter;
+mod temp_built_in_files;
 mod test_runner;
 mod type_defs;
 mod values;

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use serde_bencode::value::Value;
 use tracing::{debug, error, info, warn};
 
+use crate::built_in_files::BuiltInFiles;
 use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
 use crate::eval::{
@@ -345,7 +346,12 @@ fn handle_completions(env: &Env, prefix: &str, base_msg: &HashMap<Vec<u8>, Value
 /// Build the `lookup` response for a given symbol name. Looks up the
 /// symbol in the session's current namespace and returns information
 /// about it (file, line, doc, arglists, ...).
-fn handle_lookup(env: &Env, sym: &str, base_msg: &HashMap<Vec<u8>, Value>) -> Vec<Value> {
+fn handle_lookup(
+    env: &Env,
+    sym: &str,
+    base_msg: &HashMap<Vec<u8>, Value>,
+    built_in_files: Option<&BuiltInFiles>,
+) -> Vec<Value> {
     let ns = env.current_namespace();
     let ns_borrow = ns.borrow();
     let ns_name = ns_borrow
@@ -386,8 +392,10 @@ fn handle_lookup(env: &Env, sym: &str, base_msg: &HashMap<Vec<u8>, Value>) -> Ve
         let arglists_str = format!("({})", params.join(", "));
         info.insert(b"arglists-str".to_vec(), bstr(arglists_str));
 
-        let rel_path = to_project_relative(&fun_info.pos.path, &env.project_root);
-        info.insert(b"file".to_vec(), bstr(rel_path.display().to_string()));
+        let file_path = built_in_files
+            .and_then(|b| b.resolve(&fun_info.pos.path))
+            .unwrap_or_else(|| to_project_relative(&fun_info.pos.path, &env.project_root));
+        info.insert(b"file".to_vec(), bstr(file_path.display().to_string()));
         info.insert(
             b"line".to_vec(),
             Value::Int((fun_info.pos.line_number as i64) + 1),
@@ -485,15 +493,27 @@ struct Connection {
     /// watchdog to broadcast a global interrupt to every active
     /// session.
     interrupt_flags: Arc<Mutex<Vec<Weak<AtomicBool>>>>,
+    /// On-disk copies of the built-in Garden files, shared across all
+    /// sessions of this connection so `lookup` responses can point at
+    /// real files for built-in symbols.
+    built_in_files: Arc<Option<BuiltInFiles>>,
 }
 
 impl Connection {
     fn new(response_tx: Sender<Value>) -> Self {
+        Self::with_built_in_files(response_tx, Arc::new(None))
+    }
+
+    fn with_built_in_files(
+        response_tx: Sender<Value>,
+        built_in_files: Arc<Option<BuiltInFiles>>,
+    ) -> Self {
         Self {
             sessions: HashMap::new(),
             next_id: 0,
             response_tx,
             interrupt_flags: Arc::new(Mutex::new(Vec::new())),
+            built_in_files,
         }
     }
 
@@ -509,11 +529,14 @@ impl Connection {
 
         let response_tx = self.response_tx.clone();
         let worker_interrupted = Arc::clone(&interrupted);
+        let built_in_files = Arc::clone(&self.built_in_files);
         let thread_name = format!("nrepl-session-{id}");
 
         thread::Builder::new()
             .name(thread_name)
-            .spawn(move || session_worker(request_rx, response_tx, worker_interrupted))
+            .spawn(move || {
+                session_worker(request_rx, response_tx, worker_interrupted, built_in_files)
+            })
             .expect("Could not spawn nREPL session worker");
 
         self.sessions.insert(
@@ -603,6 +626,7 @@ fn session_worker(
     request_rx: Receiver<SessionRequest>,
     response_tx: Sender<Value>,
     interrupted: Arc<AtomicBool>,
+    built_in_files: Arc<Option<BuiltInFiles>>,
 ) {
     let id_gen = IdGenerator::default();
     let vfs = Vfs::default();
@@ -650,7 +674,9 @@ fn session_worker(
             SessionRequest::Completions { prefix, base_msg } => {
                 handle_completions(&env, &prefix, &base_msg)
             }
-            SessionRequest::Lookup { sym, base_msg } => handle_lookup(&env, &sym, &base_msg),
+            SessionRequest::Lookup { sym, base_msg } => {
+                handle_lookup(&env, &sym, &base_msg, built_in_files.as_ref().as_ref())
+            }
         };
         for r in responses {
             if response_tx.send(r).is_err() {
@@ -1044,7 +1070,11 @@ fn writer_thread(mut writer: TcpStream, rx: Receiver<Value>) {
 }
 
 /// Serve a single TCP connection until the client disconnects.
-fn serve_connection(stream: TcpStream, interrupted: Arc<AtomicBool>) {
+fn serve_connection(
+    stream: TcpStream,
+    interrupted: Arc<AtomicBool>,
+    built_in_files: Arc<Option<BuiltInFiles>>,
+) {
     let peer = stream
         .peer_addr()
         .map(|a| a.to_string())
@@ -1061,7 +1091,7 @@ fn serve_connection(stream: TcpStream, interrupted: Arc<AtomicBool>) {
         .spawn(move || writer_thread(writer_stream, response_rx))
         .expect("Could not spawn nREPL writer thread");
 
-    let mut conn = Connection::new(response_tx);
+    let mut conn = Connection::with_built_in_files(response_tx, built_in_files);
 
     let watchdog_flags = Arc::downgrade(&conn.interrupt_flags);
     thread::Builder::new()
@@ -1338,6 +1368,14 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         }
     };
 
+    let built_in_files = Arc::new(match BuiltInFiles::new("garden-nrepl") {
+        Ok(b) => Some(b),
+        Err(e) => {
+            warn!("nREPL: could not write built-in files to a temporary directory: {e}");
+            None
+        }
+    });
+
     // Use a non-blocking listener so the accept loop can periodically
     // check the interrupted flag and shut down on Ctrl-C.
     if let Err(e) = listener.set_nonblocking(true) {
@@ -1354,9 +1392,10 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         match listener.accept() {
             Ok((stream, _)) => {
                 let interrupted = Arc::clone(&interrupted);
+                let built_in_files = Arc::clone(&built_in_files);
                 std::thread::Builder::new()
                     .name("nrepl-client".to_owned())
-                    .spawn(move || serve_connection(stream, interrupted))
+                    .spawn(move || serve_connection(stream, interrupted, built_in_files))
                     .expect("Could not spawn nREPL client thread");
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -27,7 +27,6 @@ use std::time::{Duration, Instant};
 use serde_bencode::value::Value;
 use tracing::{debug, error, info, warn};
 
-use crate::built_in_files::BuiltInFiles;
 use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
 use crate::eval::{
@@ -38,6 +37,7 @@ use crate::namespaces::NamespaceInfo;
 use crate::parser::ast::{IdGenerator, SymbolName};
 use crate::parser::vfs::{to_abs_path, to_project_relative, Vfs};
 use crate::parser::{parse_toplevel_items, ParseError};
+use crate::temp_built_in_files::TempBuiltInFiles;
 use crate::values::Value_;
 
 /// Refuse to buffer a single message larger than this. Prevents a
@@ -350,7 +350,7 @@ fn handle_lookup(
     env: &Env,
     sym: &str,
     base_msg: &HashMap<Vec<u8>, Value>,
-    built_in_files: Option<&BuiltInFiles>,
+    temp_built_in_files: Option<&TempBuiltInFiles>,
 ) -> Vec<Value> {
     let ns = env.current_namespace();
     let ns_borrow = ns.borrow();
@@ -392,7 +392,7 @@ fn handle_lookup(
         let arglists_str = format!("({})", params.join(", "));
         info.insert(b"arglists-str".to_vec(), bstr(arglists_str));
 
-        let file_path = built_in_files
+        let file_path = temp_built_in_files
             .and_then(|b| b.resolve(&fun_info.pos.path))
             .unwrap_or_else(|| to_project_relative(&fun_info.pos.path, &env.project_root));
         info.insert(b"file".to_vec(), bstr(file_path.display().to_string()));
@@ -496,24 +496,24 @@ struct Connection {
     /// On-disk copies of the built-in Garden files, shared across all
     /// sessions of this connection so `lookup` responses can point at
     /// real files for built-in symbols.
-    built_in_files: Arc<Option<BuiltInFiles>>,
+    temp_built_in_files: Arc<Option<TempBuiltInFiles>>,
 }
 
 impl Connection {
     fn new(response_tx: Sender<Value>) -> Self {
-        Self::with_built_in_files(response_tx, Arc::new(None))
+        Self::with_temp_built_in_files(response_tx, Arc::new(None))
     }
 
-    fn with_built_in_files(
+    fn with_temp_built_in_files(
         response_tx: Sender<Value>,
-        built_in_files: Arc<Option<BuiltInFiles>>,
+        temp_built_in_files: Arc<Option<TempBuiltInFiles>>,
     ) -> Self {
         Self {
             sessions: HashMap::new(),
             next_id: 0,
             response_tx,
             interrupt_flags: Arc::new(Mutex::new(Vec::new())),
-            built_in_files,
+            temp_built_in_files,
         }
     }
 
@@ -529,13 +529,18 @@ impl Connection {
 
         let response_tx = self.response_tx.clone();
         let worker_interrupted = Arc::clone(&interrupted);
-        let built_in_files = Arc::clone(&self.built_in_files);
+        let temp_built_in_files = Arc::clone(&self.temp_built_in_files);
         let thread_name = format!("nrepl-session-{id}");
 
         thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                session_worker(request_rx, response_tx, worker_interrupted, built_in_files)
+                session_worker(
+                    request_rx,
+                    response_tx,
+                    worker_interrupted,
+                    temp_built_in_files,
+                )
             })
             .expect("Could not spawn nREPL session worker");
 
@@ -626,7 +631,7 @@ fn session_worker(
     request_rx: Receiver<SessionRequest>,
     response_tx: Sender<Value>,
     interrupted: Arc<AtomicBool>,
-    built_in_files: Arc<Option<BuiltInFiles>>,
+    temp_built_in_files: Arc<Option<TempBuiltInFiles>>,
 ) {
     let id_gen = IdGenerator::default();
     let vfs = Vfs::default();
@@ -675,7 +680,7 @@ fn session_worker(
                 handle_completions(&env, &prefix, &base_msg)
             }
             SessionRequest::Lookup { sym, base_msg } => {
-                handle_lookup(&env, &sym, &base_msg, built_in_files.as_ref().as_ref())
+                handle_lookup(&env, &sym, &base_msg, temp_built_in_files.as_ref().as_ref())
             }
         };
         for r in responses {
@@ -1073,7 +1078,7 @@ fn writer_thread(mut writer: TcpStream, rx: Receiver<Value>) {
 fn serve_connection(
     stream: TcpStream,
     interrupted: Arc<AtomicBool>,
-    built_in_files: Arc<Option<BuiltInFiles>>,
+    temp_built_in_files: Arc<Option<TempBuiltInFiles>>,
 ) {
     let peer = stream
         .peer_addr()
@@ -1091,7 +1096,7 @@ fn serve_connection(
         .spawn(move || writer_thread(writer_stream, response_rx))
         .expect("Could not spawn nREPL writer thread");
 
-    let mut conn = Connection::with_built_in_files(response_tx, built_in_files);
+    let mut conn = Connection::with_temp_built_in_files(response_tx, temp_built_in_files);
 
     let watchdog_flags = Arc::downgrade(&conn.interrupt_flags);
     thread::Builder::new()
@@ -1368,7 +1373,7 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         }
     };
 
-    let built_in_files = Arc::new(match BuiltInFiles::new("garden-nrepl") {
+    let temp_built_in_files = Arc::new(match TempBuiltInFiles::new("garden-nrepl") {
         Ok(b) => Some(b),
         Err(e) => {
             warn!("nREPL: could not write built-in files to a temporary directory: {e}");
@@ -1392,10 +1397,10 @@ pub(crate) fn run_nrepl(host: &str, port: u16, interrupted: Arc<AtomicBool>) {
         match listener.accept() {
             Ok((stream, _)) => {
                 let interrupted = Arc::clone(&interrupted);
-                let built_in_files = Arc::clone(&built_in_files);
+                let temp_built_in_files = Arc::clone(&temp_built_in_files);
                 std::thread::Builder::new()
                     .name("nrepl-client".to_owned())
-                    .spawn(move || serve_connection(stream, interrupted, built_in_files))
+                    .spawn(move || serve_connection(stream, interrupted, temp_built_in_files))
                     .expect("Could not spawn nREPL client thread");
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {

--- a/src/temp_built_in_files.rs
+++ b/src/temp_built_in_files.rs
@@ -16,12 +16,12 @@ use crate::eval::BUILT_IN_FILES;
 /// On-disk copies of the built-in Garden files, written into a
 /// temporary directory. The directory is removed when this value is
 /// dropped.
-pub(crate) struct BuiltInFiles {
+pub(crate) struct TempBuiltInFiles {
     dir: PathBuf,
     paths: FxHashMap<PathBuf, PathBuf>,
 }
 
-impl BuiltInFiles {
+impl TempBuiltInFiles {
     /// Write the built-in files into a fresh directory inside the
     /// system temp directory, named with `prefix` and the current
     /// process ID.
@@ -59,7 +59,7 @@ impl BuiltInFiles {
     }
 }
 
-impl Drop for BuiltInFiles {
+impl Drop for TempBuiltInFiles {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.dir);
     }
@@ -73,7 +73,7 @@ mod tests {
     fn resolves_built_in_and_cleans_up() {
         let dir_path;
         {
-            let built_ins = BuiltInFiles::new("garden-built-in-files-test").unwrap();
+            let built_ins = TempBuiltInFiles::new("garden-built-in-files-test").unwrap();
             dir_path = built_ins.dir().to_path_buf();
             assert!(dir_path.is_dir());
 


### PR DESCRIPTION
Enable editors to navigate to built-in Garden files via go-to-definition and lookup by writing them to temporary on-disk copies.

## Summary

Built-in Garden files (`__prelude.gdn`, `__fs.gdn`, etc.) are normally embedded in the binary. When users try to navigate to definitions in these files via LSP's go-to-definition or nREPL's lookup, editors cannot open them since they don't exist on disk. This change writes the built-in files to a temporary directory on startup, allowing editors to open and navigate them.

## Key Changes

- **New module `src/built_in_files.rs`**: Manages on-disk copies of built-in files
  - `BuiltInFiles` struct writes built-in files to a temp directory on creation
  - Files are marked read-only for safety
  - Directory is cleaned up automatically when the value is dropped
  - Provides `resolve()` method to map built-in file paths to their temporary locations

- **LSP integration**: Pass `BuiltInFiles` to `handle_definition()` to redirect built-in file paths to temporary copies in go-to-definition responses

- **nREPL integration**: Share `BuiltInFiles` across all sessions so lookup responses can point to real files for built-in symbols

- **Error handling**: Both LSP and nREPL gracefully degrade if the temporary directory cannot be created (e.g., due to permissions), continuing to work without on-disk navigation support

## Implementation Details

- Built-in files are written to `{temp_dir}/garden-{lsp|nrepl}-{pid}` to avoid conflicts
- The temporary directory is removed on startup if it already exists (cleanup from previous runs)
- File permissions are set to read-only to prevent accidental modification
- The `BuiltInFiles` value is wrapped in `Arc<Option<_>>` to allow graceful degradation and sharing across threads

https://claude.ai/code/session_01S8XNH6yyg4ZGtts82AoQ1R