### PR TITLE
Add shell namespace documentation to website

### DIFF
--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -478,6 +478,11 @@ fun substitute_shorthand(website_dir: Path, src: String): String {
   })
   let reflect_funs = join_with_commas_and(reflect_funs)
 
+  let shell_funs = reflect::namespace_functions(shell).map(fun(name: String) {
+    code_link(name ^ "()", "./fun:__shell.gdn::" ^ name ^ ".html")
+  })
+  let shell_funs = join_with_commas_and(shell_funs)
+
   let time_funs = reflect::namespace_functions(time).map(fun(name: String) {
     code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
   })
@@ -519,6 +524,7 @@ fun substitute_shorthand(website_dir: Path, src: String): String {
     .replace("__FS_FUNS", fs_funs)
     .replace("__RANDOM_FUNS", random_funs)
     .replace("__REFLECT_FUNS", reflect_funs)
+    .replace("__SHELL_FUNS", shell_funs)
     .replace("__TIME_FUNS", time_funs)
     .replace("__BLOG_LINKS", blog_links)
 }

--- a/website/manual.md
+++ b/website/manual.md
@@ -30,6 +30,10 @@ __RANDOM_FUNS
 
 __REFLECT_FUNS
 
+## Shell `__shell.gdn`
+
+__SHELL_FUNS
+
 ## Time `__time.gdn`
 
 __TIME_FUNS


### PR DESCRIPTION
Add documentation for the `__shell.gdn` built-in namespace to the generated website.

**Changes:**
- Generate function links for the shell namespace in `build_site.gdn`, following the same pattern used for other built-in namespaces (fs, random, reflect, time)
- Add a new "Shell" section to `manual.md` that displays the generated shell function links
- The shell functions are automatically extracted via `reflect::namespace_functions(shell)` and formatted as code links to their documentation pages

This makes the shell namespace functions discoverable in the website documentation alongside the other built-in namespaces.

https://claude.ai/code/session_01U9612qRbBK3ZMd2UQ9Voyr