### PR TITLE
Move file reading functions from Path methods to __fs module

### DIFF
--- a/sample_programs/hangman.gdn
+++ b/sample_programs/hangman.gdn
@@ -1,6 +1,8 @@
+import "__fs.gdn" as fs
+
 public fun words(): List<String> {
   // https://github.com/first20hours/google-10000-english/blob/master/google-10000-english-no-swears.txt
   let f = Path{ p: "words.txt"}
-  let src = f.read().or_throw()
+  let src = fs::read_file(f).or_throw()
   src.lines()
 }

--- a/src/__fs.gdn
+++ b/src/__fs.gdn
@@ -1,3 +1,36 @@
+/// Read the contents of file `path` as a string.
+///
+/// ```
+/// import "__fs.gdn" as fs
+/// fs::read_file(Path{ p: "/tmp/foo.txt" })
+/// ```
+public fun read_file(path: Path): Result<String, String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+test read_file {
+  assert(read_file(Path{ p: "/dev/null" }) == Ok(""))
+}
+
+/// Read the contents of file `path` as a list of bytes.
+///
+/// Each byte is returned as an `Int` in the range 0 to 255.
+///
+/// ```
+/// import "__fs.gdn" as fs
+/// fs::read_file_bytes(Path{ p: "/tmp/foo.txt" })
+/// ```
+public fun read_file_bytes(path: Path): Result<List<Int>, String> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
+test read_file_bytes {
+  match read_file_bytes(Path{ p: "/dev/null" }) {
+    Ok(bs) => { assert(bs.is_empty()) }
+    Err(_) => { assert(False) }
+  }
+}
+
 /// Write `content` to file `path`.
 ///
 /// If `path` already exists, its content is replaced with `content`.

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -382,6 +382,10 @@ test string_chars {
 }
 
 /// A filesystem path.
+///
+/// `Path` provides path manipulation methods such as `parent`, `join`,
+/// `extension` and `set_extension`. Functions that read from or write
+/// to the filesystem live in the `__fs.gdn` module.
 struct Path {
   p: String,
 }
@@ -1064,37 +1068,6 @@ public method exists(this: Path): Bool {
 test path_exists {
   assert(Path{ p: "/" }.exists() == True)
   assert(Path{ p: "/no_such_dir_for_garden_test" }.exists() == False)
-}
-
-/// Read the contents of `path` as a string.
-///
-/// ```
-/// Path{ p: "/tmp/foo.txt" }.read()
-/// ```
-public method read(this: Path): Result<String, String> {
-  __BUILT_IN_IMPLEMENTATION
-}
-
-test path_read {
-  assert(Path{ p: "/dev/null" }.read() == Ok(""))
-}
-
-/// Read the contents of `path` as a list of bytes.
-///
-/// Each byte is returned as an `Int` in the range 0 to 255.
-///
-/// ```
-/// Path{ p: "/tmp/foo.txt" }.read_bytes()
-/// ```
-public method read_bytes(this: Path): Result<List<Int>, String> {
-  __BUILT_IN_IMPLEMENTATION
-}
-
-test path_read_bytes {
-  match Path{ p: "/dev/null" }.read_bytes() {
-    Ok(bs) => { assert(bs.is_empty()) }
-    Err(_) => { assert(False) }
-  }
 }
 
 /// Metadata about a filesystem path, returned by `Path.info`.

--- a/src/env.rs
+++ b/src/env.rs
@@ -522,8 +522,6 @@ fn fresh_prelude(env: &mut Env, prelude_vfs_path: &VfsPathBuf) -> Rc<RefCell<Nam
             "Path",
             vec![
                 ("exists", BuiltInMethodKind::PathExists),
-                ("read", BuiltInMethodKind::PathRead),
-                ("read_bytes", BuiltInMethodKind::PathReadBytes),
                 ("info", BuiltInMethodKind::PathInfo),
             ],
         ),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3796,6 +3796,165 @@ fn eval_built_in_call(
                 env.push_value(v);
             }
         }
