### PR TITLE
Enforce type annotations in built-in namespace functions

### DIFF
--- a/src/__fs.gdn
+++ b/src/__fs.gdn
@@ -116,7 +116,7 @@ public fun list_directory(path: Path): Result<List<Path>, String> {
 
 /// Kludge to perform a runtime check that list_directory returns a
 /// list of paths.
-fun takes_list_of_paths(_: List<Path>) {}
+fun takes_list_of_paths(_: List<Path>): Unit {}
 
 test list_directory {
   match list_directory(Path{p: "/"}) {

--- a/src/__reflect.gdn
+++ b/src/__reflect.gdn
@@ -173,7 +173,7 @@ test source_for_fun {
 }
 
 /// Get the source code for the function definition of `name`.
-public fun source_for_method(type_name: String, method_name): Option<String> {
+public fun source_for_method(type_name: String, method_name: String): Option<String> {
   __BUILT_IN_IMPLEMENTATION
 }
 

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,3 +1,4 @@
+mod builtin_annotations;
 mod duplicates;
 mod hints;
 mod infinite_while;
@@ -41,6 +42,7 @@ use unnecessary_return::check_unnecessary_return;
 use unreachable::check_unreachable;
 use unused_defs::check_unused_defs;
 
+use self::builtin_annotations::check_builtin_annotations;
 use self::duplicates::check_duplicates;
 use self::hints::check_hints;
 use self::struct_fields::check_struct_fields;
@@ -79,6 +81,7 @@ pub(crate) fn check_toplevel_items_in_env(
     diagnostics.extend(check_unused_literals(items, env));
     diagnostics.extend(check_struct_fields(items, env));
     diagnostics.extend(check_hints(items, env));
+    diagnostics.extend(check_builtin_annotations(vfs_path, items));
 
     let summary = check_types(vfs_path, items, env, namespace);
     diagnostics.extend(check_unused_defs(items, &summary));

--- a/src/checks/builtin_annotations.rs
+++ b/src/checks/builtin_annotations.rs
@@ -1,0 +1,82 @@
+//! Check that functions and methods in built-in namespaces have type
+//! annotations on every parameter and the return type.
+
+use std::path::Path;
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::eval::BUILT_IN_FILES;
+use crate::parser::ast::{FunInfo, Symbol, ToplevelItem};
+use crate::parser::diagnostics::ErrorMessage;
+use crate::parser::vfs::VfsPathBuf;
+use crate::{msgcode, msgtext};
+
+/// Whether `path` refers to a built-in namespace file, such as
+/// `__fs.gdn` or `__prelude.gdn`.
+fn is_built_in_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    BUILT_IN_FILES
+        .iter()
+        .any(|(file_name, _)| *file_name == name)
+}
+
+fn check_fun_info(name_sym: &Symbol, fun_info: &FunInfo, diagnostics: &mut Vec<Diagnostic>) {
+    for param in &fun_info.params.params {
+        if param.hint.is_none() {
+            diagnostics.push(Diagnostic {
+                message: ErrorMessage(vec![
+                    msgtext!("Parameters in built-in namespaces must have a type annotation, but "),
+                    msgcode!("{}", param.symbol.name),
+                    msgtext!(" does not."),
+                ]),
+                position: param.symbol.position.clone(),
+                notes: vec![],
+                severity: Severity::Error,
+                fixes: vec![],
+            });
+        }
+    }
+
+    if fun_info.return_hint.is_none() {
+        diagnostics.push(Diagnostic {
+            message: ErrorMessage(vec![
+                msgtext!(
+                    "Functions in built-in namespaces must have a return type annotation, but "
+                ),
+                msgcode!("{}", name_sym.name),
+                msgtext!(" does not."),
+            ]),
+            position: name_sym.position.clone(),
+            notes: vec![],
+            severity: Severity::Error,
+            fixes: vec![],
+        });
+    }
+}
+
+pub(crate) fn check_builtin_annotations(
+    vfs_path: &VfsPathBuf,
+    items: &[ToplevelItem],
+) -> Vec<Diagnostic> {
+    if !is_built_in_path(&vfs_path.path) {
+        return vec![];
+    }
+
+    let mut diagnostics = vec![];
+    for item in items {
+        match item {
+            ToplevelItem::Fun(name_sym, fun_info, _) => {
+                check_fun_info(name_sym, fun_info, &mut diagnostics);
+            }
+            ToplevelItem::Method(method_info, _) => {
+                if let Some(fun_info) = method_info.fun_info() {
+                    check_fun_info(&method_info.name_sym, fun_info, &mut diagnostics);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    diagnostics
+}

--- a/src/test_files/check/__time.gdn
+++ b/src/test_files/check/__time.gdn
@@ -1,0 +1,32 @@
+fun missing_param_type(x): Unit {
+  println(string_repr(x))
+}
+
+fun missing_return_type(name: String) {
+  println(name)
+}
+
+missing_param_type(1)
+missing_return_type("hello")
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Parameters in built-in namespaces must have a type annotation, but `x` does not.
+// 
+// -| src/test_files/check/__time.gdn:1:24
+// 1| fun missing_param_type(x): Unit {
+//  |                        ^
+// 2|   println(string_repr(x))
+// 3| }
+// 
+// Error: Functions in built-in namespaces must have a return type annotation, but `missing_return_type` does not.
+// 
+// -| src/test_files/check/__time.gdn:5:5
+// 3| }
+// 4| 
+// 5| fun missing_return_type(name: String) {
+//  |     ^^^^^^^^^^^^^^^^^^^
+// 6|   println(name)
+// 7| }
+


### PR DESCRIPTION
Add a new static analysis check that requires all functions and methods in built-in namespace files (`__fs.gdn`, `__reflect.gdn`, etc.) to have type annotations on every parameter and a return type annotation.

The check is implemented in a new `builtin_annotations` module that inspects top-level functions and methods in built-in files and reports errors when annotations are missing. This ensures consistency and clarity in the public API of built-in namespaces.

Also fix missing type annotations in existing built-in files that are now caught by this check:
- `__fs.gdn`: Add return type `Unit` to `takes_list_of_paths`
- `__reflect.gdn`: Add type annotation `String` to `method_name` parameter in `source_for_method`

https://claude.ai/code/session_01C1vjkMxGfuGntuwupfYtU7