### PR TITLE
Add doc comment examples to built-in functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,45 @@ fs::list_directory(Path{ p: "/"})
 Do not make changes to CHANGELOG.md unless the user explicitly
 requests it.
 
+# Doc Comment Examples
+
+Public functions in the built-in namespaces (`src/__fs.gdn`,
+`src/__random.gdn`, `src/__reflect.gdn`, `src/__shell.gdn`,
+`src/__time.gdn`) carry a runnable example inside a fenced code block in
+their `///` doc comment. These examples are rendered on the website
+(`website/build_site.gdn` builds a page per function), so every public
+function should have one. The convention is to show the import followed
+by a call:
+
+```
+/// Read the contents of file `path` as a string.
+///
+/// ```
+/// import "__fs.gdn" as fs
+/// fs::read_file(Path{ p: "/tmp/foo.txt" })
+/// ```
+```
+
+These blocks are executed and checked by the `run-code-blocks`
+subcommand (implemented in `src/run_code_blocks.rs`):
+
+- `./target/debug/garden run-code-blocks src/__fs.gdn` runs every code
+  block in a file's doc comments and reports failures. The reftests in
+  `src/test_files/run_code_blocks/` cover the machinery itself.
+- A `//->` trailing comment asserts the expression's displayed value,
+  e.g. `reflect::keywords().contains("if") //-> True`. The value must
+  match exactly, so prefer stable assertions (`.is_some()`,
+  `.contains(...)`) over brittle ones for large or non-deterministic
+  results.
+- Use `//->` `*exception*` to assert an expression throws.
+- A plain `//` comment (e.g. `// e.g. Some(2)`) is not asserted, which
+  suits non-deterministic results like `random::int()`.
+
+Garden has no turbofish; to get a typed empty list in an example, bind
+it first: `let empty: List<Int> = []`. Examples run in the file's own
+namespace, so importing a sibling built-in (or even the file itself) in
+a block is fine.
+
 # Commit Messages
 
 Keep commit messages concise and matter-of-fact. State what changed,

--- a/src/__random.gdn
+++ b/src/__random.gdn
@@ -2,6 +2,11 @@
 ///
 /// This is a pseudorandom number, and should not be used for
 /// cryptographic purposes.
