### PR TITLE
Highlight both parens on arity errors when called with no arguments

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -586,12 +586,17 @@ impl TypeCheckVisitor<'_> {
                         msgtext!(" argument."),
                     ])
                 };
+                let position = if paren_args.arguments.is_empty() {
+                    Position::merge(&paren_args.open_paren, &paren_args.close_paren)
+                } else {
+                    paren_args.close_paren.clone()
+                };
                 self.diagnostics.push(Diagnostic {
                     notes: vec![],
                     fixes: vec![],
                     severity: Severity::Error,
                     message,
-                    position: paren_args.close_paren.clone(),
+                    position,
                 });
                 return;
             }

--- a/src/test_files/check/dbg_no_args.gdn
+++ b/src/test_files/check/dbg_no_args.gdn
@@ -5,6 +5,7 @@ dbg()
 // expected stdout:
 // Error: `dbg` requires an additional argument.
 // 
-// -| src/test_files/check/dbg_no_args.gdn:1:5
+// -| src/test_files/check/dbg_no_args.gdn:1:4
 // 1| dbg()
-// 2|     ^
+// 2|    ^^
+

--- a/src/test_files/check/fun_no_args_arity.gdn
+++ b/src/test_files/check/fun_no_args_arity.gdn
@@ -1,0 +1,24 @@
+fun foo(x: Int): Unit {}
+
+{
+  foo()
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: `x` is unused.
+// 
+// -| src/test_files/check/fun_no_args_arity.gdn:1:9
+// 1| fun foo(x: Int): Unit {}
+// 2|         ^
+// 3| {
+// 
+// Error: `foo` requires an additional `Int` argument.
+// 
+// -| src/test_files/check/fun_no_args_arity.gdn:4:6
+// 3| {
+// 4|   foo()
+// 5| }    ^^
+
+// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check/type_error_lambda.gdn
+++ b/src/test_files/check/type_error_lambda.gdn
@@ -16,8 +16,9 @@
 // 
 // Error: This function call requires an additional `Int` argument.
 // 
-// -| src/test_files/check/type_error_lambda.gdn:3:7
+// -| src/test_files/check/type_error_lambda.gdn:3:6
 // 1| {
 // 2|     let f = fun(x: Int): Int { x.no_such_meth() }
 // 3|     f()
-// 4| }     ^
+// 4| }    ^^
+


### PR DESCRIPTION
When a function expects arguments but is called with none, highlight both the open and close paren instead of just the close paren.

Before: `foo()` squiggle on `)` only
After: `foo()` squiggle on `()`

https://claude.ai/code/session_017MuwVSKevdERQrbXA9awhd