### PR TITLE
Document pull request description conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,18 @@ as a fix/cleanup/refactor in evaluative terms. Do not repeat internal
 implementation details that are visible in the diff. Headings are
 rarely needed — a single short line is usually enough.
 
+# Pull Request Descriptions
+
+Keep PR descriptions short. The same principles as commit messages
+apply: state what changed, not why it's an improvement, and don't
+restate details visible in the diff. A sentence or two of plain prose
+is usually enough.
+
+Do not add headings like Summary, Changes, Note, or Verification, do
+not enumerate every changed file, and do not list the commands you ran
+to check the work. Mention test or build results only when they are
+genuinely noteworthy.
+
 # Writing Error Messages
 
 Error messages in Garden are extensively marked up so they can be


### PR DESCRIPTION
Add guidance to CLAUDE.md on writing pull request descriptions, establishing consistency with commit message conventions.

The new section clarifies that PR descriptions should be concise, state what changed rather than justifying the change, and avoid restating details visible in the diff. It also discourages adding unnecessary headings, enumerating files, or listing verification commands.

https://claude.ai/code/session_01SrVkoWYsvnCayU4ZbxHWKk