### PR TITLE
Validate enum pattern payload arity and fix generic type resolution

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1935,14 +1935,24 @@ impl TypeCheckVisitor<'_> {
                 sym_to_expected_ty.insert(field.sym.name.clone(), (field.sym.position.clone(), ty));
             }
 
+            // Solve the struct's type parameters from the field
+            // values, e.g. `Box{ value: 1 }` solves `T` to `Int` for
+            // `struct Box<T> { value: T }`.
+            for (sym, _, ty) in &field_tys {
+                if let Some((_, field_decl_ty)) = sym_to_expected_ty.get(&sym.name) {
+                    unify_and_solve_ty(field_decl_ty, ty, &mut ty_var_env);
+                }
+            }
+
             for (sym, expr_pos, ty) in field_tys {
-                let Some((field_pos, field_ty)) = sym_to_expected_ty.get(&sym.name) else {
+                let Some((field_pos, field_decl_ty)) = sym_to_expected_ty.get(&sym.name) else {
                     continue;
                 };
 
                 self.id_to_def_pos.insert(sym.id, field_pos.clone());
 
-                if !is_subtype(&ty, field_ty) {
+                let field_ty = substitute_ty_vars(field_decl_ty, &ty_var_env);
+                if !is_subtype(&ty, &field_ty) {
                     let mut message_parts = vec![msgtext!("Expected ")];
                     message_parts.extend_from_slice(&field_ty.as_message_parts());
                     message_parts.push(msgtext!(" for this field but got "));

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -810,6 +810,38 @@ impl TypeCheckVisitor<'_> {
                 }
             };
 
+            // A pattern must bind the payload exactly when the
+            // variant has one, otherwise the case can never match at
+            // runtime.
+            let variant_has_payload = matches!(value.as_ref(), Value_::EnumConstructor { .. });
+            if pattern.payload.is_some() && !variant_has_payload {
+                self.diagnostics.push(Diagnostic {
+                    notes: vec![],
+                    fixes: vec![],
+                    severity: Severity::Error,
+                    message: ErrorMessage(vec![
+                        msgcode!("{}", pattern.variant_sym.name),
+                        msgtext!(" does not have a payload, so this pattern should be written as "),
+                        msgcode!("{}", pattern.variant_sym.name),
+                        msgtext!("."),
+                    ]),
+                    position: pattern.variant_sym.position.clone(),
+                });
+            } else if pattern.payload.is_none() && variant_has_payload {
+                self.diagnostics.push(Diagnostic {
+                    notes: vec![],
+                    fixes: vec![],
+                    severity: Severity::Error,
+                    message: ErrorMessage(vec![
+                        msgcode!("{}", pattern.variant_sym.name),
+                        msgtext!(" has a payload, so this pattern should be written as "),
+                        msgcode!("{}(_)", pattern.variant_sym.name),
+                        msgtext!("."),
+                    ]),
+                    position: pattern.variant_sym.position.clone(),
+                });
+            }
+
             let Some(scrutinee_ty_name) = &scrutinee_ty_name else {
                 continue;
             };

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -2632,17 +2632,15 @@ fn enum_payload_type(env: &Env, scrutinee_ty: &Type, variant_sym: &Symbol) -> Ty
         return Type::error("Match scrutinee value is not an enum.");
     };
 
-    // If the payload is a generic type from the enum definition, use
-    // the value for that generic from the value.
+    // Bind the enum's type parameters to the type arguments of the
+    // scrutinee, so a payload hint like `List<T>` resolves to
+    // `List<Int>` when matching on a `Wrap<Int>`.
+    let mut type_bindings = TypeVarEnv::default();
     for (type_def_param, value_type_param) in type_def.params().iter().zip(args) {
-        if payload_hint.sym.name == type_def_param.name {
-            return value_type_param.clone();
-        }
+        type_bindings.insert(type_def_param.name.clone(), Some(value_type_param.clone()));
     }
 
-    // The payload is not a generic type, so the type hint is
-    // referring to a defined type.
-    Type::from_hint(&payload_hint, &env.types, &FxHashMap::default()).unwrap_or_err_ty()
+    Type::from_hint(&payload_hint, &env.types, &type_bindings).unwrap_or_err_ty()
 }
 
 /// Solve the type variables in this method, and return the resolved

