### PR TITLE
Handle textDocument/didClose LSP notification

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -456,6 +456,27 @@ fn handle_did_change(
     diagnostics_notification(url, diagnostics)
 }
 
+/// Handle textDocument/didClose notification, returning the
+/// publishDiagnostics notification that clears diagnostics for the
+/// closed file.
+fn handle_did_close(
+    params: &serde_json::Value,
+    documents: &mut DocumentStore,
+) -> Option<serde_json::Value> {
+    let text_document = params.get("textDocument")?;
+    let uri = text_document.get("uri")?.as_str()?;
+
+    // Convert URI to path
+    let url = Url::parse(uri).ok()?;
+    let path = url.to_file_path().ok()?;
+
+    // Forget the document content now that the client has closed it.
+    documents.remove(&path);
+
+    // Clear any diagnostics we previously published for this file.
+    diagnostics_notification(url, vec![])
+}
+
 /// Handle a textDocument/completion request.
 fn handle_completion(
     id: serde_json::Value,
@@ -1148,6 +1169,10 @@ fn handle_message(
         Some("textDocument/didChange") => {
             let params = message.get("params").unwrap_or(&serde_json::Value::Null);
             outgoing.extend(handle_did_change(params, documents));
+        }
+        Some("textDocument/didClose") => {
+            let params = message.get("params").unwrap_or(&serde_json::Value::Null);
+            outgoing.extend(handle_did_close(params, documents));
         }
         Some("shutdown") => {
             if let Some(id) = parsed.id {

--- a/src/test_files/lsp/did_close.jsonl
+++ b/src/test_files/lsp/did_close.jsonl
@@ -1,0 +1,39 @@
+// Opening a file with an unbound variable produces a diagnostic, and
+// closing the file clears it.
+{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {"textDocument": {"uri": "file:///did_close.gdn", "languageId": "garden", "version": 1, "text": "println(no_such_var)\n"}}}
+{"jsonrpc": "2.0", "method": "textDocument/didClose", "params": {"textDocument": {"uri": "file:///did_close.gdn"}}}
+
+// args: reftest-lsp
+// expected stdout:
+// {
+//   "jsonrpc": "2.0",
+//   "method": "textDocument/publishDiagnostics",
+//   "params": {
+//     "diagnostics": [
+//       {
+//         "message": "Unbound symbol: `no_such_var`",
+//         "range": {
+//           "end": {
+//             "character": 19,
+//             "line": 0
+//           },
+//           "start": {
+//             "character": 8,
+//             "line": 0
+//           }
+//         },
+//         "severity": 1
+//       }
+//     ],
+//     "uri": "file:///did_close.gdn"
+//   }
+// }
+// {
+//   "jsonrpc": "2.0",
+//   "method": "textDocument/publishDiagnostics",
+//   "params": {
+//     "diagnostics": [],
+//     "uri": "file:///did_close.gdn"
+//   }
+// }
+


### PR DESCRIPTION
Implement support for the textDocument/didClose LSP notification. When a client closes a file, the server now removes it from the document store and publishes an empty diagnostics notification to clear any previously reported issues.

- Added `handle_did_close()` function to process didClose notifications
- Integrated didClose handler into the main message dispatch loop
- Added reftest to verify diagnostics are cleared when a file is closed

https://claude.ai/code/session_011yapbgbBrhEKFHdF3HVWoc