### PR TITLE
Remove bottom margin from lint panel list items

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -378,6 +378,11 @@ ul li {
   margin-bottom: 1em;
 }
 
+.cm-tooltip-lint li,
+.cm-panel-lint li {
+  margin-bottom: 0;
+}
+
 /* Nested lists should still be indented. */
 ul ul {
   margin-left: 1em;


### PR DESCRIPTION
Remove the default bottom margin from list items in CodeMirror's lint tooltip and panel components.

The lint UI components (`.cm-tooltip-lint` and `.cm-panel-lint`) display lists of diagnostics. These lists were inheriting the `1em` bottom margin from the global `ul li` rule, causing excessive spacing between lint items. This change adds a targeted rule to reset the margin for these specific list items to `0`, improving the visual density of the lint UI.

https://claude.ai/code/session_01WMiGiGi2ndGKLiYKPq5kgk