### PR TITLE
Change TypeScript moduleResolution from node to bundler

### DIFF
--- a/website/static/tsconfig.json
+++ b/website/static/tsconfig.json
@@ -8,7 +8,7 @@
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
     "module": "es2015",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "es2015",
     "types": [],
 


### PR DESCRIPTION
Update the TypeScript configuration in the website static assets to use the `bundler` module resolution strategy instead of `node`.

## Summary
This change updates `website/static/tsconfig.json` to use `"bundler"` as the `moduleResolution` setting, which is the recommended module resolution strategy for bundled applications.

## Changes
- Changed `moduleResolution` from `"node"` to `"bundler"` in `website/static/tsconfig.json`

## Details
The `bundler` module resolution strategy is designed for projects that use bundlers (like webpack, esbuild, etc.) and provides better compatibility with modern bundling tools. This aligns the TypeScript configuration with current best practices for web projects.

https://claude.ai/code/session_01HqxYwACp5DAhxnRr32kXsE