### PR TITLE
Improve list type mismatch error messages with actual types

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -836,7 +836,7 @@ impl TypeCheckVisitor<'_> {
         let ty = match expected_ty {
             Type::Any => match unify_all(&case_tys) {
                 Ok(ty) => ty,
-                Err(position) => {
+                Err((_, _, position)) => {
                     self.diagnostics.push(Diagnostic {
                         notes: vec![],
                         fixes: vec![],
@@ -1028,14 +1028,19 @@ impl TypeCheckVisitor<'_> {
 
                 let elem_ty = match unify_all(&item_tys) {
                     Ok(ty) => ty,
-                    Err(position) => {
+                    Err((prev_ty, ty, position)) => {
+                        let mut message_parts =
+                            vec![msgtext!("List elements have different types: ")];
+                        message_parts.extend_from_slice(&prev_ty.as_message_parts());
+                        message_parts.push(msgtext!(" and "));
+                        message_parts.extend_from_slice(&ty.as_message_parts());
+                        message_parts.push(msgtext!("."));
+
                         self.diagnostics.push(Diagnostic {
                             notes: vec![],
                             fixes: vec![],
                             severity: Severity::Error,
-                            message: ErrorMessage(vec![Text(
-                                "List elements have different types.".to_owned(),
-                            )]),
+                            message: ErrorMessage(message_parts),
                             position,
                         });
                         Type::Any
@@ -1056,7 +1061,7 @@ impl TypeCheckVisitor<'_> {
 
                 let value_ty = match unify_all(&value_tys) {
                     Ok(ty) => ty,
-                    Err(position) => {
+                    Err((_, _, position)) => {
                         self.diagnostics.push(Diagnostic {
                             notes: vec![],
                             fixes: vec![],
@@ -2873,13 +2878,13 @@ fn unify_and_solve_hint(
 ///
 /// If we can't find a compatible type, return the position of the
 /// first type that didn't unify.
-fn unify_all(tys: &[(Type, Position)]) -> Result<Type, Position> {
+fn unify_all(tys: &[(Type, Position)]) -> Result<Type, (Type, Type, Position)> {
     let mut unified_ty = Type::no_value();
 
     // Unify the types pairwise.
     for (ty, position) in tys {
         let Some(new_unified_ty) = unify(&unified_ty, ty) else {
-            return Err(position.clone());
+            return Err((unified_ty, ty.clone(), position.clone()));
         };
         unified_ty = new_unified_ty;
     }

--- a/src/test_files/check/list_mixed.gdn
+++ b/src/test_files/check/list_mixed.gdn
@@ -12,7 +12,7 @@ public fun returns_bools(): List<Bool> {
 // args: check
 // expected exit status: 1
 // expected stdout:
-// Error: List elements have different types.
+// Error: List elements have different types: an `Int` and a `Bool`.
 // 
 // -| src/test_files/check/list_mixed.gdn:4:17
 // 3| {
@@ -35,3 +35,4 @@ public fun returns_bools(): List<Bool> {
 //  8| public fun returns_bools(): List<Bool> {
 //  9|   [1, True]
 // 10| }  ^
+


### PR DESCRIPTION
When list elements have incompatible types, the error message now shows the specific types that failed to unify, rather than a generic message.

The `unify_all` function now returns the conflicting types along with the position, allowing error messages to display them. List type checking uses this information to construct a detailed error message showing both types involved in the mismatch.

https://claude.ai/code/session_01HyoF7yyLktFPE9LB3MjQaB