### PR TITLE
Improve EOF error messages for clarity

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -73,7 +73,7 @@ fn require_a_token<'a>(
 
             diagnostics.push(ParseError::Incomplete {
                 message: ErrorMessage(vec![msgtext!(
-                    "Expected {}, but got EOF.",
+                    "Expected {}, but reached the end of the file.",
                     token_description
                 )]),
                 position,
@@ -142,7 +142,7 @@ fn check_required_token<'a>(
                 message: ErrorMessage(vec![
                     msgtext!("Expected "),
                     msgcode!("{}", expected),
-                    msgtext!(", but got EOF."),
+                    msgtext!(", but reached the end of the file."),
                 ]),
                 position,
             });
@@ -431,7 +431,7 @@ fn parse_dict_literal_items(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!("]"),
-                    msgtext!(", but got EOF."),
+                    msgtext!(", but reached the end of the file."),
                 ]),
             });
             break;
@@ -925,7 +925,7 @@ fn parse_struct_literal_fields(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!("}}"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;
@@ -987,7 +987,7 @@ fn parse_match(
                 message: ErrorMessage(vec![
                     msgtext!("Expected "),
                     msgcode!("}}"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;
@@ -1166,7 +1166,7 @@ fn parse_comma_separated_exprs(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!("{}", terminator),
-                    msgtext!(", but got EOF."),
+                    msgtext!(", but reached the end of the file."),
                 ]),
             });
             break;
@@ -1577,7 +1577,7 @@ fn parse_enum_body(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!("}}"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;
@@ -1871,7 +1871,7 @@ fn parse_type_arguments(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!(">"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break arg_pos;
@@ -1934,7 +1934,7 @@ fn parse_type_params(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!(">"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;
@@ -1974,7 +1974,7 @@ fn parse_tuple_type_hint(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!(")"),
-                    msgtext!(" after this, but got EOF."),
+                    msgtext!(" after this, but reached the end of the file."),
                 ]),
             });
             break;
@@ -2180,7 +2180,7 @@ fn parse_parameters(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!(")"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;
@@ -2255,7 +2255,7 @@ fn parse_struct_fields(
                 message: ErrorMessage(vec![
                     msgtext!("Expected a struct field name here, such as "),
                     msgcode!("age: Int"),
-                    msgtext!(", but got EOF."),
+                    msgtext!(", but reached the end of the file."),
                 ]),
             });
             break;
@@ -2290,7 +2290,7 @@ fn parse_struct_fields(
                     msgcode!(","),
                     msgtext!(" or "),
                     msgcode!("}}"),
-                    msgtext!(" here, but got EOF."),
+                    msgtext!(" here, but reached the end of the file."),
                 ]),
             });
             break;

--- a/src/test_files/nrepl/load_file_parse_error.jsonl
+++ b/src/test_files/nrepl/load_file_parse_error.jsonl
@@ -10,7 +10,7 @@
 //   ]
 // }
 // {
-//   "err": "Expected variable name, but got EOF.\nExpected a parameter name after this.\nExpected `,` or `)` here, but got `(`.\nExpected `)` after this.\nExpected `{` after this.\nExpected an expression after this.\nExpected `)`, but got EOF.\n",
+//   "err": "Expected variable name, but reached the end of the file.\nExpected a parameter name after this.\nExpected `,` or `)` here, but got `(`.\nExpected `)` after this.\nExpected `{` after this.\nExpected an expression after this.\nExpected `)`, but reached the end of the file.\n",
 //   "session": "garden-1"
 // }
 // {

--- a/src/test_files/run_code_blocks/bad_syntax.gdn
+++ b/src/test_files/run_code_blocks/bad_syntax.gdn
@@ -6,6 +6,6 @@ fun foo() {
 // args: run-code-blocks
 // expected exit status: 1
 // expected stderr:
-// Expected `}`, but got EOF.
+// Expected `}`, but reached the end of the file.
 // Parsing failed.
 // Checked 1 block in 1 file.


### PR DESCRIPTION
Replace "but got EOF" with "but reached the end of the file" in parser error messages for better clarity and consistency.

This change improves the user experience by using more natural language in error messages when the parser encounters an unexpected end of file. The phrase "reached the end of the file" is clearer and more user-friendly than the technical "got EOF".

**Changes made:**
- Updated 14 error messages across the parser to use "reached the end of the file" instead of "got EOF"
- Updated corresponding test expectations in `load_file_parse_error.jsonl` and `bad_syntax.gdn`

**Affected areas:**
- `require_a_token()` — general token expectation errors
- `check_required_token()` — required token validation
- `parse_dict_literal_items()` — dictionary parsing
- `parse_struct_literal_fields()` — struct literal parsing
- `parse_match()` — match expression parsing
- `parse_comma_separated_exprs()` — expression list parsing
- `parse_enum_body()` — enum definition parsing
- `parse_type_arguments()` and `parse_type_params()` — type parameter parsing
- `parse_tuple_type_hint()` — tuple type parsing
- `parse_parameters()` — function parameter parsing
- `parse_struct_fields()` — struct field definition parsing

https://claude.ai/code/session_014hxUhB9YURhZUft1Ynog5y