### PR TITLE
Normalize spacing around commas, arrows, and control-flow keywords

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -70,9 +70,13 @@ pub(crate) fn format(src: &str, path: &Path) -> String {
     let src_after_blanks = normalize_blank_lines(&src_after_indent, &visitor.toplevel_start_lines);
 
     // Phase 7: Fix type annotation spacing
-    let mut result = fix_type_annotation_spacing(&src_after_blanks, &vfs_path);
+    let src_after_types = fix_type_annotation_spacing(&src_after_blanks, &vfs_path);
 
-    // Phase 8: Ensure non-empty output ends with exactly one newline.
+    // Phase 8: Normalize spacing around commas, `=>` arrows,
+    // compound-assignment operators, and control-flow keywords.
+    let mut result = normalize_token_spacing(&src_after_types, &vfs_path);
+
+    // Phase 9: Ensure non-empty output ends with exactly one newline.
     while result.ends_with("\n\n") {
         result.pop();
     }
@@ -881,6 +885,90 @@ fn fix_type_annotation_spacing(src: &str, vfs_path: &crate::parser::vfs::VfsPath
     }
 
     result
+}
+
+/// Control-flow keywords that should be separated from a following `(`
+/// by a single space, e.g. `if(x)` becomes `if (x)`. Function-call-style
+/// constructs such as `assert(...)` are deliberately excluded.
+const SPACED_BEFORE_PAREN: &[&str] = &["if", "while", "for", "match", "return"];
+
+/// Normalize whitespace around commas, `=>` arrows, compound-assignment
+/// operators (`+=`, `-=`), and control-flow keywords.
+///
+/// This works on the gaps between adjacent tokens produced by the lexer,
+/// so it never touches whitespace inside string literals. Gaps that span
+/// a newline or contain a comment are left untouched, which preserves
+/// intentional line breaks (such as wrapped argument lists with trailing
+/// commas) and comment placement.
+///
+/// The rules are:
+/// - No space before a comma (`a ,b` -> `a,b`).
+/// - Exactly one space after a comma, unless the comma is immediately
+///   followed by a closing delimiter (a trailing comma).
+/// - Exactly one space on each side of a `=>` arrow.
+/// - Exactly one space on each side of a `+=` or `-=` operator.
+/// - A single space between a control-flow keyword and a following `(`.
+fn normalize_token_spacing(src: &str, vfs_path: &crate::parser::vfs::VfsPathBuf) -> String {
+    let (mut token_stream, _) = lex_between(vfs_path, src, 0, src.len());
+
+    let mut tokens = vec![];
+    while let Some(token) = token_stream.pop() {
+        tokens.push(token);
+    }
+
+    let mut edits: Vec<SpanEdit> = vec![];
+
+    for pair in tokens.windows(2) {
+        let prev = &pair[0];
+        let next = &pair[1];
+
+        let gap_start = prev.position.end_offset;
+        let gap_end = next.position.start_offset;
+        if gap_start > gap_end {
+            continue;
+        }
+        let gap = &src[gap_start..gap_end];
+
+        // Preserve comments and intentional line breaks. A `/` in an
+        // inter-token gap can only be the start of a comment, since
+        // division operators are tokens in their own right.
+        if gap.contains('/') || gap.contains('\n') {
+            continue;
+        }
+
+        let desired: Option<&str> = if next.text == "," {
+            // No space before a comma.
+            Some("")
+        } else if prev.text == "," {
+            // One space after a comma, but not before a closing delimiter.
+            if matches!(next.text, ")" | "]" | "}") {
+                Some("")
+            } else {
+                Some(" ")
+            }
+        } else if prev.text == "=>"
+            || next.text == "=>"
+            || matches!(prev.text, "+=" | "-=")
+            || matches!(next.text, "+=" | "-=")
+            || (SPACED_BEFORE_PAREN.contains(&prev.text) && next.text == "(")
+        {
+            Some(" ")
+        } else {
+            None
+        };
+
+        if let Some(desired) = desired {
+            if gap != desired {
+                edits.push(SpanEdit {
+                    start_offset: gap_start,
+                    end_offset: gap_end,
+                    replacement: desired.to_owned(),
+                });
+            }
+        }
+    }
+
+    apply_span_edits(src, &mut edits)
 }
 
 /// Wrap function and method signatures that fit on a single line

