### PR TITLE
Replace Bool.not() method with not() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Moved `source_directory()` from the prelude to `__reflect.gdn` and
 renamed it to `source_file()`, reflecting that it returns the path of
 the current source file.
 
+Replaced the `not` method on `Bool` with a `not()` function. Write
+`not(x)` instead of `x.not()`.
+
 # 0.25 (released 29th May 2026)
 **Goal: Better REPL experience.**
 **Goal: Better runtime performance.**

--- a/src/__prelude.gdn
+++ b/src/__prelude.gdn
@@ -10,18 +10,18 @@ enum Bool {
 /// Negate this value.
 ///
 /// ```
-/// True.not() //-> False
+/// not(True) //-> False
 /// ```
-public method not(this: Bool): Bool {
-  match this {
+public fun not(b: Bool): Bool {
+  match b {
     True => False,
     False => True,
   }
 }
 
 test not {
-  assert(True.not() == False)
-  assert(False.not() == True)
+  assert(not(True) == False)
+  assert(not(False) == True)
 }
 
 /// The unit type. Use this when your function doesn't have any useful
@@ -658,7 +658,7 @@ public method is_empty<T>(this: List<T>): Bool {
 
 test is_empty {
   assert([].is_empty())
-  assert([1].is_empty().not())
+  assert(not([1].is_empty()))
 }
 
 /// Is this list non-empty?
@@ -667,7 +667,7 @@ public method is_non_empty<T>(this: List<T>): Bool {
 }
 
 test is_non_empty {
-  assert([].is_non_empty().not())
+  assert(not([].is_non_empty()))
   assert([1].is_non_empty())
 }
 

--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -205,7 +205,7 @@ fun split_metadata(src: String): (Option<String>, String) {
   let metadata_start = "```metadata\n"
   let metadata_end = "\n```\n"
 
-  if src.starts_with(metadata_start).not() {
+  if not(src.starts_with(metadata_start)) {
     return (None, src)
   }
 
@@ -266,7 +266,7 @@ fun blog_posts(website_dir: Path): List<BlogPost> {
 
 fun build_blog(website_dir: Path, out_dir: Path, base_tmpl_src: String): Unit {
   for post in blog_posts(website_dir) {
-    if post.published.not() {
+    if not(post.published) {
       continue
     }
 
@@ -341,14 +341,14 @@ fun build_site(): Unit {
   }
 
   for keyword in reflect::keywords() {
-    if seen_keyword_pages.contains(keyword).not() {
+    if not(seen_keyword_pages.contains(keyword)) {
       log::warn("Expected a page documenting keyword: " ^ keyword)
     }
   }
 
   for operator in reflect::operators() {
     let page_name = ops::url_safe_name(operator)
-    if seen_operator_pages.contains(page_name).not() {
+    if not(seen_operator_pages.contains(page_name)) {
       log::warn("Expected a page documenting operator: " ^ operator)
     }
   }
@@ -356,7 +356,7 @@ fun build_site(): Unit {
   for type_name in reflect::prelude_types() {
     // We have a manually created type::Tuple.md file, so don't look
     // for a doc comment in that case.
-    if website_dir.join("type:" ^ type_name ^ ".md").exists().not() {
+    if not(website_dir.join("type:" ^ type_name ^ ".md").exists()) {
       write_type_page(type_name, out_dir, base_tmpl_src)
     }
 
@@ -380,7 +380,7 @@ fun build_site(): Unit {
     documented_files = documented_files.append(ns_name)
   }
   for built_in_file in reflect::built_in_files() {
-    if documented_files.contains(built_in_file).not() {
+    if not(documented_files.contains(built_in_file)) {
       log::warn("Builtin file " ^ built_in_file ^ " is not included in the namespaces list")
     }
   }
@@ -490,7 +490,7 @@ fun substitute_shorthand(website_dir: Path, src: String): String {
 
   let blog_links: List<String> = []
   for post in blog_posts(website_dir) {
-    if post.published.not() {
+    if not(post.published) {
       continue
     }
 

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -176,7 +176,7 @@ fun render_heading(src: String, self_url: Option<String>): String {
     content = content.strip_prefix("#")
   }
 
-  if (h_count > 6) || content.starts_with(" ").not() {
+  if (h_count > 6) || not(content.starts_with(" ")) {
     return "<p>" ^ src ^ "</p>"
   }
 
@@ -257,7 +257,7 @@ fun check_source(src: String, path: Option<Path>): Unit {
 }
 
 fun render_garden_code(snippet: Snippet, self_url: Option<String>): String {
-  if snippet.labels.contains("nocheck").not() {
+  if not(snippet.labels.contains("nocheck")) {
     check_source(snippet.content, snippet.file)
 
     // Check that the expected values comments type check too.
@@ -528,7 +528,7 @@ fun split_on_terminator(s: String, terminator: String): Option<(String, String)>
 /// split_markdown_link("[link text](url) rest") // Some(("[link text](url)", " rest"))
 /// ```
 fun split_markdown_link(s: String): Option<(String, String)> {
-  if s.starts_with("[").not() && s.starts_with("![").not() {
+  if not(s.starts_with("[")) && not(s.starts_with("![")) {
     return None
   }
 
@@ -640,7 +640,7 @@ fun render_inline_code(src: String, self_url: Option<String>): String {
 
   if reflect::operators().contains(inner) {
     let operator_url = "/operator:" ^ ops::url_safe_name(inner) ^ ".html"
-    if (inner.ends_with("=") && (inner.len() > 1)).not() {
+    if not(inner.ends_with("=") && (inner.len() > 1)) {
       // Don't linkify += or !=, as they redirect to + and == respectively.
       // TODO: track redirects properly.
       url = Some(operator_url)
@@ -851,5 +851,5 @@ fun looks_like_type(name: String): Bool {
 test looks_like_type {
   assert(looks_like_type("Abc"))
 
-  assert(looks_like_type("abc").not())
+  assert(not(looks_like_type("abc")))
 }


### PR DESCRIPTION
Convert the `not` method on `Bool` to a standalone function. This changes the call syntax from `x.not()` to `not(x)` throughout the codebase.

- Changed `not` from a method to a function in the prelude
- Updated all call sites in src/__prelude.gdn, website/build_site.gdn, and website/markdown.gdn to use function call syntax
- Updated documentation examples and test cases accordingly

https://claude.ai/code/session_01K5cJaeu2bTvQsWiRrrLeR2