### PR TITLE
Add linting UI and display diagnostics in editor

### DIFF
--- a/website/static/api.ts
+++ b/website/static/api.ts
@@ -32,7 +32,7 @@ type PlaygroundResponse = {
   rawOutput?: string;
 };
 
-type CheckDiagnostic = {
+export type CheckDiagnostic = {
   line_number: number;
   end_line_number: number;
   column: number;
@@ -120,7 +120,11 @@ export function evalSnippet(src: string, snippetDiv: HTMLElement): void {
     });
 }
 
-export function checkSnippet(src: string, snippetDiv: HTMLElement): void {
+export function checkSnippet(
+  src: string,
+  snippetDiv: HTMLElement,
+  onDiagnostics?: (diagnostics: CheckDiagnostic[]) => void,
+): void {
   snippetDiv.hidden = false;
 
   snippetDiv.innerHTML = '<div class="spinner"></div>';
@@ -140,6 +144,9 @@ export function checkSnippet(src: string, snippetDiv: HTMLElement): void {
       }
 
       const diagnostics = data.diagnostics || [];
+      if (onDiagnostics) {
+        onDiagnostics(diagnostics);
+      }
       if (diagnostics.length === 0) {
         snippetDiv.innerHTML = "No issues found.";
         return;

--- a/website/static/editor.ts
+++ b/website/static/editor.ts
@@ -3,7 +3,10 @@ import { EditorState } from "@codemirror/state";
 import { history, historyKeymap } from "@codemirror/commands";
 import { keymap, highlightActiveLine } from "@codemirror/view";
 import { defaultKeymap } from "@codemirror/commands";
+import { linter, setDiagnostics } from "@codemirror/lint";
+import type { Diagnostic } from "@codemirror/lint";
 import { gardenLanguage, gardenHighlighting } from "./language";
+import type { CheckDiagnostic } from "./api";
 
 export function createGardenEditor(doc: string): EditorView {
   const state = EditorState.create({
@@ -16,8 +19,55 @@ export function createGardenEditor(doc: string): EditorView {
       highlightActiveLine(),
       gardenLanguage,
       gardenHighlighting,
+      // Install the lint UI but don't auto-run; diagnostics are
+      // pushed via setEditorDiagnostics after a /check call.
+      linter(() => [], { delay: 0 }),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          // Clear stale diagnostics once the user edits.
+          queueMicrotask(() => {
+            update.view.dispatch(setDiagnostics(update.view.state, []));
+          });
+        }
+      }),
     ],
   });
 
   return new EditorView({ state });
+}
+
+export function setEditorDiagnostics(
+  view: EditorView,
+  diagnostics: CheckDiagnostic[],
+): void {
+  const doc = view.state.doc;
+  const lineCount = doc.lines;
+
+  const cmDiagnostics: Diagnostic[] = diagnostics.map((d) => {
+    // Garden line numbers are 1-indexed; columns are 0-indexed byte
+    // offsets within the line.
+    const startLineNum = Math.min(Math.max(d.line_number, 1), lineCount);
+    const endLineNum = Math.min(
+      Math.max(d.end_line_number, startLineNum),
+      lineCount,
+    );
+
+    const startLine = doc.line(startLineNum);
+    const endLine = doc.line(endLineNum);
+
+    const from = Math.min(startLine.from + d.column, startLine.to);
+    let to = Math.min(endLine.from + d.end_column, endLine.to);
+    if (to <= from) {
+      to = Math.min(from + 1, doc.length);
+    }
+
+    return {
+      from,
+      to,
+      severity: d.severity,
+      message: d.message,
+    };
+  });
+
+  view.dispatch(setDiagnostics(view.state, cmDiagnostics));
 }

--- a/website/static/package-lock.json
+++ b/website/static/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@codemirror/commands": "^6.3.3",
         "@codemirror/language": "^6.11.3",
+        "@codemirror/lint": "^6.9.2",
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.23.0",
         "@lezer/highlight": "^1.2.3",

--- a/website/static/package.json
+++ b/website/static/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@codemirror/commands": "^6.3.3",
     "@codemirror/language": "^6.11.3",
+    "@codemirror/lint": "^6.9.2",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.0",
     "@lezer/highlight": "^1.2.3",

--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -1,5 +1,5 @@
 import { evalSnippet, checkSnippet } from "./api";
-import { createGardenEditor } from "./editor";
+import { createGardenEditor, setEditorDiagnostics } from "./editor";
 import { setupSnippetButtons } from "./snippets";
 
 function setupPlayground(): void {
@@ -29,7 +29,9 @@ function setupPlayground(): void {
     if (playgroundCheckButton) {
       playgroundCheckButton.addEventListener("click", () => {
         const src = editorView.state.sliceDoc();
-        checkSnippet(src, playgroundOutput);
+        checkSnippet(src, playgroundOutput, (diagnostics) => {
+          setEditorDiagnostics(editorView, diagnostics);
+        });
       });
     }
 


### PR DESCRIPTION
Integrate CodeMirror's linting system into the playground editor to display diagnostics from the `/check` API call directly in the editor.

## Summary
This change connects the backend `/check` endpoint with the editor's UI, allowing users to see compilation errors and warnings highlighted inline as they work.

## Key Changes
- Added `@codemirror/lint` dependency and integrated the linter extension into the editor
- Created `setEditorDiagnostics()` function to convert Garden diagnostics (1-indexed lines, byte-offset columns) to CodeMirror format (0-indexed positions)
- Modified `checkSnippet()` to accept an optional callback that receives diagnostics from the API response
- Updated the playground's check button handler to pass diagnostics to the editor
- Diagnostics are automatically cleared when the user edits the document, preventing stale error markers

## Implementation Details
- The linter is installed with an empty diagnostic function and `delay: 0` to prevent auto-running; diagnostics are pushed manually via `setDiagnostics()` after a `/check` call
- Line number and column bounds are clamped to valid ranges to handle edge cases gracefully
- Stale diagnostics are cleared asynchronously (via `queueMicrotask`) when the document changes, ensuring the UI stays in sync with the code

https://claude.ai/code/session_014pmwGsbVvK16iiePaNv4HD