+        BuiltInFunctionKind::FsReadFile => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(&arg_values[0], env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: receiver_pos.clone(),
+                            message: msg,
+                        }),
+                    ));
+                }
+            };
+
+            let orig_path = PathBuf::from(path_s.clone());
+            let path = if orig_path.is_relative() {
+                env.working_directory.join(&orig_path)
+            } else {
+                orig_path.clone()
+            };
+
+            let v = match std::fs::read_to_string(&path) {
+                Ok(s) => Value::ok(Value::new(Value_::String(s))),
+                Err(e) => {
+                    let reason = match e.kind() {
+                        std::io::ErrorKind::NotFound => "No such file".to_owned(),
+                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
+                        std::io::ErrorKind::IsADirectory => "Is a directory".to_owned(),
+                        kind => format!("{kind}"),
+                    };
+                    let msg = if orig_path.is_relative() {
+                        format!(
+                            "Could not read `{path_s}` (relative to `{}`). {reason}.",
+                            env.working_directory.display()
+                        )
+                    } else {
+                        format!("Could not read `{path_s}`. {reason}.")
+                    };
+                    Value::err(Value::new(Value_::String(msg)))
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(v);
+            }
+        }
+        BuiltInFunctionKind::FsReadFileBytes => {
+            if env.enforce_sandbox {
+                let mut saved_values = vec![];
+                for value in arg_values.iter().rev() {
+                    saved_values.push(value.clone());
+                }
+                saved_values.push(receiver_value.clone());
+
+                return Err((
+                    RestoreValues(saved_values),
+                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
+                ));
+            }
+
+            check_arity(
+                &SymbolName {
+                    text: format!("{kind}"),
+                },
+                receiver_value,
+                receiver_pos,
+                1,
+                arg_positions,
+                arg_values,
+            )?;
+
+            let path_s = match unwrap_path(&arg_values[0], env) {
+                Ok(s) => s,
+                Err(msg) => {
+                    let mut saved_values = vec![];
+                    for value in arg_values.iter().rev() {
+                        saved_values.push(value.clone());
+                        saved_values.push(receiver_value.clone());
+                    }
+                    return Err((
+                        RestoreValues(saved_values),
+                        EvalError::Exception(ExceptionInfo {
+                            position: receiver_pos.clone(),
+                            message: msg,
+                        }),
+                    ));
+                }
+            };
+
+            let orig_path = PathBuf::from(path_s.clone());
+            let path = if orig_path.is_relative() {
+                env.working_directory.join(&orig_path)
+            } else {
+                orig_path.clone()
+            };
+
+            let v = match std::fs::read(&path) {
+                Ok(bytes) => {
+                    let items = bytes
+                        .into_iter()
+                        .map(|b| Value::new(Value_::Int(b as i64)))
+                        .collect();
+                    Value::ok(Value::new(Value_::List {
+                        items,
+                        elem_type: Type::int(),
+                    }))
+                }
+                Err(e) => {
+                    let reason = match e.kind() {
+                        std::io::ErrorKind::NotFound => "No such file".to_owned(),
+                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
+                        std::io::ErrorKind::IsADirectory => "Is a directory".to_owned(),
+                        kind => format!("{kind}"),
+                    };
+                    let msg = if orig_path.is_relative() {
+                        format!(
+                            "Could not read `{path_s}` (relative to `{}`). {reason}.",
+                            env.working_directory.display()
+                        )
+                    } else {
+                        format!("Could not read `{path_s}`. {reason}.")
+                    };
+                    Value::err(Value::new(Value_::String(msg)))
+                }
+            };
+
+            if expr_value_is_used {
+                env.push_value(v);
+            }
+        }
         BuiltInFunctionKind::FsRemoveFile => {
             if env.enforce_sandbox {
                 let mut saved_values = vec![];
@@ -5727,165 +5886,6 @@ fn eval_built_in_method_call(
                     path
                 };
                 env.push_value(Value::bool(path.exists()));
-            }
-        }
-        BuiltInMethodKind::PathRead => {
-            if env.enforce_sandbox {
-                let mut saved_values = vec![];
-                for value in arg_values.iter().rev() {
-                    saved_values.push(value.clone());
-                }
-                saved_values.push(receiver_value.clone());
-
-                return Err((
-                    RestoreValues(saved_values),
-                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
-                ));
-            }
-
-            check_arity(
-                &SymbolName {
-                    text: "Path::read".to_owned(),
-                },
-                receiver_value,
-                receiver_pos,
-                0,
-                arg_positions,
-                arg_values,
-            )?;
-
-            let path_s = match unwrap_path(receiver_value, env) {
-                Ok(s) => s,
-                Err(msg) => {
-                    let mut saved_values = vec![];
-                    for value in arg_values.iter().rev() {
-                        saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
-                    }
-                    return Err((
-                        RestoreValues(saved_values),
-                        EvalError::Exception(ExceptionInfo {
-                            position: receiver_pos.clone(),
-                            message: msg,
-                        }),
-                    ));
-                }
-            };
-
-            let orig_path = PathBuf::from(path_s.clone());
-            let path = if orig_path.is_relative() {
-                env.working_directory.join(&orig_path)
-            } else {
-                orig_path.clone()
-            };
-
-            let v = match std::fs::read_to_string(&path) {
-                Ok(s) => Value::ok(Value::new(Value_::String(s))),
-                Err(e) => {
-                    let reason = match e.kind() {
-                        std::io::ErrorKind::NotFound => "No such file".to_owned(),
-                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
-                        std::io::ErrorKind::IsADirectory => "Is a directory".to_owned(),
-                        kind => format!("{kind}"),
-                    };
-                    let msg = if orig_path.is_relative() {
-                        format!(
-                            "Could not read `{path_s}` (relative to `{}`). {reason}.",
-                            env.working_directory.display()
-                        )
-                    } else {
-                        format!("Could not read `{path_s}`. {reason}.")
-                    };
-                    Value::err(Value::new(Value_::String(msg)))
-                }
-            };
-
-            if expr_value_is_used {
-                env.push_value(v);
-            }
-        }
-        BuiltInMethodKind::PathReadBytes => {
-            if env.enforce_sandbox {
-                let mut saved_values = vec![];
-                for value in arg_values.iter().rev() {
-                    saved_values.push(value.clone());
-                }
-                saved_values.push(receiver_value.clone());
-
-                return Err((
-                    RestoreValues(saved_values),
-                    EvalError::ForbiddenInSandbox(receiver_pos.clone()),
-                ));
-            }
-
-            check_arity(
-                &SymbolName {
-                    text: "Path::read_bytes".to_owned(),
-                },
-                receiver_value,
-                receiver_pos,
-                0,
-                arg_positions,
-                arg_values,
-            )?;
-
-            let path_s = match unwrap_path(receiver_value, env) {
-                Ok(s) => s,
-                Err(msg) => {
-                    let mut saved_values = vec![];
-                    for value in arg_values.iter().rev() {
-                        saved_values.push(value.clone());
-                        saved_values.push(receiver_value.clone());
-                    }
-                    return Err((
-                        RestoreValues(saved_values),
-                        EvalError::Exception(ExceptionInfo {
-                            position: receiver_pos.clone(),
-                            message: msg,
-                        }),
-                    ));
-                }
-            };
-
-            let orig_path = PathBuf::from(path_s.clone());
-            let path = if orig_path.is_relative() {
-                env.working_directory.join(&orig_path)
-            } else {
-                orig_path.clone()
-            };
-
-            let v = match std::fs::read(&path) {
-                Ok(bytes) => {
-                    let items = bytes
-                        .into_iter()
-                        .map(|b| Value::new(Value_::Int(b as i64)))
-                        .collect();
-                    Value::ok(Value::new(Value_::List {
-                        items,
-                        elem_type: Type::int(),
-                    }))
-                }
-                Err(e) => {
-                    let reason = match e.kind() {
-                        std::io::ErrorKind::NotFound => "No such file".to_owned(),
-                        std::io::ErrorKind::PermissionDenied => "Permission denied".to_owned(),
-                        std::io::ErrorKind::IsADirectory => "Is a directory".to_owned(),
-                        kind => format!("{kind}"),
-                    };
-                    let msg = if orig_path.is_relative() {
-                        format!(
-                            "Could not read `{path_s}` (relative to `{}`). {reason}.",
-                            env.working_directory.display()
-                        )
-                    } else {
-                        format!("Could not read `{path_s}`. {reason}.")
-                    };
-                    Value::err(Value::new(Value_::String(msg)))
-                }
-            };
-
-            if expr_value_is_used {
-                env.push_value(v);
             }
         }
         BuiltInMethodKind::PathInfo => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1607,7 +1607,7 @@ fun main() {
 
         // Create a temporary test file with a typo that has a quickfix
         let test_content = r#"fun main() {
-  Path{ p: "/foo" }.readd()
+  Path{ p: "/foo" }.existts()
 }
 "#;
         let test_file = std::env::temp_dir().join("garden_lsp_test_code_action.gdn");
