### PR TITLE
LSP: handle exit notification and case-insensitive headers

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -118,13 +118,17 @@ fn read_message() -> io::Result<Option<serde_json::Value>> {
             break;
         }
 
-        if let Some(length_str) = header.strip_prefix("Content-Length: ") {
-            content_length = Some(length_str.parse::<usize>().map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Invalid Content-Length: {e}"),
-                )
-            })?);
+        // Header field names are case-insensitive per the LSP spec, and
+        // the amount of whitespace after the colon is not fixed.
+        if let Some((name, value)) = header.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("Content-Length") {
+                content_length = Some(value.trim().parse::<usize>().map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Invalid Content-Length: {e}"),
+                    )
+                })?);
+            }
         }
     }
 
@@ -1026,15 +1030,26 @@ fn push_request_response<P: serde::de::DeserializeOwned, T: Serialize>(
     }
 }
 
+/// What the server should do after handling a message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Action {
+    /// Continue processing messages.
+    Continue,
+    /// A shutdown request was received.
+    Shutdown,
+    /// An exit notification was received; stop the loop.
+    Exit,
+}
+
 /// Handle a single message from the client. Returns the messages to
-/// send back, and whether the server should exit.
+/// send back, and the action the server should take next.
 fn handle_message(
     message: &serde_json::Value,
     documents: &mut DocumentStore,
     temp_built_in_files: Option<&TempBuiltInFiles>,
-) -> (Vec<serde_json::Value>, bool) {
+) -> (Vec<serde_json::Value>, Action) {
     let mut outgoing: Vec<serde_json::Value> = vec![];
-    let mut should_exit = false;
+    let mut action = Action::Continue;
 
     // Parse the message
     let parsed: Message = match serde_json::from_value(message.clone()) {
@@ -1051,7 +1066,7 @@ fn handle_message(
                     format!("Could not parse message: {e}"),
                 );
             }
-            return (outgoing, should_exit);
+            return (outgoing, action);
         }
     };
 
@@ -1153,11 +1168,11 @@ fn handle_message(
             if let Some(id) = parsed.id {
                 push_response(&mut outgoing, handle_shutdown(id));
             }
-            should_exit = true;
+            action = Action::Shutdown;
         }
         Some("exit") => {
             // Exit notification
-            should_exit = true;
+            action = Action::Exit;
         }
         Some(method) => {
             // Unknown notifications can be safely ignored, but
@@ -1178,7 +1193,7 @@ fn handle_message(
         }
     }
 
-    (outgoing, should_exit)
+    (outgoing, action)
 }
 
 /// Run the LSP server.
@@ -1193,6 +1208,8 @@ pub(crate) fn run_lsp() {
         }
     };
 
+    let mut shutdown_received = false;
+
     loop {
         let message = match read_message() {
             Ok(Some(msg)) => msg,
@@ -1206,7 +1223,7 @@ pub(crate) fn run_lsp() {
             }
         };
 
-        let (outgoing, should_exit) =
+        let (outgoing, action) =
             handle_message(&message, &mut documents, temp_built_in_files.as_ref());
 
         for msg in &outgoing {
@@ -1215,8 +1232,15 @@ pub(crate) fn run_lsp() {
             }
         }
 
-        if should_exit {
-            break;
+        match action {
+            Action::Continue => {}
+            Action::Shutdown => shutdown_received = true,
+            Action::Exit => {
+                // Per the LSP spec, the server exits with code 0 if an
+                // `exit` notification follows a `shutdown` request, and
+                // with code 1 otherwise.
+                std::process::exit(if shutdown_received { 0 } else { 1 });
+            }
         }
     }
 }
@@ -1253,7 +1277,7 @@ pub(crate) fn reftest_lsp(src: &str) {
 
         // Built-in files are not written to disk in reftests, so
         // definition positions in built-ins keep their relative paths.
-        let (outgoing, _should_exit) = handle_message(&message, &mut documents, None);
+        let (outgoing, _action) = handle_message(&message, &mut documents, None);
         for msg in outgoing {
             println!("{}", serde_json::to_string_pretty(&msg).unwrap());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1216,6 +1216,90 @@ mod tests {
     }
 
     #[test]
+    fn test_lsp_exit_without_shutdown() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let path = assert_cmd::cargo::cargo_bin("garden");
+        let mut child = Command::new(path)
+            .arg("lsp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn command");
+
+        // An `exit` notification with no preceding `shutdown` request
+        // should make the server exit with a non-zero status.
+        let exit = r#"{"jsonrpc":"2.0","method":"exit"}"#;
+        let input = format!("Content-Length: {}\r\n\r\n{}", exit.len(), exit);
+
+        {
+            let stdin = child.stdin.as_mut().expect("Failed to get stdin");
+            stdin
+                .write_all(input.as_bytes())
+                .expect("Failed to write to stdin");
+        }
+
+        let output = child
+            .wait_with_output()
+            .expect("Failed to wait for command");
+
+        assert!(
+            !output.status.success(),
+            "exit without shutdown should fail"
+        );
+        assert_eq!(output.status.code(), Some(1));
+    }
+
+    #[test]
+    fn test_lsp_header_case_insensitive() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let path = assert_cmd::cargo::cargo_bin("garden");
+        let mut child = Command::new(path)
+            .arg("lsp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn command");
+
+        let init_request =
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+        let shutdown_request = r#"{"jsonrpc":"2.0","id":2,"method":"shutdown"}"#;
+        let exit = r#"{"jsonrpc":"2.0","method":"exit"}"#;
+
+        // Use a lower-case header name and extra whitespace after the colon
+        // to exercise case-insensitive, whitespace-tolerant parsing.
+        let input =
+            format!(
+            "content-length:  {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}Content-Length: {}\r\n\r\n{}",
+            init_request.len(), init_request,
+            shutdown_request.len(), shutdown_request,
+            exit.len(), exit
+        );
+
+        {
+            let stdin = child.stdin.as_mut().expect("Failed to get stdin");
+            stdin
+                .write_all(input.as_bytes())
+                .expect("Failed to write to stdin");
+        }
+
+        let output = child
+            .wait_with_output()
+            .expect("Failed to wait for command");
+
+        assert!(output.status.success());
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(r#""name":"garden-lsp""#),
+            "Should parse the lower-case Content-Length header and respond to initialize"
+        );
+    }
+
+    #[test]
     fn test_lsp_goto_definition() {
         use std::io::Write;
         use std::process::Stdio;


### PR DESCRIPTION
The LSP server now properly distinguishes between shutdown requests and exit notifications, exiting with code 0 after a shutdown followed by exit, and code 1 if exit is received without shutdown. Header parsing is also made case-insensitive and whitespace-tolerant per the LSP specification.

Key changes:
- Introduced an `Action` enum to track whether the server should continue, shutdown, or exit
- Exit notifications now cause immediate termination with the appropriate exit code based on whether shutdown was previously received
- Header field parsing now uses case-insensitive comparison and trims whitespace around the colon
- Added tests for exit without shutdown and case-insensitive header handling

https://claude.ai/code/session_01H3gi8yind2bpcK1gnkC9fj