### PR TITLE
Standardize indentation in runtime test files to 2 spaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,16 @@ jobs:
           done < <(find src website sample_programs benchmarks -name '*.gdn' -not -path '*/test_files/*' -not -path '*/unit_test_files/*' -print0)
           exit "$status"
 
+      - name: Check Garden formatting (reftest runtime files)
+        run: |
+          status=0
+          while IFS= read -r -d '' f; do
+            if ! ./target/debug/garden format --check "$f"; then
+              status=1
+            fi
+          done < <(find src/test_files/runtime -name '*.gdn' -print0)
+          exit "$status"
+
   typos:
     name: Check spelling
     runs-on: ubuntu-24.04

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,8 +577,16 @@ fn main() {
         }
         CliCommands::Format { path, check } => {
             let abs_path = to_abs_path(&path);
-            let mut src = read_utf8_or_die(&abs_path);
-            src = remove_testing_footer(&src);
+            let raw_src = read_utf8_or_die(&abs_path);
+            let mut src = remove_testing_footer(&raw_src);
+            // The formatter emits a single trailing newline. When a
+            // reftest footer separates the body from `// args:`, trim
+            // those blank lines so the comparison ignores them.
+            if src.len() != raw_src.len() {
+                while src.ends_with("\n\n") {
+                    src.pop();
+                }
+            }
             let formatted = format::format(&src, &abs_path);
             if check {
                 if src != formatted {

--- a/src/test_files/runtime/assign_closure_to_local.gdn
+++ b/src/test_files/runtime/assign_closure_to_local.gdn
@@ -17,7 +17,7 @@ fun stuff() {
   // which is compatible with any more specific type for a function of
   // two arguments.
   let f: Fun<(Int, Int), Int> = fun(x, y) { x + y }
-  
+
   dbg(f(2, 3))
 }
 

--- a/src/test_files/runtime/assignment_returns_unit.gdn
+++ b/src/test_files/runtime/assignment_returns_unit.gdn
@@ -1,6 +1,6 @@
 {
-    let i = 0
-    i = 2
+  let i = 0
+  i = 2
 }
 
 // args: run

--- a/src/test_files/runtime/block_inside_for.gdn
+++ b/src/test_files/runtime/block_inside_for.gdn
@@ -1,23 +1,23 @@
 fun render_inline() {
-    for _ in [10] {
-        if True {
-            11
-        } else {
-            12
-        }
+  for _ in [10] {
+    if True {
+      11
+    } else {
+      12
     }
-    
-    for _ in [13] {
-        match True {
-            True => 14,
-            False => 15,
-        }
+  }
+
+  for _ in [13] {
+    match True {
+      True => 14,
+      False => 15,
     }
+  }
 }
 
 {
-    render_inline()
-    println("done")
+  render_inline()
+  println("done")
 }
 
 // args: run

--- a/src/test_files/runtime/call_generic_fun.gdn
+++ b/src/test_files/runtime/call_generic_fun.gdn
@@ -1,7 +1,7 @@
 fun foo<T>(x: T): Unit {}
 
 {
-    foo(1)
+  foo(1)
 }
 
 // args: run

--- a/src/test_files/runtime/check_snippet.gdn
+++ b/src/test_files/runtime/check_snippet.gdn
@@ -7,4 +7,3 @@ import "__reflect.gdn" as reflect
 // args: run
 // expected stderr:
 // [src/test_files/runtime/check_snippet.gdn:4:3] reflect::check_snippet("True", Path{ p: "__snippet.gdn" }) //-> Ok(Unit)
-

--- a/src/test_files/runtime/dict_duplicate_keys.gdn
+++ b/src/test_files/runtime/dict_duplicate_keys.gdn
@@ -3,4 +3,3 @@ dbg(Dict["a" => "hello", "a" => "world"])
 // args: run
 // expected stderr:
 // [src/test_files/runtime/dict_duplicate_keys.gdn:1:1] Dict["a" => "hello", "a" => "world"] //-> Dict["a" => "world"]
-

--- a/src/test_files/runtime/dict_literal.gdn
+++ b/src/test_files/runtime/dict_literal.gdn
@@ -8,4 +8,3 @@ dbg(get_dict())
 // args: run
 // expected stderr:
 // [src/test_files/runtime/dict_literal.gdn:6:1] get_dict() //-> Dict["a" => "hello", "bc" => "world", "z" => ""]
-

--- a/src/test_files/runtime/dict_methods.gdn
+++ b/src/test_files/runtime/dict_methods.gdn
@@ -26,4 +26,3 @@ print_dict(d.remove("x"))
 // [src/test_files/runtime/dict_methods.gdn:3:3] d //-> Dict["x" => 1, "y" => 43]
 // [src/test_files/runtime/dict_methods.gdn:17:1] d.items() //-> [("x", 1), ("y", 43)]
 // [src/test_files/runtime/dict_methods.gdn:3:3] d //-> Dict["y" => 43]
-

--- a/src/test_files/runtime/dot_access_bad_type.gdn
+++ b/src/test_files/runtime/dot_access_bad_type.gdn
@@ -1,11 +1,12 @@
 {
-    let x = 1
-    x.y
+  let x = 1
+  x.y
 }
 
 // args: run
 // expected stderr:
 // Exception: Expected `struct` but `1` has type `Int`.
-// -| src/test_files/runtime/dot_access_bad_type.gdn:3:5	 __toplevel__
-// 3|     x.y
-//  |     ^
+// -| src/test_files/runtime/dot_access_bad_type.gdn:3:3	 __toplevel__
+// 3|   x.y
+//  |   ^
+

--- a/src/test_files/runtime/dot_access_enum.gdn
+++ b/src/test_files/runtime/dot_access_enum.gdn
@@ -1,11 +1,12 @@
 {
-    let x = Some(1)
-    x.y
+  let x = Some(1)
+  x.y
 }
 
 // args: run
 // expected stderr:
 // Exception: Expected `struct` but `Some(1)` has type `Option<Int>`.
-// -| src/test_files/runtime/dot_access_enum.gdn:3:5	 __toplevel__
-// 3|     x.y
-//  |     ^
+// -| src/test_files/runtime/dot_access_enum.gdn:3:3	 __toplevel__
+// 3|   x.y
+//  |   ^
+

--- a/src/test_files/runtime/eprint.gdn
+++ b/src/test_files/runtime/eprint.gdn
@@ -1,7 +1,7 @@
 {
-    eprint("hello ")
-    eprintln("stderr")
-    println("stdout")
+  eprint("hello ")
+  eprintln("stderr")
+  println("stdout")
 }
 
 // args: run

--- a/src/test_files/runtime/float_arithmetic.gdn
+++ b/src/test_files/runtime/float_arithmetic.gdn
@@ -11,4 +11,3 @@
 // [src/test_files/runtime/float_arithmetic.gdn:3:3] 0.25 -. 1.5 //-> -1.25
 // [src/test_files/runtime/float_arithmetic.gdn:4:3] 0.5 *. 10.2 //-> 5.1
 // [src/test_files/runtime/float_arithmetic.gdn:5:3] 1.0 /. 3.0 //-> 0.3333333333333333
-

--- a/src/test_files/runtime/float_rounding.gdn
+++ b/src/test_files/runtime/float_rounding.gdn
@@ -12,4 +12,3 @@
 // [src/test_files/runtime/float_rounding.gdn:3:3] 1.2.ceil() //-> 2
 // [src/test_files/runtime/float_rounding.gdn:5:3] -1.2.ceil() //-> -1
 // [src/test_files/runtime/float_rounding.gdn:6:3] -1.2.floor() //-> -2
-

--- a/src/test_files/runtime/float_whole_number_repr.gdn
+++ b/src/test_files/runtime/float_whole_number_repr.gdn
@@ -7,4 +7,3 @@
 // expected stderr:
 // [src/test_files/runtime/float_whole_number_repr.gdn:2:3] 1.0 //-> 1.0
 // [src/test_files/runtime/float_whole_number_repr.gdn:3:3] -1.010 //-> -1.01
-

--- a/src/test_files/runtime/for.gdn
+++ b/src/test_files/runtime/for.gdn
@@ -33,4 +33,3 @@ fun foo(): String { "abc" }
 // [src/test_files/runtime/for.gdn:16:5] item //-> 3
 // [src/test_files/runtime/for.gdn:25:5] x * y //-> 2
 // [src/test_files/runtime/for.gdn:25:5] x * y //-> 12
-

--- a/src/test_files/runtime/for_continue.gdn
+++ b/src/test_files/runtime/for_continue.gdn
@@ -1,18 +1,18 @@
 {
-    let items = [1, 2, 3, 4, 5]
-    for item in items {
-        if item == 3 {
-            continue
-        }
-
-        dbg(item)
+  let items = [1, 2, 3, 4, 5]
+  for item in items {
+    if item == 3 {
+      continue
     }
+
+    dbg(item)
+  }
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 1
-// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 2
-// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 4
-// [src/test_files/runtime/for_continue.gdn:8:9] item //-> 5
+// [src/test_files/runtime/for_continue.gdn:8:5] item //-> 1
+// [src/test_files/runtime/for_continue.gdn:8:5] item //-> 2
+// [src/test_files/runtime/for_continue.gdn:8:5] item //-> 4
+// [src/test_files/runtime/for_continue.gdn:8:5] item //-> 5
 

--- a/src/test_files/runtime/hello.gdn
+++ b/src/test_files/runtime/hello.gdn
@@ -1,5 +1,5 @@
 {
-    println("Hello, World!")
+  println("Hello, World!")
 }
 
 // args: run

--- a/src/test_files/runtime/if_without_else.gdn
+++ b/src/test_files/runtime/if_without_else.gdn
@@ -1,12 +1,12 @@
 fun foo(b: Bool): Int {
-    if b {
-        // Type error, but should also error at runtime.
-        123
-    }
+  if b {
+    // Type error, but should also error at runtime.
+    123
+  }
 }
 
 {
-    foo(True)
+  foo(True)
 }
 
 // args: run
@@ -15,6 +15,7 @@ fun foo(b: Bool): Int {
 // -| src/test_files/runtime/if_without_else.gdn:1:19	 fun foo()
 // 1| fun foo(b: Bool): Int {
 //  |                   ^^^
-// -| src/test_files/runtime/if_without_else.gdn:9:5	 __toplevel__
-// 9|     foo(True)
-//  |     ^^^^^^^^^
+// -| src/test_files/runtime/if_without_else.gdn:9:3	 __toplevel__
+// 9|   foo(True)
+//  |   ^^^^^^^^^
+

--- a/src/test_files/runtime/if_without_else_returns_unit.gdn
+++ b/src/test_files/runtime/if_without_else_returns_unit.gdn
@@ -3,14 +3,14 @@
 fun take_unit(_: Unit) {}
 
 {
-    take_unit(if True { 1 })
-    take_unit(if False { 1 })
+  take_unit(if True { 1 })
+  take_unit(if False { 1 })
 
-    let x = if True { "hello" }
-    println(string_repr(x))
+  let x = if True { "hello" }
+  println(string_repr(x))
 
-    let y = if False { "hello" }
-    println(string_repr(y))
+  let y = if False { "hello" }
+  println(string_repr(y))
 }
 
 // args: run

--- a/src/test_files/runtime/int_as_float.gdn
+++ b/src/test_files/runtime/int_as_float.gdn
@@ -9,4 +9,3 @@
 // [src/test_files/runtime/int_as_float.gdn:2:3] 1.as_float() //-> 1.0
 // [src/test_files/runtime/int_as_float.gdn:3:3] 0.as_float() //-> 0.0
 // [src/test_files/runtime/int_as_float.gdn:4:3] (-3).as_float() //-> -3.0
-

--- a/src/test_files/runtime/let_hint_invalid.gdn
+++ b/src/test_files/runtime/let_hint_invalid.gdn
@@ -1,10 +1,11 @@
 {
-    let x: String = 123
+  let x: String = 123
 }
 
 // args: run
 // expected stderr:
 // Exception: Expected `String` but `123` has type `Int`.
-// -| src/test_files/runtime/let_hint_invalid.gdn:2:21	 __toplevel__
-// 2|     let x: String = 123
-//  |                     ^^^
+// -| src/test_files/runtime/let_hint_invalid.gdn:2:19	 __toplevel__
+// 2|   let x: String = 123
+//  |                   ^^^
+

--- a/src/test_files/runtime/let_hint_valid.gdn
+++ b/src/test_files/runtime/let_hint_valid.gdn
@@ -1,6 +1,6 @@
 {
-    let x: String = "foo"
-    print(x)
+  let x: String = "foo"
+  print(x)
 }
 
 // args: run

--- a/src/test_files/runtime/let_returns_unit.gdn
+++ b/src/test_files/runtime/let_returns_unit.gdn
@@ -1,10 +1,10 @@
 fun foo(): Unit {
-    // This function should still return Unit.
-    let _ = 1
+  // This function should still return Unit.
+  let _ = 1
 }
 
 {
-    foo()
+  foo()
 }
 
 // args: run

--- a/src/test_files/runtime/list_get.gdn
+++ b/src/test_files/runtime/list_get.gdn
@@ -11,4 +11,3 @@ dbg(items.get("oh no wrong type"))
 // -| src/test_files/runtime/list_get.gdn:5:15	 __toplevel__
 // 5| dbg(items.get("oh no wrong type"))
 //  |               ^^^^^^^^^^^^^^^^^^
-

--- a/src/test_files/runtime/list_literal_and_appended.gdn
+++ b/src/test_files/runtime/list_literal_and_appended.gdn
@@ -1,14 +1,14 @@
 {
-    let literal = [1]
+  let literal = [1]
 
-    let changed: List<Int> = []
-    changed = changed.append(1)
+  let changed: List<Int> = []
+  changed = changed.append(1)
 
-    // Literal [1] should equal a [1] list built at runtime.
-    dbg(literal == changed)
+  // Literal [1] should equal a [1] list built at runtime.
+  dbg(literal == changed)
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/list_literal_and_appended.gdn:8:5] literal == changed //-> True
+// [src/test_files/runtime/list_literal_and_appended.gdn:8:3] literal == changed //-> True
 

--- a/src/test_files/runtime/loop_as_argument.gdn
+++ b/src/test_files/runtime/loop_as_argument.gdn
@@ -1,22 +1,23 @@
 fun foo(_a: Int, b: Int): Int {
-    b
+  b
 }
 
 {
-    let n = 0
-    // Using a `while` loop as a function argument used to push
-    // multiple Unit values onto the value stack, corrupting it.
-    dbg(foo(10, while n < 3 { n += 1 }))
+  let n = 0
+  // Using a `while` loop as a function argument used to push
+  // multiple Unit values onto the value stack, corrupting it.
+  dbg(foo(10, while n < 3 { n += 1 }))
 
-    // Using a `for` loop as a function argument used to push no
-    // value at all, so the call popped an unrelated value as its
-    // receiver.
-    dbg(foo(20, for _ in [1, 2, 3] {}))
+  // Using a `for` loop as a function argument used to push no
+  // value at all, so the call popped an unrelated value as its
+  // receiver.
+  dbg(foo(20, for _ in [1, 2, 3] {}))
 }
 
 // args: run
 // expected stderr:
 // Exception: Expected `Int` but got `Unit`.
-// -| src/test_files/runtime/loop_as_argument.gdn:9:17	 __toplevel__
-// 9|     dbg(foo(10, while n < 3 { n += 1 }))
-//  |                 ^^^^^^^^^^^^^^^^^^^^^^
+// -| src/test_files/runtime/loop_as_argument.gdn:9:15	 __toplevel__
+// 9|   dbg(foo(10, while n < 3 { n += 1 }))
+//  |               ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test_files/runtime/loop_break.gdn
+++ b/src/test_files/runtime/loop_break.gdn
@@ -1,15 +1,15 @@
 {
-    let i = 0
-    while True {
-        if i == 10 {
-            break
-        }
-
-        i = i + 1
+  let i = 0
+  while True {
+    if i == 10 {
+      break
     }
 
-    dbg(i)
+    i = i + 1
+  }
+
+  dbg(i)
 }
 
 // args: run
-// expected stderr: [src/test_files/runtime/loop_break.gdn:11:5] i //-> 10
+// expected stderr: [src/test_files/runtime/loop_break.gdn:11:3] i //-> 10

--- a/src/test_files/runtime/loop_continue.gdn
+++ b/src/test_files/runtime/loop_continue.gdn
@@ -1,23 +1,23 @@
 {
-    let i = 0
-    while i < 5 {
-        i = i + 1
+  let i = 0
+  while i < 5 {
+    i = i + 1
 
-        if i == 3 {
-            continue
-        }
-
-        dbg(i)
+    if i == 3 {
+      continue
     }
 
-    dbg("done")
+    dbg(i)
+  }
+
+  dbg("done")
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 1
-// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 2
-// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 4
-// [src/test_files/runtime/loop_continue.gdn:10:9] i //-> 5
-// [src/test_files/runtime/loop_continue.gdn:13:5] "done" //-> "done"
+// [src/test_files/runtime/loop_continue.gdn:10:5] i //-> 1
+// [src/test_files/runtime/loop_continue.gdn:10:5] i //-> 2
+// [src/test_files/runtime/loop_continue.gdn:10:5] i //-> 4
+// [src/test_files/runtime/loop_continue.gdn:10:5] i //-> 5
+// [src/test_files/runtime/loop_continue.gdn:13:3] "done" //-> "done"
 

--- a/src/test_files/runtime/match_destructure.gdn
+++ b/src/test_files/runtime/match_destructure.gdn
@@ -23,4 +23,3 @@
 // --| src/test_files/runtime/match_destructure.gdn:12:5	 __toplevel__
 // 12|     Some((_, _)) => {
 //   |     ^^^^
-

--- a/src/test_files/runtime/match_variant_no_payload.gdn
+++ b/src/test_files/runtime/match_variant_no_payload.gdn
@@ -1,16 +1,16 @@
 fun takes_opt(v: Option<Int>): Int {
-    match v {
-        Some(i) => i + 1,
-        None => 123,
-    }
+  match v {
+    Some(i) => i + 1,
+    None => 123,
+  }
 }
 
 {
-    dbg(takes_opt(None))
-    Unit
+  dbg(takes_opt(None))
+  Unit
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/match_variant_no_payload.gdn:9:5] takes_opt(None) //-> 123
+// [src/test_files/runtime/match_variant_no_payload.gdn:9:3] takes_opt(None) //-> 123
 

--- a/src/test_files/runtime/modulo.gdn
+++ b/src/test_files/runtime/modulo.gdn
@@ -12,4 +12,3 @@
 // -| src/test_files/runtime/modulo.gdn:4:3	 __toplevel__
 // 4|   10 % 0
 //  |   ^^^^^^
-

--- a/src/test_files/runtime/nonexistent_type_return_type_arg.gdn
+++ b/src/test_files/runtime/nonexistent_type_return_type_arg.gdn
@@ -1,9 +1,9 @@
 fun foo(): Option<NoSuchType> {
-    None
+  None
 }
 
 {
-    foo()
+  foo()
 }
 
 // args: run
@@ -12,6 +12,7 @@ fun foo(): Option<NoSuchType> {
 // -| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:1:12	 fun foo()
 // 1| fun foo(): Option<NoSuchType> {
 //  |            ^^^^^^^^^^^^^^^^^^
-// -| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:6:5	 __toplevel__
-// 6|     foo()
-//  |     ^^^^^
+// -| src/test_files/runtime/nonexistent_type_return_type_arg.gdn:6:3	 __toplevel__
+// 6|   foo()
+//  |   ^^^^^
+

--- a/src/test_files/runtime/read_missing_file_relative.gdn
+++ b/src/test_files/runtime/read_missing_file_relative.gdn
@@ -12,4 +12,3 @@ import "__fs.gdn" as fs
 // args: run
 // expected stderr:
 // [src/test_files/runtime/read_missing_file_relative.gdn:9:3] Path{ p: "no_such_file_garden.txt" }.read() //-> Err("Could not read `no_such_file_garden.txt` (relative to `/tmp`). No such file.")
-

--- a/src/test_files/runtime/redefine_type.gdn
+++ b/src/test_files/runtime/redefine_type.gdn
@@ -19,4 +19,3 @@ struct Foo {
 // args: run
 // expected stderr:
 // [src/test_files/runtime/redefine_type.gdn:16:3] Foo{ name: "" }.do_stuff() //-> 123
-

--- a/src/test_files/runtime/return_generic.gdn
+++ b/src/test_files/runtime/return_generic.gdn
@@ -1,12 +1,12 @@
 fun option_identity<T>(value: Option<T>): Option<T> {
-    value
+  value
 }
 
 {
-    dbg(option_identity(Some(1)))
+  dbg(option_identity(Some(1)))
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/return_generic.gdn:6:5] option_identity(Some(1)) //-> Some(1)
+// [src/test_files/runtime/return_generic.gdn:6:3] option_identity(Some(1)) //-> Some(1)
 

--- a/src/test_files/runtime/return_invalid_list.gdn
+++ b/src/test_files/runtime/return_invalid_list.gdn
@@ -1,10 +1,10 @@
 fun foo(): List<Int> {
-    [""] // should error
+  [""] // should error
 }
 
 {
-    foo()
-    return
+  foo()
+  return
 }
 
 // args: run
@@ -13,6 +13,7 @@ fun foo(): List<Int> {
 // -| src/test_files/runtime/return_invalid_list.gdn:1:12	 fun foo()
 // 1| fun foo(): List<Int> {
 //  |            ^^^^^^^^^
-// -| src/test_files/runtime/return_invalid_list.gdn:6:5	 __toplevel__
-// 6|     foo()
-//  |     ^^^^^
+// -| src/test_files/runtime/return_invalid_list.gdn:6:3	 __toplevel__
+// 6|   foo()
+//  |   ^^^^^
+

--- a/src/test_files/runtime/return_invalid_option.gdn
+++ b/src/test_files/runtime/return_invalid_option.gdn
@@ -1,10 +1,10 @@
 fun foo(): Option<Int> {
-    Some("") // should error
+  Some("") // should error
 }
 
 {
-    foo()
-    return
+  foo()
+  return
 }
 
 // args: run
@@ -13,6 +13,7 @@ fun foo(): Option<Int> {
 // -| src/test_files/runtime/return_invalid_option.gdn:1:12	 fun foo()
 // 1| fun foo(): Option<Int> {
 //  |            ^^^^^^^^^^^
-// -| src/test_files/runtime/return_invalid_option.gdn:6:5	 __toplevel__
-// 6|     foo()
-//  |     ^^^^^
+// -| src/test_files/runtime/return_invalid_option.gdn:6:3	 __toplevel__
+// 6|   foo()
+//  |   ^^^^^
+

--- a/src/test_files/runtime/return_invalid_unit.gdn
+++ b/src/test_files/runtime/return_invalid_unit.gdn
@@ -1,7 +1,7 @@
 fun foo(): Int {}
 
 {
-    foo()
+  foo()
 }
 
 // args: run
@@ -10,6 +10,7 @@ fun foo(): Int {}
 // -| src/test_files/runtime/return_invalid_unit.gdn:1:12	 fun foo()
 // 1| fun foo(): Int {}
 //  |            ^^^
-// -| src/test_files/runtime/return_invalid_unit.gdn:4:5	 __toplevel__
-// 4|     foo()
-//  |     ^^^^^
+// -| src/test_files/runtime/return_invalid_unit.gdn:4:3	 __toplevel__
+// 4|   foo()
+//  |   ^^^^^
+

--- a/src/test_files/runtime/shell_invalid_command.gdn
+++ b/src/test_files/runtime/shell_invalid_command.gdn
@@ -1,9 +1,10 @@
 import "__shell.gdn" as shell
 
 {
-    dbg(shell::run("no_such_command", []))
+  dbg(shell::run("no_such_command", []))
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/shell_invalid_command.gdn:4:5] shell::run("no_such_command", []) //-> Err((-1, "No such file or directory (os error 2)"))
+// [src/test_files/runtime/shell_invalid_command.gdn:4:3] shell::run("no_such_command", []) //-> Err((-1, "No such file or directory (os error 2)"))
+

--- a/src/test_files/runtime/shell_tuple.gdn
+++ b/src/test_files/runtime/shell_tuple.gdn
@@ -1,13 +1,13 @@
 import "__shell.gdn" as shell
 
 {
-    let (stdout, stderr) = shell::run("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
-    dbg(stdout)
-    dbg(stderr)
+  let (stdout, stderr) = shell::run("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
+  dbg(stdout)
+  dbg(stderr)
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/shell_tuple.gdn:5:5] stdout //-> "out\n"
-// [src/test_files/runtime/shell_tuple.gdn:6:5] stderr //-> "err\n"
+// [src/test_files/runtime/shell_tuple.gdn:5:3] stdout //-> "out\n"
+// [src/test_files/runtime/shell_tuple.gdn:6:3] stderr //-> "err\n"
 

--- a/src/test_files/runtime/source_directory.gdn
+++ b/src/test_files/runtime/source_directory.gdn
@@ -5,4 +5,3 @@
 // args: run
 // expected stderr:
 // [src/test_files/runtime/source_directory.gdn:2:3] source_directory().or_throw().file_name() //-> Some("source_directory.gdn")
-

--- a/src/test_files/runtime/stack_trace.gdn
+++ b/src/test_files/runtime/stack_trace.gdn
@@ -1,28 +1,29 @@
 test foo {
-    call_it2()
+  call_it2()
 }
 
 fun call_it() {
-    no_such()
+  no_such()
 }
 
 fun call_it2() {
-    call_it()
+  call_it()
 }
 
 {
-    call_it2()
+  call_it2()
 }
 
 // args: run
 // expected stderr:
 // Exception: No such variable `no_such`.
-// -| src/test_files/runtime/stack_trace.gdn:6:5	 fun call_it()
-// 6|     no_such()
-//  |     ^^^^^^^
-// --| src/test_files/runtime/stack_trace.gdn:10:5	 fun call_it2()
-// 10|     call_it()
-//   |     ^^^^^^^^^
-// --| src/test_files/runtime/stack_trace.gdn:14:5	 __toplevel__
-// 14|     call_it2()
-//   |     ^^^^^^^^^^
+// -| src/test_files/runtime/stack_trace.gdn:6:3	 fun call_it()
+// 6|   no_such()
+//  |   ^^^^^^^
+// --| src/test_files/runtime/stack_trace.gdn:10:3	 fun call_it2()
+// 10|   call_it()
+//   |   ^^^^^^^^^
+// --| src/test_files/runtime/stack_trace.gdn:14:3	 __toplevel__
+// 14|   call_it2()
+//   |   ^^^^^^^^^^
+

--- a/src/test_files/runtime/string_concat_operator.gdn
+++ b/src/test_files/runtime/string_concat_operator.gdn
@@ -1,6 +1,6 @@
 {
-    dbg("ab" ^ "cd")
+  dbg("ab" ^ "cd")
 }
 
 // args: run
-// expected stderr: [src/test_files/runtime/string_concat_operator.gdn:2:5] "ab" ^ "cd" //-> "abcd"
+// expected stderr: [src/test_files/runtime/string_concat_operator.gdn:2:3] "ab" ^ "cd" //-> "abcd"

--- a/src/test_files/runtime/string_repr_of_fun.gdn
+++ b/src/test_files/runtime/string_repr_of_fun.gdn
@@ -11,4 +11,3 @@ fun do_stuff() {}
 // <fun do_stuff string_repr_of_fun.gdn:1>
 // <fun println __prelude.gdn:901>
 // <closure string_repr_of_fun.gdn:6>
-

--- a/src/test_files/runtime/struct_access.gdn
+++ b/src/test_files/runtime/struct_access.gdn
@@ -3,13 +3,13 @@ struct Foo {
 }
 
 fun get_x(foo: Foo): Int {
-    foo.x
+  foo.x
 }
 
 {
-    dbg(get_x(Foo{ x: 1 + 2 }))
-    Unit
+  dbg(get_x(Foo{ x: 1 + 2 }))
+  Unit
 }
 
 // args: run
-// expected stderr: [src/test_files/runtime/struct_access.gdn:10:5] get_x(Foo{ x: 1 + 2 }) //-> 3
+// expected stderr: [src/test_files/runtime/struct_access.gdn:10:3] get_x(Foo{ x: 1 + 2 }) //-> 3

--- a/src/test_files/runtime/struct_create.gdn
+++ b/src/test_files/runtime/struct_create.gdn
@@ -4,11 +4,11 @@ struct Foo {
 }
 
 {
-    dbg(Foo{ x: 1 + 2, y: "abc" })
-    Unit
+  dbg(Foo{ x: 1 + 2, y: "abc" })
+  Unit
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/struct_create.gdn:7:5] Foo{ x: 1 + 2, y: "abc" } //-> Foo{ x: 3, y: "abc" }
+// [src/test_files/runtime/struct_create.gdn:7:3] Foo{ x: 1 + 2, y: "abc" } //-> Foo{ x: 3, y: "abc" }
 

--- a/src/test_files/runtime/struct_create_invalid_types.gdn
+++ b/src/test_files/runtime/struct_create_invalid_types.gdn
@@ -3,13 +3,14 @@ struct Foo {
 }
 
 {
-    dbg(Foo{ x: "abc" })
-    Unit
+  dbg(Foo{ x: "abc" })
+  Unit
 }
 
 // args: run
 // expected stderr:
 // Exception: Incorrect type for field: Expected `Int` but `"abc"` has type `String`.
-// -| src/test_files/runtime/struct_create_invalid_types.gdn:6:17	 __toplevel__
-// 6|     dbg(Foo{ x: "abc" })
-//  |                 ^^^^^
+// -| src/test_files/runtime/struct_create_invalid_types.gdn:6:15	 __toplevel__
+// 6|   dbg(Foo{ x: "abc" })
+//  |               ^^^^^
+

--- a/src/test_files/runtime/struct_create_missing_fields.gdn
+++ b/src/test_files/runtime/struct_create_missing_fields.gdn
@@ -3,13 +3,14 @@ struct Foo {
 }
 
 {
-    dbg(Foo{})
-    Unit
+  dbg(Foo{})
+  Unit
 }
 
 // args: run
 // expected stderr:
 // Exception: Missing fields from `Foo`: `x`.
-// -| src/test_files/runtime/struct_create_missing_fields.gdn:6:9	 __toplevel__
-// 6|     dbg(Foo{})
-//  |         ^^^^^
+// -| src/test_files/runtime/struct_create_missing_fields.gdn:6:7	 __toplevel__
+// 6|   dbg(Foo{})
+//  |       ^^^^^
+

--- a/src/test_files/runtime/struct_extra_field.gdn
+++ b/src/test_files/runtime/struct_extra_field.gdn
@@ -1,12 +1,13 @@
 struct Foo {}
 
 {
-    Foo{ x: 1 }
+  Foo{ x: 1 }
 }
 
 // args: run
 // expected stderr:
 // Exception: `Foo` does not have a field named `x`.
-// -| src/test_files/runtime/struct_extra_field.gdn:4:10	 __toplevel__
-// 4|     Foo{ x: 1 }
-//  |          ^
+// -| src/test_files/runtime/struct_extra_field.gdn:4:8	 __toplevel__
+// 4|   Foo{ x: 1 }
+//  |        ^
+

--- a/src/test_files/runtime/struct_invalid_type_param.gdn
+++ b/src/test_files/runtime/struct_invalid_type_param.gdn
@@ -3,12 +3,12 @@ struct Box<T> {
 }
 
 fun foo(): Box<Int> {
-    Box{ value: "not an int" }
+  Box{ value: "not an int" }
 }
 
 {
-    foo()
-    return
+  foo()
+  return
 }
 
 // args: run
@@ -17,6 +17,7 @@ fun foo(): Box<Int> {
 // -| src/test_files/runtime/struct_invalid_type_param.gdn:5:12	 fun foo()
 // 5| fun foo(): Box<Int> {
 //  |            ^^^^^^^^
-// --| src/test_files/runtime/struct_invalid_type_param.gdn:10:5	 __toplevel__
-// 10|     foo()
-//   |     ^^^^^
+// --| src/test_files/runtime/struct_invalid_type_param.gdn:10:3	 __toplevel__
+// 10|   foo()
+//   |   ^^^^^
+

--- a/src/test_files/runtime/struct_syntax_invalid_type.gdn
+++ b/src/test_files/runtime/struct_syntax_invalid_type.gdn
@@ -1,12 +1,13 @@
 enum Foo { X }
 
 {
-    Foo{ x: 1 }
+  Foo{ x: 1 }
 }
 
 // args: run
 // expected stderr:
 // Exception: `Foo` is not a struct, so it cannot be initialized with struct syntax.
-// -| src/test_files/runtime/struct_syntax_invalid_type.gdn:4:5	 __toplevel__
-// 4|     Foo{ x: 1 }
-//  |     ^^^
+// -| src/test_files/runtime/struct_syntax_invalid_type.gdn:4:3	 __toplevel__
+// 4|   Foo{ x: 1 }
+//  |   ^^^
+

--- a/src/test_files/runtime/struct_undefined_type.gdn
+++ b/src/test_files/runtime/struct_undefined_type.gdn
@@ -1,10 +1,11 @@
 {
-    Foo{ x: 1 }
+  Foo{ x: 1 }
 }
 
 // args: run
 // expected stderr:
 // Exception: No type exists named `Foo`.
-// -| src/test_files/runtime/struct_undefined_type.gdn:2:5	 __toplevel__
-// 2|     Foo{ x: 1 }
-//  |     ^^^
+// -| src/test_files/runtime/struct_undefined_type.gdn:2:3	 __toplevel__
+// 2|   Foo{ x: 1 }
+//  |   ^^^
+

--- a/src/test_files/runtime/struct_valid_type_param.gdn
+++ b/src/test_files/runtime/struct_valid_type_param.gdn
@@ -3,12 +3,12 @@ struct Box<T> {
 }
 
 fun foo(): Box<Int> {
-    Box{ value: 1234 }
+  Box{ value: 1234 }
 }
 
 {
-    foo()
-    return
+  foo()
+  return
 }
 
 // args: run

--- a/src/test_files/runtime/tuple.gdn
+++ b/src/test_files/runtime/tuple.gdn
@@ -1,16 +1,16 @@
 fun return_tuple(): (Int, String) {
-    (123, "foo")
+  (123, "foo")
 }
 
 {
-    let v = return_tuple()
-    dbg(v)
-    let (i, _) = v
-    dbg(i)
+  let v = return_tuple()
+  dbg(v)
+  let (i, _) = v
+  dbg(i)
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/tuple.gdn:7:5] v //-> (123, "foo")
-// [src/test_files/runtime/tuple.gdn:9:5] i //-> 123
+// [src/test_files/runtime/tuple.gdn:7:3] v //-> (123, "foo")
+// [src/test_files/runtime/tuple.gdn:9:3] i //-> 123
 

--- a/src/test_files/runtime/working_directory.gdn
+++ b/src/test_files/runtime/working_directory.gdn
@@ -8,4 +8,3 @@ import "__fs.gdn" as fs
 // args: run
 // expected stderr:
 // [src/test_files/runtime/working_directory.gdn:5:3] fs::working_directory() //-> Path{ p: "/tmp" }
-

--- a/src/test_files/runtime/write_file_missing_directory.gdn
+++ b/src/test_files/runtime/write_file_missing_directory.gdn
@@ -13,4 +13,3 @@ dbg(fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }))
 // [src/test_files/runtime/write_file_missing_directory.gdn:5:1] fs::list_directory(Path{ p: "/tmp/no_such_dir_garden/" }) //-> Err("Could not read directory `/tmp/no_such_dir_garden/`. No such file or directory (os error 2)")
 // [src/test_files/runtime/write_file_missing_directory.gdn:7:1] Path{ p: "/tmp/no_such_dir_garden/foo.txt" }.read() //-> Err("Could not read `/tmp/no_such_dir_garden/foo.txt`. No such file.")
 // [src/test_files/runtime/write_file_missing_directory.gdn:9:1] fs::write_file("hello world", Path{ p: "/tmp/no_such_dir_garden/bar.txt" }) //-> Err("Could not write `/tmp/no_such_dir_garden/bar.txt`. No such file or directory (os error 2)")
-


### PR DESCRIPTION
This change standardizes indentation across all runtime test files in `src/test_files/runtime/` from 4 spaces to 2 spaces, making them consistent with the Garden code style.

## Changes Made

- Updated indentation in 40+ runtime test files from 4 spaces to 2 spaces
- Adjusted expected output line/column numbers in test assertions to reflect the new indentation
- Fixed trailing whitespace and blank lines in several test files
- Updated `.github/workflows/test.yml` to add a new CI check that validates formatting of runtime test files

## Implementation Details

The formatter now correctly handles test files with reftest footers (lines starting with `// args:` and `// expected`). When a reftest footer is present, the formatter trims excess blank lines between the code body and the footer to ensure clean formatting. This is implemented in `src/main.rs` in the `Format` command handler.

The CI workflow now includes a dedicated step to check that all runtime test files conform to the expected formatting, preventing future inconsistencies.

https://claude.ai/code/session_014HvKrpq3opRH8YcdBJbNNj