--- a/src/test_files/format/arrow_spacing.gdn
+++ b/src/test_files/format/arrow_spacing.gdn
@@ -1,0 +1,20 @@
+fun foo(x: Int): Int {
+  let d = Dict[1=>2, 3 =>4, 5=> 6]
+  match (x) {
+    1 =>10
+    2=> 20
+    _ => 30
+  }
+}
+
+// args: format
+// expected stdout:
+// fun foo(x: Int): Int {
+//   let d = Dict[1 => 2, 3 => 4, 5 => 6]
+//   match (x) {
+//     1 => 10
+//     2 => 20
+//     _ => 30
+//   }
+// }
+

--- a/src/test_files/format/comma_spacing.gdn
+++ b/src/test_files/format/comma_spacing.gdn
@@ -1,0 +1,18 @@
+fun foo(a:Int,b:Int): Int {
+  let xs = [1,2,3]
+  let t = (1 ,2 , 3)
+  bar(a,b,c)
+  baz(x , y)
+  a + b
+}
+
+// args: format
+// expected stdout:
+// fun foo(a: Int, b: Int): Int {
+//   let xs = [1, 2, 3]
+//   let t = (1, 2, 3)
+//   bar(a, b, c)
+//   baz(x, y)
+//   a + b
+// }
+

--- a/src/test_files/format/compound_assignment.gdn
+++ b/src/test_files/format/compound_assignment.gdn
@@ -1,0 +1,16 @@
+fun foo(): Unit {
+  let x = 1
+  x+=1
+  x  -=  2
+  x += 3
+}
+
+// args: format
+// expected stdout:
+// fun foo(): Unit {
+//   let x = 1
+//   x += 1
+//   x -= 2
+//   x += 3
+// }
+

--- a/src/test_files/format/keyword_paren_spacing.gdn
+++ b/src/test_files/format/keyword_paren_spacing.gdn
@@ -1,0 +1,34 @@
+fun foo(a: Bool, b: Bool): Unit {
+  if(a) {
+    1
+  }
+  while(b) {
+    2
+  }
+  for(x, y) in [(1, 2)] {
+    3
+  }
+  match(a) {
+    _ => 4
+  }
+  assert(a)
+}
+
+// args: format
+// expected stdout:
+// fun foo(a: Bool, b: Bool): Unit {
+//   if (a) {
+//     1
+//   }
+//   while (b) {
+//     2
+//   }
+//   for (x, y) in [(1, 2)] {
+//     3
+//   }
+//   match (a) {
+//     _ => 4
+//   }
+//   assert(a)
+// }
+

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -115,7 +115,7 @@ fun render_doc_comment(
 
   doc_comment = doc_comment.replace("\n\n```\n", "\n\n```title:Example\n")
 
-  let md_src = "".join([heading, "\n\n" , doc_comment, "\n\n", src])
+  let md_src = "".join([heading, "\n\n", doc_comment, "\n\n", src])
   markdown::render(md_src, file, self_url)
 }
 
@@ -138,7 +138,7 @@ fun render_type_doc_comment(
     "\n\n## Methods\n\n" ^ "\n".join(method_list)
   }
 
-  let md_src = "".join([heading, "\n\n" , doc_comment, "\n\n", src, methods_section])
+  let md_src = "".join([heading, "\n\n", doc_comment, "\n\n", src, methods_section])
   markdown::render(md_src, None, self_url)
 }
 


### PR DESCRIPTION
Add a new formatting phase that normalizes whitespace around commas, `=>` arrows, compound-assignment operators (`+=`, `-=`), and control-flow keywords (`if`, `while`, `for`, `match`, `return`).

## Changes

- Added `normalize_token_spacing()` function that processes inter-token gaps to enforce consistent spacing rules:
  - No space before commas
  - One space after commas (except before closing delimiters for trailing commas)
  - One space on each side of `=>` arrows
  - One space on each side of `+=` and `-=` operators
  - One space between control-flow keywords and following `(`
  - Preserves comments and intentional line breaks by skipping gaps containing `/` or newlines

- Integrated the new phase into the formatting pipeline as Phase 8, after type annotation spacing

- Added test cases covering:
  - Keyword-parenthesis spacing (`if(x)` → `if (x)`, but `assert(x)` unchanged)
  - Arrow spacing in match expressions and dict literals
  - Comma spacing in function calls, tuples, and lists
  - Compound assignment operator spacing

The implementation uses the existing lexer and token stream to identify gaps between tokens, ensuring it never modifies whitespace inside string literals.

https://claude.ai/code/session_01GeRTfwE8LmgF2f97orNeBF