### PR TITLE
Document __shell and __time built-in files and garden format command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ test add_one_to_two {
 }
 ```
 
-The built-in files available are `__fs`, `__random` and
-`__reflect`. You can import and use them like this:
+The built-in files available are `__fs`, `__random`, `__reflect`,
+`__shell` and `__time`. You can import and use them like this:
 
 ```
 import "__fs.gdn" as fs
@@ -66,7 +66,7 @@ use crate::{msgcode, msgtext};
 ErrorMessage(vec![
     msgtext!("Unknown built-in file "),
     msgcode!("{}", path.display()),
-    msgtext!(". Available files are: __fs, __random, __reflect."),
+    msgtext!(". Available files are: __fs, __random, __reflect, __shell, __time."),
 ])
 ```
 
@@ -183,6 +183,10 @@ output.
 - ./target/debug/garden run yourfile.gdn: Run the code in yourfile.gdn.
 - ./target/debug/garden run -c 'println("Hello")': Run a code snippet directly without a file.
 - ./target/debug/garden test yourfile.gdn: Run unit tests in yourfile.gdn.
+- ./target/debug/garden format yourfile.gdn: Print yourfile.gdn re-indented. Pass --check to exit non-zero when the file is not already formatted instead of printing.
+
+Garden source uses 2-space indentation. Run `garden format` on `.gdn`
+files you change to match the project convention.
 
 To generate target/debug/garden use `cargo build`. This separation
 allows Claude to set permissions on separate Garden subcommands.


### PR DESCRIPTION
Updates CLAUDE.md to reflect recent additions to the Garden toolchain.

**Changes:**
- Added `__shell` and `__time` to the list of available built-in files in the documentation
- Updated the error message for unknown built-in files to include `__shell` and `__time`
- Documented the `garden format` subcommand, which re-indents Garden source files
- Added guidance on using 2-space indentation and running `garden format` on modified `.gdn` files to match project conventions

These changes ensure the documentation accurately reflects the current set of built-in modules and development tools available to Garden users.

https://claude.ai/code/session_01Lt3eKPBYH76DyAmhMDNRkJ