--- a/src/test_files/check/enum_generic_payload.gdn
+++ b/src/test_files/check/enum_generic_payload.gdn
@@ -1,0 +1,11 @@
+enum Wrap<T> {
+  Wrapped(List<T>),
+}
+
+public fun first_wrapped(w: Wrap<Int>): Option<Int> {
+  match w {
+    Wrapped(xs) => xs.first()
+  }
+}
+
+// args: check

--- a/src/test_files/check/enum_generic_payload_mismatch.gdn
+++ b/src/test_files/check/enum_generic_payload_mismatch.gdn
@@ -1,0 +1,22 @@
+enum Wrap<T> {
+  Wrapped(List<T>),
+}
+
+public fun unwrap(w: Wrap<Int>): String {
+  match w {
+    Wrapped(xs) => xs
+  }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Expected a `String` but got a `List<Int>`.
+// 
+// -| src/test_files/check/enum_generic_payload_mismatch.gdn:7:20
+// 5| public fun unwrap(w: Wrap<Int>): String {
+// 6|   match w {
+// 7|     Wrapped(xs) => xs
+// 8|   }                ^^
+// 9| }
+

--- a/src/test_files/check/generic_struct_literal.gdn
+++ b/src/test_files/check/generic_struct_literal.gdn
@@ -1,0 +1,9 @@
+struct Box<T> {
+  value: T,
+}
+
+public fun make_box(): Box<Int> {
+  Box{ value: 1234 }
+}
+
+// args: check

--- a/src/test_files/check/generic_struct_literal_mismatch.gdn
+++ b/src/test_files/check/generic_struct_literal_mismatch.gdn
@@ -1,0 +1,19 @@
+struct Pair<T> {
+  first: T,
+  second: T,
+}
+
+public fun make_pair(): Pair<String> {
+  Pair{ first: "foo", second: 1 }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Expected an `Int` for this field but got a `String`.
+// 
+// -| src/test_files/check/generic_struct_literal_mismatch.gdn:7:16
+// 6| public fun make_pair(): Pair<String> {
+// 7|   Pair{ first: "foo", second: 1 }
+// 8| }              ^^^^^
+

--- a/src/test_files/check/match_payload_arity.gdn
+++ b/src/test_files/check/match_payload_arity.gdn
@@ -1,0 +1,29 @@
+public fun unwrap_or_zero(o: Option<Int>): Int {
+  match o {
+    Some => 0
+    None(x) => x
+  }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: `Some` has a payload, so this pattern should be written as `Some(_)`.
+// 
+// -| src/test_files/check/match_payload_arity.gdn:3:5
+// 1| public fun unwrap_or_zero(o: Option<Int>): Int {
+// 2|   match o {
+// 3|     Some => 0
+//  |     ^^^^
+// 4|     None(x) => x
+// 5|   }
+// 
+// Error: `None` does not have a payload, so this pattern should be written as `None`.
+// 
+// -| src/test_files/check/match_payload_arity.gdn:4:5
+// 2|   match o {
+// 3|     Some => 0
+// 4|     None(x) => x
+// 5|   } ^^^^
+// 6| }
+


### PR DESCRIPTION
Adds validation that enum match patterns must bind payloads exactly when the variant has one, and fixes type parameter resolution in generic struct literals and enum pattern matching.

- Add error diagnostics when enum patterns have mismatched payload arity (e.g., `Some` without payload when it should have one, or `None(x)` with payload when it shouldn't)
- Fix generic type parameter resolution in struct literals by solving type variables from field values before type checking, so `Box{ value: 1 }` correctly infers `T` as `Int`
- Fix generic type parameter resolution in enum pattern matching by binding enum type parameters to the scrutinee's type arguments, so pattern payloads like `List<T>` resolve correctly when matching on `Wrap<Int>`
- Add test cases covering enum payload arity validation, generic struct literals, and generic enum payloads

https://claude.ai/code/session_01EkQQrm7UKii9SFfBUfePk2