+///
+/// ```
+/// import "__random.gdn" as random
+/// random::int() // e.g. -4044220887577020587
+/// ```
 public fun int(): Int {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -11,6 +16,14 @@ test random_int {
 }
 
 /// Randomly choose an item from `items`.
+///
+/// ```
+/// import "__random.gdn" as random
+/// random::choose([1, 2, 3]) // e.g. Some(2)
+///
+/// let empty: List<Int> = []
+/// random::choose(empty) //-> None
+/// ```
 public fun choose<T>(items: List<T>): Option<T> {
   if items.is_empty() {
     return None

--- a/src/__reflect.gdn
+++ b/src/__reflect.gdn
@@ -5,6 +5,11 @@ import "__fs.gdn" as fs
 /// Check the syntax of `src`. `path` is treated as the location of
 /// the file that the snippet represents, which is used to resolve
 /// relative imports.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::check_snippet("fun f() {}", Path{ p: "__snippet.gdn" }) //-> Ok(Unit)
+/// ```
 public fun check_snippet(src: String, path: Path): Result<Unit, List<String>> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -38,6 +43,11 @@ test check_snippet_bad_name {
 
 /// Split `src` into individual lexed tokens, along with their offsets
 /// in the original string.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::lex("1 + 2") //-> [(0, "1"), (2, "+"), (4, "2")]
+/// ```
 public fun lex(src: String): List<(Int, String)> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -58,6 +68,12 @@ test lex {
 
 /// Get the doc comment for `fun_name` in the namespace `ns`. The
 /// string does not include the leading `//` comment.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// import "__fs.gdn" as fs
+/// reflect::doc_comment(fs, "read_file").is_some() //-> True
+/// ```
 public fun doc_comment(ns: Namespace, fun_name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -70,6 +86,11 @@ test doc_comment {
 }
 
 /// Get the doc comment for type `type_name`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::doc_comment_for_type("Int").is_some() //-> True
+/// ```
 public fun doc_comment_for_type(type_name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -87,6 +108,11 @@ test doc_comment_for_type {
 }
 
 /// Get the doc comment for the method `method_name` on `type_name`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::doc_comment_for_method("List", "len").is_some() //-> True
+/// ```
 public fun doc_comment_for_method(type_name: String, method_name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -100,6 +126,11 @@ test doc_comment_for_method {
 
 /// A list of all the type names in the prelude, `String`, `Option` and
 /// so on. The list is sorted alphabetically.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::prelude_types().contains("String") //-> True
+/// ```
 public fun prelude_types(): List<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -113,6 +144,11 @@ test prelude_types {
 }
 
 /// All the keywords in Garden. Variables cannot use these as names.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::keywords().contains("if") //-> True
+/// ```
 public fun keywords(): List<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -122,6 +158,11 @@ test keywords {
 }
 
 /// All the operators in Garden.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::operators().contains("+") //-> True
+/// ```
 public fun operators(): List<String> {
   // See lex_between in lex.rs for all lexemes that can be operators.
   ["==", "!=", ">=", "<=", "&&", "||", "+=", "-=", "**", "+.", "-.", "*.", "/.",
@@ -130,6 +171,11 @@ public fun operators(): List<String> {
 }
 
 /// Get the source code for the type definition of `name`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::source_for_type("Option").is_some() //-> True
+/// ```
 public fun source_for_type(name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -146,6 +192,12 @@ test source_for_type {
 }
 
 /// Get the source code for the function definition of `name`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// import "__fs.gdn" as fs
+/// reflect::source_for_fun(fs, "read_file").is_some() //-> True
+/// ```
 public fun source_for_fun(ns: Namespace, name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -173,6 +225,11 @@ test source_for_fun {
 }
 
 /// Get the source code for the function definition of `name`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::source_for_method("String", "len").is_some() //-> True
+/// ```
 public fun source_for_method(type_name: String, method_name): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -189,6 +246,12 @@ test source_for_method {
 }
 
 /// All the `external` functions in `ns`.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// import "__fs.gdn" as fs
+/// reflect::namespace_functions(fs).contains("list_directory") //-> True
+/// ```
 public fun namespace_functions(ns: Namespace): List<String> {
   // This is deliberately not a method on Namespace, so code
   // completion isn't confusing.
@@ -201,6 +264,11 @@ test namespace_functions {
 }
 
 /// Get all the methods defined on a given type.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::methods_for_type("List").contains("len") //-> True
+/// ```
 public fun methods_for_type(type_name: String): List<String> {
   __BUILT_IN_IMPLEMENTATION
 }
@@ -211,6 +279,11 @@ test methods_for_type {
 }
 
 /// Get all the built-in file names that can be imported.
+///
+/// ```
+/// import "__reflect.gdn" as reflect
+/// reflect::built_in_files().contains("__fs.gdn") //-> True
+/// ```
 public fun built_in_files(): List<String> {
   __BUILT_IN_IMPLEMENTATION
 }

--- a/src/__reflect.gdn
+++ b/src/__reflect.gdn
@@ -224,7 +224,8 @@ test source_for_fun {
   }
 }
 
-/// Get the source code for the function definition of `name`.
+/// Get the source code for the definition of method `method_name` on
+/// `type_name`.
 ///
 /// ```
 /// import "__reflect.gdn" as reflect
@@ -245,7 +246,7 @@ test source_for_method {
   }
 }
 
-/// All the `external` functions in `ns`.
+/// All the public functions in `ns`, sorted alphabetically.
 ///
 /// ```
 /// import "__reflect.gdn" as reflect

--- a/src/test_files/go_to_def/namespace_fun.gdn
+++ b/src/test_files/go_to_def/namespace_fun.gdn
@@ -5,4 +5,5 @@ reflect::lex("abc")
 
 // args: reftest-position
 // expected stdout:
-// {"start_offset":950,"end_offset":953,"line_number":40,"end_line_number":40,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}
+// {"start_offset":1211,"end_offset":1214,"line_number":50,"end_line_number":50,"column":11,"end_column":14,"path":"GDN_TEST_ROOT/__reflect.gdn"}
+

--- a/src/test_files/json_session/doc_namespace.json
+++ b/src/test_files/json_session/doc_namespace.json
@@ -32,7 +32,7 @@
 // {
 //   "kind": {
 //     "run_command": {
-//       "message": "Split `src` into individual lexed tokens, along with their offsets\nin the original string.\n\n// Defined in __reflect.gdn:41\nfn lex(src: String): List<(Int, String)> { ... }",
+//       "message": "Split `src` into individual lexed tokens, along with their offsets\nin the original string.\n\n```\nimport \"__reflect.gdn\" as reflect\nreflect::lex(\"1 + 2\") //-> [(0, \"1\"), (2, \"+\"), (4, \"2\")]\n```\n\n// Defined in __reflect.gdn:51\nfn lex(src: String): List<(Int, String)> { ... }",
 //       "stack_frame_name": "__user.gdn"
 //     }
 //   },


### PR DESCRIPTION
Added runnable code examples to the doc comments of public functions in `__reflect.gdn` and `__random.gdn`. These examples follow the convention documented in CLAUDE.md: they show the import statement followed by a function call, with assertions using `//->` comments where appropriate.

Examples were added to:
- `__reflect.gdn`: `check_snippet`, `lex`, `doc_comment`, `doc_comment_for_type`, `doc_comment_for_method`, `prelude_types`, `keywords`, `operators`, `source_for_type`, `source_for_fun`, `source_for_method`, `namespace_functions`, `methods_for_type`, `built_in_files`
- `__random.gdn`: `int`, `choose`

Also updated CLAUDE.md to document the doc comment example convention, including how to use `//->` assertions, handle non-deterministic results with plain comments, and work around Garden's lack of turbofish syntax.

https://claude.ai/code/session_011TNtEVV2zERA2ZtbMQSAr2