@@ -1628,9 +1628,9 @@ fun main() {
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
         let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
 
-        // Request code actions at line 1, characters 20-25 (where "readd" is)
+        // Request code actions at line 1, characters 20-27 (where "existts" is)
         let code_action_request = format!(
-            r#"{{"jsonrpc":"2.0","id":2,"method":"textDocument/codeAction","params":{{"textDocument":{{"uri":"{}"}},"range":{{"start":{{"line":1,"character":20}},"end":{{"line":1,"character":25}}}},"context":{{"diagnostics":[]}}}}}}"#,
+            r#"{{"jsonrpc":"2.0","id":2,"method":"textDocument/codeAction","params":{{"textDocument":{{"uri":"{}"}},"range":{{"start":{{"line":1,"character":20}},"end":{{"line":1,"character":27}}}},"context":{{"diagnostics":[]}}}}}}"#,
             file_uri
         );
 
@@ -1679,8 +1679,8 @@ fun main() {
 
         // Should contain the quickfix title
         assert!(
-            stdout.contains("read"),
-            "Should contain 'read' in the quickfix suggestion"
+            stdout.contains("exists"),
+            "Should contain 'exists' in the quickfix suggestion"
         );
 
         // Should contain quickfix kind

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -952,8 +952,6 @@ pub(crate) enum BuiltInMethodKind {
     ListLen,
     ListSlice,
     PathExists,
-    PathRead,
-    PathReadBytes,
     PathInfo,
     StringAsInt,
     StringChars,

--- a/src/test_files/check/method_after_or_throw.gdn
+++ b/src/test_files/check/method_after_or_throw.gdn
@@ -1,5 +1,7 @@
+import "__fs.gdn" as fs
+
 {
-  let s = Path{ p: "/foo" }.read().or_throw()
+  let s = fs::read_file(Path{ p: "/foo" }).or_throw()
   s.split_once(",")
 }
 

--- a/src/test_files/check/missing_method_chained.gdn
+++ b/src/test_files/check/missing_method_chained.gdn
@@ -1,6 +1,6 @@
 {
   // Previously Path methods did not produce a type error here.
-  Path{ p: "/foo" }.read().foo()
+  Path{ p: "/foo" }.info().foo()
 }
 
 // args: check
@@ -11,5 +11,6 @@
 // -| src/test_files/check/missing_method_chained.gdn:3:28
 // 1| {
 // 2|   // Previously Path methods did not produce a type error here.
-// 3|   Path{ p: "/foo" }.read().foo()
+// 3|   Path{ p: "/foo" }.info().foo()
 // 4| }                          ^^^
+

--- a/src/test_files/check_fix/method_name.gdn
+++ b/src/test_files/check_fix/method_name.gdn
@@ -1,9 +1,9 @@
 {
-  Path{ p: "/foo" }.readd()
+  Path{ p: "/foo" }.existts()
 }
 
 // args: check --fix --stdout
 // expected stdout:
 // {
-//   Path{ p: "/foo" }.read()
+//   Path{ p: "/foo" }.exists()
 // }

--- a/src/test_files/nrepl/lookup_prelude.jsonl
+++ b/src/test_files/nrepl/lookup_prelude.jsonl
@@ -15,7 +15,7 @@
 //     "column": 1,
 //     "doc": "Write a string to stdout, with a newline appended. See also `print()` and `eprintln()`.\n\n```\nprintln(\"hello world\")\n```",
 //     "file": "__prelude.gdn",
-//     "line": 901,
+//     "line": 905,
 //     "name": "println",
 //     "ns": "__user"
 //   },

--- a/src/test_files/playground/sandboxed.gdn
+++ b/src/test_files/playground/sandboxed.gdn
@@ -1,4 +1,6 @@
-Path{ p: "/tmp/foo.txt" }.read()
+import "__fs.gdn" as fs
+
+fs::read_file(Path{ p: "/tmp/foo.txt" })
 
 // args: playground-run
 // expected stdout: {"error":"Tried to execute unsafe code in sandboxed mode","value":null}

--- a/src/test_files/runtime/read_bytes.gdn
+++ b/src/test_files/runtime/read_bytes.gdn
@@ -2,13 +2,13 @@ import "__fs.gdn" as fs
 
 {
   fs::write_file("Hi\n", Path{ p: "/tmp/garden_read_bytes_reftest.txt" })
-  dbg(Path{ p: "/tmp/garden_read_bytes_reftest.txt" }.read_bytes())
+  dbg(fs::read_file_bytes(Path{ p: "/tmp/garden_read_bytes_reftest.txt" }))
   fs::remove_file(Path{ p: "/tmp/garden_read_bytes_reftest.txt" })
 
-  dbg(Path{ p: "/no_such_file_garden_read_bytes" }.read_bytes())
+  dbg(fs::read_file_bytes(Path{ p: "/no_such_file_garden_read_bytes" }))
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/read_bytes.gdn:5:3] Path{ p: "/tmp/garden_read_bytes_reftest.txt" }.read_bytes() //-> Ok([72, 105, 10])
-// [src/test_files/runtime/read_bytes.gdn:8:3] Path{ p: "/no_such_file_garden_read_bytes" }.read_bytes() //-> Err("Could not read `/no_such_file_garden_read_bytes`. No such file.")
+// [src/test_files/runtime/read_bytes.gdn:5:3] fs::read_file_bytes(Path{ p: "/tmp/garden_read_bytes_reftest.txt" }) //-> Ok([72, 105, 10])
+// [src/test_files/runtime/read_bytes.gdn:8:3] fs::read_file_bytes(Path{ p: "/no_such_file_garden_read_bytes" }) //-> Err("Could not read `/no_such_file_garden_read_bytes`. No such file.")

--- a/src/test_files/runtime/read_missing_file_relative.gdn
+++ b/src/test_files/runtime/read_missing_file_relative.gdn
@@ -6,9 +6,9 @@ import "__fs.gdn" as fs
 
 {
   fs::set_working_directory(Path{ p: "/tmp" })
-  dbg(Path{ p: "no_such_file_garden.txt" }.read())
+  dbg(fs::read_file(Path{ p: "no_such_file_garden.txt" }))
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/read_missing_file_relative.gdn:9:3] Path{ p: "no_such_file_garden.txt" }.read() //-> Err("Could not read `no_such_file_garden.txt` (relative to `/tmp`). No such file.")
+// [src/test_files/runtime/read_missing_file_relative.gdn:9:3] fs::read_file(Path{ p: "no_such_file_garden.txt" }) //-> Err("Could not read `no_such_file_garden.txt` (relative to `/tmp`). No such file.")

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -9,5 +9,5 @@ fun do_stuff() {}
 // args: run
 // expected stdout:
 // <fun do_stuff string_repr_of_fun.gdn:1>
-// <fun println __prelude.gdn:901>
+// <fun println __prelude.gdn:905>
 // <closure string_repr_of_fun.gdn:6>

--- a/src/test_files/runtime/write_file_missing_directory.gdn
+++ b/src/test_files/runtime/write_file_missing_directory.gdn
@@ -4,12 +4,12 @@ import "__fs.gdn" as fs
 
 dbg(fs::list_directory(Path{ p: "/tmp/no_such_dir_garden/" }))
 
-dbg(Path{ p: "/tmp/no_such_dir_garden/foo.txt" }.read())
+dbg(fs::read_file(Path{ p: "/tmp/no_such_dir_garden/foo.txt" }))
 
 dbg(fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }))
 
 // args: run
 // expected stderr:
 // [src/test_files/runtime/write_file_missing_directory.gdn:5:1] fs::list_directory(Path{ p: "/tmp/no_such_dir_garden/" }) //-> Err("Could not read directory `/tmp/no_such_dir_garden/`. No such file or directory (os error 2)")
-// [src/test_files/runtime/write_file_missing_directory.gdn:7:1] Path{ p: "/tmp/no_such_dir_garden/foo.txt" }.read() //-> Err("Could not read `/tmp/no_such_dir_garden/foo.txt`. No such file.")
+// [src/test_files/runtime/write_file_missing_directory.gdn:7:1] fs::read_file(Path{ p: "/tmp/no_such_dir_garden/foo.txt" }) //-> Err("Could not read `/tmp/no_such_dir_garden/foo.txt`. No such file.")
 // [src/test_files/runtime/write_file_missing_directory.gdn:9:1] fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }) //-> Err("Could not write `/tmp/no_such_dir_garden/bar.txt`. No such file or directory (os error 2)")

--- a/src/test_files/sandboxed_test/read_file.gdn
+++ b/src/test_files/sandboxed_test/read_file.gdn
@@ -1,6 +1,8 @@
+import "__fs.gdn" as fs
+
 test read_file_is_unsafe {
-  Path{ p: "/tmp/foo.txt" }.read()
-  //                          ^
+  fs::read_file(Path{ p: "/tmp/foo.txt" })
+  //              ^
 }
 
 // args: sandboxed-test

--- a/src/values.rs
+++ b/src/values.rs
@@ -409,6 +409,8 @@ pub(crate) enum BuiltInFunctionKind {
     FsCopyFile,
     FsCreateDir,
     FsListDirectory,
+    FsReadFile,
+    FsReadFileBytes,
     FsRemoveDir,
     FsRemoveFile,
     FsSetWorkingDirectory,
@@ -456,6 +458,8 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::FsCreateDir
             | BuiltInFunctionKind::FsRemoveDir
             | BuiltInFunctionKind::FsCopyFile
+            | BuiltInFunctionKind::FsReadFile
+            | BuiltInFunctionKind::FsReadFileBytes
             | BuiltInFunctionKind::FsRemoveFile => PathBuf::from("__fs.gdn"),
             BuiltInFunctionKind::ReflectSourceForFun
             | BuiltInFunctionKind::ReflectSourceForMethod
@@ -513,6 +517,8 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::FsCreateDir => "create_dir",
             BuiltInFunctionKind::FsRemoveDir => "remove_dir",
             BuiltInFunctionKind::FsCopyFile => "copy_file",
+            BuiltInFunctionKind::FsReadFile => "read_file",
+            BuiltInFunctionKind::FsReadFileBytes => "read_file_bytes",
             BuiltInFunctionKind::FsRemoveFile => "remove_file",
             BuiltInFunctionKind::TimeUnixtime => "unixtime",
             BuiltInFunctionKind::ReflectBuiltInFiles => "built_in_files",

--- a/website/blog/sandbox.md
+++ b/website/blog/sandbox.md
@@ -29,7 +29,8 @@ while True {}
 ```
 
 ```
-Path{ p: "/etc/passwd" }.read()
+import "__fs.gdn" as fs
+fs::read_file(Path{ p: "/etc/passwd" })
 ```
 
 Some programming languages choose to compile their interpreter to

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -183,7 +183,7 @@ fun write_markdown_page(
   let html_file_name = out_path.file_name().or_throw()
   let self_url = "/" ^ html_file_name
 
-  let page_src_md = md_path.read().or_throw()
+  let page_src_md = fs::read_file(md_path).or_throw()
   let page_src = markdown::render(
     substitute_shorthand(website_dir, page_src_md),
     Some(md_path),
@@ -236,7 +236,7 @@ fun blog_posts(website_dir: Path): List<BlogPost> {
     let published = False
     let title: Option<String> = None
     let date: Option<String> = None
-    let src = match path.read() {
+    let src = match fs::read_file(path) {
       Ok(src) => {
         let (metadata, src) = split_metadata(src)
         for line in metadata.or_value("").lines() {
@@ -307,7 +307,7 @@ fun build_site(): Unit {
   fs::create_dir(out_dir.join("static").join("fonts"))
 
   let base_tmpl_path = website_dir.join("template.html")
-  let base_tmpl_src = base_tmpl_path.read().or_throw()
+  let base_tmpl_src = fs::read_file(base_tmpl_path).or_throw()
 
   build_blog(website_dir, out_dir, base_tmpl_src)
 


### PR DESCRIPTION
Move `Path.read()` and `Path.read_bytes()` methods to the `__fs` module as `read_file()` and `read_file_bytes()` functions. This reorganizes the API so that all filesystem I/O operations live in a single module.

## Changes

- Converted `Path.read()` method to `fs::read_file()` function in `__fs.gdn`
- Converted `Path.read_bytes()` method to `fs::read_file_bytes()` function in `__fs.gdn`
- Updated `Path` struct documentation to clarify that filesystem I/O lives in `__fs.gdn`
- Moved implementation from `BuiltInMethodKind` to `BuiltInFunctionKind` in the evaluator
- Updated all test files and sample programs to use the new API
- Updated LSP test to use a different method name for testing purposes

## Implementation Details

The implementation logic remains identical—only the calling convention changed from a method on `Path` to a function that takes `Path` as an argument. Both functions continue to:
- Enforce sandbox restrictions
- Handle relative and absolute paths correctly
- Return `Result<String, String>` and `Result<List<Int>, String>` respectively
- Provide detailed error messages for common I/O failures

https://claude.ai/code/session_018ShYExi7Ub6xw781Z6zfSL