### PR TITLE
Add code formatting feature to playground

### DIFF
--- a/playground/index.js
+++ b/playground/index.js
@@ -72,6 +72,13 @@ app.get('/', (req, res) => {
           src: 'Garden source code to check (string, required)'
         },
         returns: 'JSON object with success status and a list of diagnostics'
+      },
+      'POST /format': {
+        description: 'Format Garden code and return the re-indented source',
+        parameters: {
+          src: 'Garden source code to format (string, required)'
+        },
+        returns: 'JSON object with success status and the formatted source'
       }
     }
   });
@@ -214,6 +221,55 @@ app.post('/check', (req, res) => {
           rawOutput: stdout
         });
       }
+    });
+  });
+});
+
+app.post('/format', (req, res) => {
+  const { src } = req.body;
+
+  if (src === undefined || src === null) {
+    return res.status(400).json({
+      success: false,
+      error: 'src parameter is required'
+    });
+  }
+
+  const codePreview = src.length > 200 ? src.substring(0, 200) + '...' : src;
+  logger.info({
+    codeLength: src.length,
+    codePreview
+  }, 'Formatting code');
+
+  const tmpFile = path.join(os.tmpdir(), `garden-format-${Date.now()}-${Math.random().toString(36).substr(2, 9)}.gdn`);
+
+  fs.writeFile(tmpFile, src, (writeError) => {
+    if (writeError) {
+      return res.json({
+        success: false,
+        error: writeError.message
+      });
+    }
+
+    exec(`garden format "${tmpFile}"`, (execError, stdout, stderr) => {
+      fs.unlink(tmpFile, (unlinkError) => {
+        if (unlinkError) {
+          logger.error({ error: unlinkError.message, tmpFile }, 'Failed to delete temp file');
+        }
+      });
+
+      if (execError) {
+        return res.json({
+          success: false,
+          error: `Format failed: ${execError.message}`,
+          stderr: stderr
+        });
+      }
+
+      res.json({
+        success: true,
+        formatted: stdout
+      });
     });
   });
 });

--- a/website/playground.md
+++ b/website/playground.md
@@ -1,6 +1,6 @@
 # Playground
 
-<div id="playground-wrapper"><textarea rows="5" id="playground-editor">println("Hello World!")</textarea><button id="playground-run">Run</button><div id="playground-output" hidden></div></div>
+<div id="playground-wrapper"><textarea rows="5" id="playground-editor">println("Hello World!")</textarea><button id="playground-run">Run</button><button id="playground-format">Format</button><div id="playground-output" hidden></div></div>
 
 
 

--- a/website/static/api.ts
+++ b/website/static/api.ts
@@ -120,6 +120,38 @@ export function evalSnippet(src: string, snippetDiv: HTMLElement): void {
     });
 }
 
+type FormatResponse = {
+  success: boolean;
+  formatted?: string;
+  error?: string;
+};
+
+export function formatSnippet(
+  src: string,
+  onFormatted: (formatted: string) => void,
+  onError: (message: string) => void,
+): void {
+  fetch(`${PLAYGROUND_HOST}/format`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ src }),
+  })
+    .then((response) => response.json())
+    .then((data: FormatResponse) => {
+      if (!data.success || data.formatted === undefined) {
+        onError(data.error || "Unknown error");
+        return;
+      }
+      onFormatted(data.formatted);
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      onError(message);
+    });
+}
+
 export function fetchDiagnostics(
   src: string,
   onDiagnostics: (diagnostics: CheckDiagnostic[]) => void,

--- a/website/static/editor.ts
+++ b/website/static/editor.ts
@@ -36,6 +36,12 @@ export function createGardenEditor(
   return new EditorView({ state });
 }
 
+export function setEditorContent(view: EditorView, content: string): void {
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: content },
+  });
+}
+
 export function setEditorDiagnostics(
   view: EditorView,
   diagnostics: CheckDiagnostic[],

--- a/website/static/playground.ts
+++ b/website/static/playground.ts
@@ -1,5 +1,9 @@
-import { evalSnippet, fetchDiagnostics } from "./api";
-import { createGardenEditor, setEditorDiagnostics } from "./editor";
+import { evalSnippet, fetchDiagnostics, formatSnippet } from "./api";
+import {
+  createGardenEditor,
+  setEditorContent,
+  setEditorDiagnostics,
+} from "./editor";
 import { setupSnippetButtons } from "./snippets";
 
 // How long to wait after the last edit before checking the code.
@@ -7,10 +11,12 @@ const CHECK_DEBOUNCE_MS = 250;
 
 function setupPlayground(): void {
   const playgroundRunButton = document.querySelector("#playground-run");
+  const playgroundFormatButton = document.querySelector("#playground-format");
   const playgroundEditor = document.querySelector("#playground-editor");
   const playgroundOutput = document.querySelector("#playground-output");
   if (
     playgroundRunButton &&
+    playgroundFormatButton &&
     playgroundOutput &&
     playgroundOutput instanceof HTMLElement &&
     playgroundEditor &&
@@ -38,6 +44,20 @@ function setupPlayground(): void {
     playgroundRunButton.addEventListener("click", () => {
       const src = editorView.state.sliceDoc();
       evalSnippet(src, playgroundOutput);
+    });
+
+    playgroundFormatButton.addEventListener("click", () => {
+      const src = editorView.state.sliceDoc();
+      formatSnippet(
+        src,
+        (formatted) => {
+          setEditorContent(editorView, formatted);
+        },
+        (message) => {
+          playgroundOutput.hidden = false;
+          playgroundOutput.textContent = `Format error: ${message}`;
+        },
+      );
     });
 
     // Check the initial content so diagnostics show without an edit.

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -261,8 +261,13 @@ header a {
   margin: 10px;
 }
 
-#playground-run {
+#playground-run,
+#playground-format {
   margin-top: 10px;
+}
+
+#playground-format {
+  margin-left: 5px;
 }
 
 textarea {


### PR DESCRIPTION
Add a new `/format` endpoint to the playground that formats Garden source code and returns the re-indented result. This includes both backend and frontend changes to support formatting through the playground UI.

**Key changes:**

- **Backend (`playground/index.js`)**: Added `POST /format` endpoint that accepts Garden source code, writes it to a temporary file, runs the `garden format` command, and returns the formatted output
- **Frontend API (`website/static/api.ts`)**: Added `formatSnippet()` function to call the new `/format` endpoint with error handling
- **Playground UI (`website/static/playground.ts`)**: Added format button click handler that calls `formatSnippet()` and updates the editor with formatted code
- **Editor utilities (`website/static/editor.ts`)**: Added `setEditorContent()` function to programmatically update editor content
- **Styling (`website/static/style.css`)**: Added styling for the new format button
- **Markup (`website/playground.md`)**: Added format button to the playground interface

The implementation follows the same pattern as the existing check endpoint, with proper error handling and temporary file cleanup.

https://claude.ai/code/session_01LTcLJ5MMNxaaVvitZg11cs