### PR TITLE
Move source_directory to reflect module as source_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 **Goal: Offer actions when runtime errors occur.**
 **Goal: Fix precedence of `2 + 1 * 3.**
 
+## Standard Library
+
+Moved `source_directory()` from the prelude to `__reflect.gdn` and
+renamed it to `source_file()`, reflecting that it returns the path of
+the current source file.
+
 # 0.25 (released 29th May 2026)
 **Goal: Better REPL experience.**
 **Goal: Better runtime performance.**

--- a/editors/garden-mode.el
+++ b/editors/garden-mode.el
@@ -706,7 +706,7 @@ With a prefix argument, also save the stringified result to the kill ring."
          "eprint" "eprintln"
          "range" "read_line"
          "shell_arguments"
-         "sort_nums" "source_directory" "string_repr"
+         "sort_nums" "string_repr"
          "throw" "todo"
          )
        'symbols)

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -953,16 +953,6 @@ public fun string_repr<T>(value: T): String {
   __BUILT_IN_IMPLEMENTATION
 }
 
-/// Return the path of the directory that contains the current source
-/// file. Returns None when run directly in a CLI or JSON session.
-///
-/// ```
-/// source_directory() // Some(Path{ p: "/home/yourname/awesome_garden_project" })
-/// ```
-public fun source_directory(): Option<Path> {
-  __BUILT_IN_IMPLEMENTATION
-}
-
 /// Return the number of characters (codepoints) in the string.
 ///
 /// ```

--- a/src/__reflect.gdn
+++ b/src/__reflect.gdn
@@ -215,6 +215,16 @@ public fun built_in_files(): List<String> {
   __BUILT_IN_IMPLEMENTATION
 }
 
+/// Return the path of the current source file. Returns None when run
+/// directly in a CLI or JSON session.
+///
+/// ```
+/// source_file() // Some(Path{ p: "/home/yourname/awesome_garden_project/main.gdn" })
+/// ```
+public fun source_file(): Option<Path> {
+  __BUILT_IN_IMPLEMENTATION
+}
+
 test built_in_files {
   let files = built_in_files()
   assert(files.contains("__prelude.gdn"))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3209,7 +3209,7 @@ fn eval_built_in_call(
                 env.push_value(value);
             }
         }
