### PR TITLE
Remove stale diagnostic clearing from editor update listener

### DIFF
--- a/website/static/editor.ts
+++ b/website/static/editor.ts
@@ -26,14 +26,8 @@ export function createGardenEditor(
       // pushed via setEditorDiagnostics after a /check call.
       linter(() => [], { delay: 0 }),
       EditorView.updateListener.of((update) => {
-        if (update.docChanged) {
-          // Clear stale diagnostics once the user edits.
-          queueMicrotask(() => {
-            update.view.dispatch(setDiagnostics(update.view.state, []));
-          });
-          if (onDocChanged) {
-            onDocChanged(update.state.sliceDoc());
-          }
+        if (update.docChanged && onDocChanged) {
+          onDocChanged(update.state.sliceDoc());
         }
       }),
     ],


### PR DESCRIPTION
Simplifies the editor update listener by removing the logic that clears stale diagnostics when the document changes.

## Summary
The `onDocChanged` callback is now invoked directly without the intermediate step of clearing diagnostics via `setDiagnostics`. This removes unnecessary microtask queueing and diagnostic state management from the editor's update handler.

## Changes
- Removed the `queueMicrotask` call that cleared diagnostics on document changes
- Removed the `setDiagnostics(update.view.state, [])` dispatch call
- Simplified the condition to only invoke `onDocChanged` when the document has changed and the callback exists
- Reduced the update listener from 9 lines to 3 lines of logic

## Implementation Details
The change assumes that diagnostic clearing is handled elsewhere in the application flow (likely through the `/check` call mechanism mentioned in the surrounding comments), making the local clearing redundant.

https://claude.ai/code/session_01WPFDYCY15v74PJS5gWsMoL