### PR TITLE
Resolve doc comment examples in documented function's namespace

### DIFF
--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -56,7 +56,7 @@ fun write_fun_page(
       }
 
       let src = reflect::source_for_fun(ns, fun_name)
-      let page_src = render_doc_comment(heading, doc_comment, src, None, Some(self_url))
+      let page_src = render_doc_comment(heading, doc_comment, src, Some(Path{ p: ns_name }), Some(self_url))
 
       write_website_page(base_tmpl_src, page_src, dest_path, Some(fun_name))
     }


### PR DESCRIPTION
Pass the namespace of the documented function to `render_doc_comment` so that unqualified references to other functions in the same namespace resolve correctly when checking doc comment examples.

https://claude.ai/code/session_01MPn3z5fWXmE2eUfR4rp8hm