-        BuiltInFunctionKind::PreludeSourceDirectory => {
+        BuiltInFunctionKind::ReflectSourceFile => {
             check_arity(
                 &SymbolName {
                     text: format!("{kind}"),

--- a/src/test_files/runtime/source_directory.gdn
+++ b/src/test_files/runtime/source_directory.gdn
@@ -1,7 +1,0 @@
-{
-  dbg(source_directory().or_throw().file_name())
-}
-
-// args: run
-// expected stderr:
-// [src/test_files/runtime/source_directory.gdn:2:3] source_directory().or_throw().file_name() //-> Some("source_directory.gdn")

--- a/src/test_files/runtime/source_file.gdn
+++ b/src/test_files/runtime/source_file.gdn
@@ -1,0 +1,9 @@
+import "__reflect.gdn" as reflect
+
+{
+  dbg(reflect::source_file().or_throw().file_name())
+}
+
+// args: run
+// expected stderr:
+// [src/test_files/runtime/source_file.gdn:4:3] reflect::source_file().or_throw().file_name() //-> Some("source_file.gdn")

--- a/src/values.rs
+++ b/src/values.rs
@@ -398,7 +398,6 @@ pub(crate) enum BuiltInFunctionKind {
     PreludePrintln,
     PreludeReadLine,
     PreludeShellArguments,
-    PreludeSourceDirectory,
     PreludeStringRepr,
     PreludeThrow,
 
@@ -428,6 +427,7 @@ pub(crate) enum BuiltInFunctionKind {
     ReflectMethodsForType,
     ReflectNamespaceFunctions,
     ReflectPreludeTypes,
+    ReflectSourceFile,
     ReflectSourceForFun,
     ReflectSourceForMethod,
     ReflectSourceForType,
@@ -445,7 +445,6 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::PreludeEprint
             | BuiltInFunctionKind::PreludeEprintln
             | BuiltInFunctionKind::PreludeReadLine
-            | BuiltInFunctionKind::PreludeSourceDirectory
             | BuiltInFunctionKind::PreludeShellArguments => PathBuf::from("__prelude.gdn"),
             BuiltInFunctionKind::ShellRun
             | BuiltInFunctionKind::ShellGetEnv
@@ -461,7 +460,8 @@ impl BuiltInFunctionKind {
             | BuiltInFunctionKind::FsReadFile
             | BuiltInFunctionKind::FsReadFileBytes
             | BuiltInFunctionKind::FsRemoveFile => PathBuf::from("__fs.gdn"),
-            BuiltInFunctionKind::ReflectSourceForFun
+            BuiltInFunctionKind::ReflectSourceFile
+            | BuiltInFunctionKind::ReflectSourceForFun
             | BuiltInFunctionKind::ReflectSourceForMethod
             | BuiltInFunctionKind::ReflectSourceForType
             | BuiltInFunctionKind::ReflectPreludeTypes
@@ -493,7 +493,6 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::PreludeEprint => "eprint",
             BuiltInFunctionKind::PreludeEprintln => "eprintln",
             BuiltInFunctionKind::PreludeReadLine => "read_line",
-            BuiltInFunctionKind::PreludeSourceDirectory => "source_directory",
             BuiltInFunctionKind::PreludeShellArguments => "shell_arguments",
             BuiltInFunctionKind::FsSetWorkingDirectory => "set_working_directory",
             BuiltInFunctionKind::FsWorkingDirectory => "working_directory",
@@ -504,6 +503,7 @@ impl Display for BuiltInFunctionKind {
             BuiltInFunctionKind::ReflectDocComment => "doc_comment",
             BuiltInFunctionKind::ReflectDocCommentForType => "doc_comment_for_type",
             BuiltInFunctionKind::ReflectDocCommentForMethod => "doc_comment_for_method",
+            BuiltInFunctionKind::ReflectSourceFile => "source_file",
             BuiltInFunctionKind::ReflectSourceForFun => "source_for_fun",
             BuiltInFunctionKind::ReflectSourceForMethod => "source_for_method",
             BuiltInFunctionKind::ReflectSourceForType => "source_for_type",

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -296,7 +296,7 @@ fun build_blog(website_dir: Path, out_dir: Path, base_tmpl_src: String): Unit {
 
 /// Build the entire garden website.
 fun build_site(): Unit {
-  let website_dir = source_dir_path().parent().or_throw().parent().or_throw().join("website")
+  let website_dir = source_file_path().parent().or_throw().parent().or_throw().join("website")
   fs::set_working_directory(website_dir).or_throw()
 
   let out_dir = website_dir.join("dist")
@@ -550,6 +550,6 @@ fun write_website_page(
   build_site()
 }
 
-fun source_dir_path(): Path {
-  source_directory().or_throw()
+fun source_file_path(): Path {
+  reflect::source_file().or_throw()
 }


### PR DESCRIPTION
Relocates the `source_directory()` function from the prelude to the `__reflect` module and renames it to `source_file()` to better reflect its actual behavior of returning the current source file path rather than just the directory.

**Key changes:**
- Moved `source_directory()` function from `__prelude.gdn` to `__reflect.gdn` and renamed to `source_file()`
- Updated function documentation to clarify it returns the full file path, not just the directory
- Updated `BuiltInFunctionKind` enum: removed `PreludeSourceDirectory` variant and added `ReflectSourceFile` variant
- Updated all references in `src/values.rs` to map the new variant to `__reflect.gdn`
- Updated `src/eval.rs` to handle the function in its new location
- Updated editor syntax highlighting in `garden-mode.el`
- Updated `website/build_site.gdn` to use the new function location
- Replaced test file `source_directory.gdn` with `source_file.gdn` with updated assertions

The function behavior remains the same—returning `Option<Path>` with the current source file path or `None` when run in CLI/JSON sessions—but is now properly categorized as a reflection utility rather than a prelude function.

https://claude.ai/code/session_01WRP8jhqvDTqtBuVikewCP7