### PR TITLE
Change __shell::run() to return (Int, String, String)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Standard Library
 
+`__shell::run()` now returns `(Int, String, String)`, always providing
+the exit code, stdout and stderr. Previously it returned a `Result`
+with different tuple shapes for success and failure.
+
 Moved `source_directory()` from the prelude to `__reflect.gdn` and
 renamed it to `source_file()`, reflecting that it returns the path of
 the current source file.

--- a/sample_programs/git_fuzzy_branch.gdn
+++ b/sample_programs/git_fuzzy_branch.gdn
@@ -8,7 +8,7 @@ fun in_git_repo(): Bool {
 }
 
 fun check_out(branch_name: String): Unit {
-  let (stdout, _) = shell::run("git", ["checkout", branch_name]).or_throw()
+  let (_, stdout, _) = shell::run("git", ["checkout", branch_name])
   print(stdout)
 }
 
@@ -25,8 +25,7 @@ fun check_out(branch_name: String): Unit {
     return
   }
 
-  let (branches_output, _) = shell::run("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
-    .or_throw()
+  let (_, branches_output, _) = shell::run("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
   let all_branches = branches_output.lines()
   if all_branches.contains(needle) {
     // If there's a branch with this name exactly, use it.

--- a/src/__shell.gdn
+++ b/src/__shell.gdn
@@ -1,15 +1,14 @@
 /// Execute the given string as a shell command, and return a tuple
-/// of stdout and stderr.
+/// of the exit code, stdout and stderr.
 ///
-/// On failure, returns a tuple of the exit code and the combined
-/// stdout and stderr output. The exit code is `-1` if the command
-/// could not be spawned or was terminated by a signal.
+/// The exit code is `-1` if the command could not be spawned or was
+/// terminated by a signal.
 ///
 /// ```
 /// import "__shell.gdn" as shell
 /// shell::run("ls", ["-l", "/"])
 /// ```
-public fun run(command: String, args: List<String>): Result<(String, String), (Int, String)> {
+public fun run(command: String, args: List<String>): (Int, String, String) {
   __BUILT_IN_IMPLEMENTATION
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4,7 +4,6 @@
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2889,45 +2888,27 @@ fn eval_built_in_call(
                     let v = match command.output() {
                         Ok(output) => {
                             // TODO: complain if output is not UTF-8.
-                            if output.status.success() {
-                                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-                                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                            let exit_code = output.status.code().unwrap_or(-1);
 
-                                let tuple = Value::new(Value_::Tuple {
-                                    items: vec![
-                                        Value::new(Value_::String(stdout)),
-                                        Value::new(Value_::String(stderr)),
-                                    ],
-                                    item_types: vec![Type::string(), Type::string()],
-                                });
-                                Value::ok(tuple)
-                            } else {
-                                let mut s = String::new();
-                                s.write_str(&String::from_utf8_lossy(&output.stdout))
-                                    .unwrap();
-                                s.write_str(&String::from_utf8_lossy(&output.stderr))
-                                    .unwrap();
-                                let exit_code = output.status.code().unwrap_or(-1);
-                                let tuple = Value::new(Value_::Tuple {
-                                    items: vec![
-                                        Value::new(Value_::Int(exit_code as i64)),
-                                        Value::new(Value_::String(s)),
-                                    ],
-                                    item_types: vec![Type::int(), Type::string()],
-                                });
-                                Value::err(tuple)
-                            }
-                        }
-                        Err(e) => {
-                            let tuple = Value::new(Value_::Tuple {
+                            Value::new(Value_::Tuple {
                                 items: vec![
-                                    Value::new(Value_::Int(-1)),
-                                    Value::new(Value_::String(format!("{e}"))),
+                                    Value::new(Value_::Int(exit_code as i64)),
+                                    Value::new(Value_::String(stdout)),
+                                    Value::new(Value_::String(stderr)),
                                 ],
-                                item_types: vec![Type::int(), Type::string()],
-                            });
-                            Value::err(tuple)
+                                item_types: vec![Type::int(), Type::string(), Type::string()],
+                            })
                         }
+                        Err(e) => Value::new(Value_::Tuple {
+                            items: vec![
+                                Value::new(Value_::Int(-1)),
+                                Value::new(Value_::String(String::new())),
+                                Value::new(Value_::String(format!("{e}"))),
+                            ],
+                            item_types: vec![Type::int(), Type::string(), Type::string()],
+                        }),
                     };
 
                     if expr_value_is_used {

--- a/src/test_files/runtime/shell_invalid_command.gdn
+++ b/src/test_files/runtime/shell_invalid_command.gdn
@@ -6,5 +6,4 @@ import "__shell.gdn" as shell
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/shell_invalid_command.gdn:4:3] shell::run("no_such_command", []) //-> Err((-1, "No such file or directory (os error 2)"))
-
+// [src/test_files/runtime/shell_invalid_command.gdn:4:3] shell::run("no_such_command", []) //-> (-1, "", "No such file or directory (os error 2)")

--- a/src/test_files/runtime/shell_tuple.gdn
+++ b/src/test_files/runtime/shell_tuple.gdn
@@ -1,13 +1,14 @@
 import "__shell.gdn" as shell
 
 {
-  let (stdout, stderr) = shell::run("sh", ["-c", "echo out; echo err 1>&2"]).or_throw()
+  let (exit_code, stdout, stderr) = shell::run("sh", ["-c", "echo out; echo err 1>&2"])
+  dbg(exit_code)
   dbg(stdout)
   dbg(stderr)
 }
 
 // args: run
 // expected stderr:
-// [src/test_files/runtime/shell_tuple.gdn:5:3] stdout //-> "out\n"
-// [src/test_files/runtime/shell_tuple.gdn:6:3] stderr //-> "err\n"
-
+// [src/test_files/runtime/shell_tuple.gdn:5:3] exit_code //-> 0
+// [src/test_files/runtime/shell_tuple.gdn:6:3] stdout //-> "out\n"
+// [src/test_files/runtime/shell_tuple.gdn:7:3] stderr //-> "err\n"


### PR DESCRIPTION
## Summary

`__shell::run()` now always returns `(Int, String, String)` — the exit code, stdout, and stderr — instead of a `Result` with different tuple shapes for success and failure.

Previously the signature was `Result<(String, String), (Int, String)>`:
- success: `Ok((stdout, stderr))`
- failure: `Err((exit_code, combined_stdout_and_stderr))`

Now callers always get the exit code alongside separated stdout/stderr and decide for themselves what counts as failure. The exit code is `-1` if the command could not be spawned or was terminated by a signal; on a spawn error stdout is empty and stderr holds the error message.

## Changes

- **`src/__shell.gdn`** — Updated `run` signature and doc comment.
- **`src/eval.rs`** — `ShellRun` builtin builds a single 3-element tuple unconditionally; removed the now-unused `std::fmt::Write` import.
- **Reftests** — Updated `shell_tuple.gdn` and `shell_invalid_command.gdn`.
- **`sample_programs/git_fuzzy_branch.gdn`** — Updated both call sites to destructure `(_, stdout, _)` and dropped `.or_throw()`.
- **`CHANGELOG.md`** — Added an entry under Standard Library.

## Note

This is a **breaking API change** for Garden code calling `shell::run` — callers matching on `Result`/`.or_throw()` or the old 2-tuples must update.

## Verification

- `cargo build` — succeeds
- `cargo test reftest` — 21 passed, 0 failed
- `cargo clippy` — clean
- `cargo fmt` — applied

https://claude.ai/code/session_01GeETzKKDxxfiAMYGK3bkHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeETzKKDxxfiAMYGK3bkHh)_