### PR TITLE
Implement List::slice as a built-in method

### DIFF
--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -720,22 +720,7 @@ test list_index_of {
 /// [10, 11, 12].slice(1, -1) //-> [11]
 /// ```
 public method slice<T>(this: List<T>, i: Int, j: Int): List<T> {
-  if (j < 0) {
-    j = this.len() + j
-  }
-
-  let items: List<T> = []
-
-  let index = 0
-  for item in this {
-    if (index >= i) && (index < j) {
-      items = items.append(item)
-    }
-
-    index += 1
-  }
-
-  items
+  __BUILT_IN_IMPLEMENTATION
 }
 
 test list_slice {

--- a/src/env.rs
+++ b/src/env.rs
@@ -510,6 +510,7 @@ fn fresh_prelude(env: &mut Env, prelude_vfs_path: &VfsPathBuf) -> Rc<RefCell<Nam
                 ("contains", BuiltInMethodKind::ListContains),
                 ("get", BuiltInMethodKind::ListGet),
                 ("len", BuiltInMethodKind::ListLen),
+                ("slice", BuiltInMethodKind::ListSlice),
             ],
         ),
         (

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5439,6 +5439,103 @@ fn eval_built_in_method_call(
                 }
             }
         }
+        BuiltInMethodKind::ListSlice => {
+            check_arity(
+                &SymbolName {
+                    text: "List::slice".to_owned(),
+                },
+                receiver_value,
+                receiver_pos,
+                2,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let (items, elem_type) = match receiver_value.as_ref() {
+                Value_::List { items, elem_type } => (items, elem_type),
+                _ => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                    }
+                    saved_values.push(receiver_value.clone());
+
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: receiver_pos.clone(),
+                            message: format_type_error(
+                                &TypeName {
+                                    text: "List".into(),
+                                },
+                                receiver_value,
+                                env,
+                            ),
+                        }),
+                    ));
+                }
+            };
+
+            let i_arg = match arg_values[0].as_ref() {
+                Value_::Int(i) => *i,
+                _ => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                    }
+                    saved_values.push(receiver_value.clone());
+
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: arg_positions[0].clone(),
+                            message: format_type_error(
+                                &TypeName { text: "Int".into() },
+                                &arg_values[0],
+                                env,
+                            ),
+                        }),
+                    ));
+                }
+            };
+            let j_arg = match arg_values[1].as_ref() {
+                Value_::Int(j) => *j,
+                _ => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                    }
+                    saved_values.push(receiver_value.clone());
+
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: arg_positions[1].clone(),
+                            message: format_type_error(
+                                &TypeName { text: "Int".into() },
+                                &arg_values[1],
+                                env,
+                            ),
+                        }),
+                    ));
+                }
+            };
+
+            let len = items.len() as i64;
+            let j_adjusted = if j_arg < 0 { len + j_arg } else { j_arg };
+
+            let start = i_arg.max(0).min(len) as usize;
+            let end = j_adjusted.max(0).min(len) as usize;
+            let end = end.max(start);
+
+            if expr_value_is_used {
+                let new_items = items[start..end].to_vec();
+                env.push_value(Value::new(Value_::List {
+                    items: new_items,
+                    elem_type: elem_type.clone(),
+                }));
+            }
+        }
         BuiltInMethodKind::PathExists => {
             if env.enforce_sandbox {
                 let mut saved_values = vec![];

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -950,6 +950,7 @@ pub(crate) enum BuiltInMethodKind {
     ListContains,
     ListGet,
     ListLen,
+    ListSlice,
     PathExists,
     PathRead,
     PathReadBytes,

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 916,
+//     "line": 901,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,6 +9,6 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:916>
+// <fun println __prelude.gdn:901>
 // <closure string_repr_of_fun.gdn:6>
 


### PR DESCRIPTION
Converts the `List::slice` method from a prelude implementation to a built-in method for improved performance.

## Summary
The `List::slice` method is now implemented as a native built-in operation rather than as a Garden function in the prelude. This provides better performance by avoiding the overhead of the interpreted loop-based implementation.

## Key Changes
- Added `ListSlice` variant to `BuiltInMethodKind` enum in `src/parser/ast.rs`
- Implemented `ListSlice` evaluation in `src/eval.rs` with proper type checking and bounds handling
- Registered the built-in method in `src/env.rs` for the List type
- Replaced the prelude implementation in `src/__prelude.gdn` with `__BUILT_IN_IMPLEMENTATION` marker
- Updated test file line number references to reflect the shorter prelude

## Implementation Details
The built-in implementation handles:
- Type validation for the receiver (must be a List) and both arguments (must be Int)
- Negative index support (negative `j` is treated as offset from list length)
- Proper bounds clamping to prevent out-of-range access
- Preservation of the list's element type in the result

https://claude.ai/code/session_014aW9xdm3W1Hh5XvJBQ1w8N