### PR TITLE
Pop the loop body's bindings block per iteration

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1654,14 +1654,16 @@ fn eval_while_body(
 
     let stack_frame = env.current_frame_mut();
     if b {
-        stack_frame
-            .exprs_to_eval
-            .push((ExpressionState::EvaluatedAllSubexpressions, expr.clone()));
-
         // After the loop body, we will want to evaluate the expression again.
         stack_frame
             .exprs_to_eval
             .push((ExpressionState::NotEvaluated, expr.clone()));
+
+        // Push the body block cleanup above the next-iteration entry
+        // so it runs between iterations, not deferred to the end.
+        stack_frame
+            .exprs_to_eval
+            .push((ExpressionState::EvaluatedAllSubexpressions, expr.clone()));
 
         // Evaluate the body.
         eval_block(env, expr_value_is_used, body);
@@ -1746,17 +1748,16 @@ fn eval_for_in(
         return Ok(());
     }
 
-    // After each iteration's body, we want to pop the iteration's
-    // bindings block (pushed by `eval_block`), so schedule an
-    // EvaluatedAllSubexpressions state for this iteration.
+    // After an iteration the loop body, evaluate again. We don't
+    // re-evaluate the iteree expression though.
+    env.push_expr_to_eval(ExpressionState::PartiallyEvaluated, outer_expr.clone());
+
+    // Push the body block cleanup above the next-iteration entry so
+    // it runs between iterations, not deferred to the end.
     env.push_expr_to_eval(
         ExpressionState::EvaluatedAllSubexpressions,
         outer_expr.clone(),
     );
-
-    // After an iteration the loop body, evaluate again. We don't
-    // re-evaluate the iteree expression though.
-    env.push_expr_to_eval(ExpressionState::PartiallyEvaluated, outer_expr.clone());
 
     // Push the iterated value and the index for the next time we call
     // this function.
@@ -6894,7 +6895,15 @@ pub(crate) fn eval(env: &mut Env, session: &Session) -> Result<Value, EvalError>
             //
             if env.stop_at_expr_id.is_some() && env.stop_at_expr_id.as_ref() == Some(&outer_expr.id)
             {
-                if expr_state.done_children() {
+                // For loops EvaluatedAllSubexpressions fires per
+                // iteration; don't stop while more iterations remain.
+                let more_iterations_queued = env
+                    .current_frame()
+                    .exprs_to_eval
+                    .iter()
+                    .any(|(_, e)| e.id == outer_expr.id);
+
+                if expr_state.done_children() && !more_iterations_queued {
                     let v = if let Some(value) = env.current_frame().evalled_values.last().cloned()
                     {
                         value
@@ -7019,6 +7028,9 @@ fn eval_break(env: &mut Env, expr_value_is_used: bool) {
 
         match &expr.expr_ {
             Expression_::While(_, _) => {
+                // Run the body block cleanup that the drained
+                // EvaluatedAllSubexpressions would have done.
+                env.push_expr_to_eval(ExpressionState::EvaluatedAllSubexpressions, expr.clone());
                 break;
             }
             Expression_::ForIn(_, _, _) => {
@@ -7030,6 +7042,7 @@ fn eval_break(env: &mut Env, expr_value_is_used: bool) {
                 env.pop_value()
                     .expect("Index used by `for` should be present");
 
+                env.push_expr_to_eval(ExpressionState::EvaluatedAllSubexpressions, expr.clone());
                 break;
             }
             _ => {}


### PR DESCRIPTION
## Summary

Each iteration of a `while` or `for in` loop pushed a fresh bindings block via `eval_block`, but the matching `EvaluatedAllSubexpressions` state that pops it was scheduled below the next iteration's restart, so the pop was deferred indefinitely. The block stack grew by one per iteration, and variable lookups inside the body scanned every block linearly — making the loop O(n²) overall.

The fix is to swap the push order in `eval_while_body` and `eval_for_in` so the cleanup runs immediately after the body and before the next iteration begins. Pushes and pops are now balanced per iteration.

## Changes

- **`eval_while_body` / `eval_for_in`**: swap the two `push_expr_to_eval` calls so the `EvaluatedAllSubexpressions` entry sits above the next-iteration entry on the stack.
- **`eval` main loop**: when checking `stop_at_expr_id`, only stop on the loop's `EvaluatedAllSubexpressions` once no further iterations of the same loop are queued. Without this, the per-iter cleanup would terminate an otherwise-infinite `while True { ... }` under nrepl interrupt or eval-up-to.
- **`eval_break`**: schedule one trailing `EvaluatedAllSubexpressions` for the loop being broken out of, so the current body's bindings block is popped and `stop_at_expr_id` still fires.

## Performance

A 50k-iter tight `while i < count { i += 1 }` loop drops from ~9s to ~0.05s. Scaling is now linear (1M iters in ~1s).

## Test plan

- [x] `cargo test --release` (all 98 tests pass)
- [x] `cargo fmt`, `cargo clippy --release` clean
- [x] Manual checks: `break`, `continue`, nested loops, and `while True { 1 }` under nrepl interrupt all behave as before

https://claude.ai/code/session_018HTXQ3WJowYCNt1JCHa5MB