### PR TITLE
Add type annotation code action for LSP and CLI

### DIFF
--- a/src/add_type_annotation.rs
+++ b/src/add_type_annotation.rs
@@ -1,0 +1,214 @@
+use std::path::Path;
+use std::rc::Rc;
+
+use rustc_hash::FxHashMap;
+
+use crate::checks::type_checker::check_types;
+use crate::env::Env;
+use crate::eval::load_toplevel_items;
+use crate::garden_type::Type;
+use crate::parser::ast::{
+    Block, Expression, FunInfo, IdGenerator, LetDestination, Symbol, SyntaxId, TypeHint,
+};
+use crate::parser::parse_toplevel_items;
+use crate::parser::vfs::Vfs;
+use crate::parser::visitor::Visitor;
+
+/// Add a type annotation to the local, parameter or function return
+/// type at the selected position.
+pub(crate) fn add_type_annotation(
+    src: &str,
+    path: &Path,
+    offset: usize,
+    end_offset: usize,
+) -> Result<String, String> {
+    let mut id_gen = IdGenerator::default();
+    let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
+
+    let (items, _errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
+
+    let mut env = Env::new(id_gen, vfs);
+    let ns = env.get_or_create_namespace(path);
+    load_toplevel_items(&items, &mut env, Rc::clone(&ns));
+    let summary = check_types(&vfs_path, &items, &env, ns);
+
+    let mut finder = AnnotationFinder {
+        offset,
+        end_offset,
+        id_to_ty: &summary.id_to_ty,
+        candidates: vec![],
+    };
+    for item in &items {
+        finder.visit_toplevel_item(item);
+    }
+
+    // Prefer the most specific candidate, i.e. the one with the
+    // smallest trigger region. A parameter or local symbol is much
+    // smaller than a whole function signature, so it wins when the
+    // cursor is on it.
+    let Some(candidate) = finder
+        .candidates
+        .into_iter()
+        .min_by_key(|c| c.trigger_end - c.trigger_start)
+    else {
+        return Err(
+            "No local, parameter or return type to annotate at the selected position.".to_owned(),
+        );
+    };
+
+    let mut result = String::new();
+    result.push_str(&src[..candidate.insert_offset]);
+    result.push_str(&candidate.annotation);
+    result.push_str(&src[candidate.insert_offset..]);
+
+    Ok(result)
+}
+
+/// A place where a type annotation could be inserted.
+struct Candidate {
+    /// The region the cursor must fall within for this candidate to
+    /// apply.
+    trigger_start: usize,
+    trigger_end: usize,
+    /// The byte offset at which to insert the annotation.
+    insert_offset: usize,
+    /// The annotation text to insert, e.g. `": Int"`.
+    annotation: String,
+}
+
+struct AnnotationFinder<'a> {
+    offset: usize,
+    end_offset: usize,
+    id_to_ty: &'a FxHashMap<SyntaxId, Type>,
+    candidates: Vec<Candidate>,
+}
+
+impl AnnotationFinder<'_> {
+    /// Record a candidate for the symbol `sym`, inserting the
+    /// annotation immediately after its name.
+    fn consider_symbol(&mut self, sym: &Symbol) {
+        if !sym.position.contains_region(self.offset, self.end_offset) {
+            return;
+        }
+        if sym.name.is_underscore() {
+            return;
+        }
+
+        let Some(ty) = self.id_to_ty.get(&sym.id) else {
+            return;
+        };
+        let Some(ty_src) = annotation_src(ty) else {
+            return;
+        };
+
+        self.candidates.push(Candidate {
+            trigger_start: sym.position.start_offset,
+            trigger_end: sym.position.end_offset,
+            insert_offset: sym.position.end_offset,
+            annotation: format!(": {ty_src}"),
+        });
+    }
+
+    /// Record a candidate for the return type of `fun_info`, if it
+    /// doesn't already have a return type hint.
+    fn consider_return_type(&mut self, fun_info: &FunInfo) {
+        if fun_info.return_hint.is_some() {
+            return;
+        }
+
+        // The cursor triggers a return type annotation when it's on
+        // the function name or anywhere up to the closing parenthesis
+        // of the parameter list.
+        let header_start = match &fun_info.name_sym {
+            Some(name_sym) => name_sym.position.start_offset,
+            None => fun_info.params.open_paren.start_offset,
+        };
+        let header_end = fun_info.params.close_paren.end_offset;
+        if !region_contains(header_start, header_end, self.offset, self.end_offset) {
+            return;
+        }
+
+        let Some(ty) = self.body_return_ty(&fun_info.body) else {
+            return;
+        };
+        let Some(ty_src) = annotation_src(&ty) else {
+            return;
+        };
+
+        self.candidates.push(Candidate {
+            trigger_start: header_start,
+            trigger_end: header_end,
+            insert_offset: fun_info.params.close_paren.end_offset,
+            annotation: format!(": {ty_src}"),
+        });
+    }
+
+    /// The inferred return type of a function body: the type of its
+    /// final expression, or `Unit` for an empty body.
+    fn body_return_ty(&self, body: &Block) -> Option<Type> {
+        match body.exprs.last() {
+            Some(expr) => self.id_to_ty.get(&expr.id).cloned(),
+            None => Some(Type::unit()),
+        }
+    }
+}
+
+impl Visitor for AnnotationFinder<'_> {
+    fn visit_fun_info(&mut self, fun_info: &FunInfo) {
+        self.consider_return_type(fun_info);
+
+        for param in &fun_info.params.params {
+            if param.hint.is_none() {
+                self.consider_symbol(&param.symbol);
+            }
+        }
+
+        self.visit_fun_info_default(fun_info);
+    }
+
+    fn visit_expr_let(
+        &mut self,
+        dest: &LetDestination,
+        hint: Option<&TypeHint>,
+        expr: &Expression,
+    ) {
+        if hint.is_none() {
+            if let LetDestination::Symbol(symbol) = dest {
+                self.consider_symbol(symbol);
+            }
+        }
+
+        // Recurse into the bound expression, which may contain
+        // lambdas or nested lets.
+        self.visit_expr(expr);
+    }
+}
+
+/// Render `ty` as a type annotation, or `None` if there's no useful
+/// annotation to add (an unknown `Any` type, or an unrecoverable type
+/// error).
+fn annotation_src(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Error {
+            inferred_type: Some(inferred_type),
+            ..
+        } => annotation_src(inferred_type),
+        Type::Error {
+            inferred_type: None,
+            ..
+        } => None,
+        Type::Any => None,
+        _ if ty.is_no_value() => None,
+        _ => Some(ty.to_string()),
+    }
+}
+
+/// Does the region `start..end` contain the query region, using the
+/// same semantics as `Position::contains_region`?
+fn region_contains(start: usize, end: usize, q_start: usize, q_end: usize) -> bool {
+    if q_start == q_end {
+        start <= q_start && q_start < end
+    } else {
+        start <= q_start && q_end <= end
+    }
+}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -23,6 +23,7 @@ use url::Url;
 /// Storage for open document contents, keyed by file path.
 type DocumentStore = FxHashMap<PathBuf, String>;
 
+use crate::add_type_annotation::add_type_annotation;
 use crate::checks::check_toplevel_items_in_env;
 use crate::checks::type_checker::check_types;
 use crate::completions;
@@ -774,6 +775,10 @@ fn handle_code_action(
         actions.push(CodeActionResponse::CodeAction(action));
     }
 
+    if let Some(action) = build_add_type_annotation_action(&src, &path, uri, &params.range) {
+        actions.push(CodeActionResponse::CodeAction(action));
+    }
+
     JsonRpcResponse::new(id, actions)
 }
 
@@ -994,6 +999,47 @@ fn build_wrap_in_dbg_action(
 
     Some(CodeAction {
         title: "Wrap in dbg()".to_owned(),
+        kind: Some(CodeActionKind::RefactorRewrite),
+        edit: Some(workspace_edit),
+        ..Default::default()
+    })
+}
+
+/// Build an "Add type annotation" code action for the selected range,
+/// if the selection covers a local, parameter or function return type
+/// that has no type annotation.
+fn build_add_type_annotation_action(
+    src: &str,
+    path: &Path,
+    uri: &Uri,
+    range: &Range,
+) -> Option<CodeAction> {
+    let start_offset = line_char_to_offset(
+        src,
+        range.start.line as usize,
+        range.start.character as usize,
+    );
+    let end_offset =
+        line_char_to_offset(src, range.end.line as usize, range.end.character as usize);
+
+    let new_src = add_type_annotation(src, path, start_offset, end_offset).ok()?;
+
+    let full_range = whole_document_range(src);
+    let text_edit = TextEdit {
+        range: full_range,
+        new_text: new_src,
+    };
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(uri.clone(), vec![text_edit]);
+
+    let workspace_edit = WorkspaceEdit {
+        changes: Some(changes),
+        ..Default::default()
+    };
+
+    Some(CodeAction {
+        title: "Add type annotation".to_owned(),
         kind: Some(CodeActionKind::RefactorRewrite),
         edit: Some(workspace_edit),
         ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@
 // Prefer explicit Rc::clone/Arc::clone to make refcount bumps visible.
 #![warn(clippy::clone_on_ref_ptr)]
 
+mod add_type_annotation;
 mod caret_finder;
 mod checks;
 mod cli_session;
@@ -195,6 +196,13 @@ enum CliCommands {
     /// Parse the Garden program at the path specified and print the
     /// AST.
     ReftestAst { path: PathBuf },
+    /// Add a type annotation to the local, parameter or function
+    /// return type at the offset specified.
+    ReftestAddTypeAnnotation {
+        path: PathBuf,
+        offset: Option<usize>,
+        end_offset: Option<usize>,
+    },
     /// Show possible completions at the position given.
     ReftestComplete {
         path: PathBuf,
@@ -589,6 +597,35 @@ fn main() {
             };
 
             match destructure::destructure(&src, &abs_path, offset, end_offset) {
+                Ok(new_src) => {
+                    print!("{new_src}");
+                }
+                Err(msg) => {
+                    eprintln!("{msg}");
+                    std::process::exit(BAD_CLI_REQUEST_EXIT_CODE);
+                }
+            }
+        }
+        CliCommands::ReftestAddTypeAnnotation {
+            path,
+            offset,
+            end_offset,
+        } => {
+            let abs_path = to_abs_path(&path);
+            let mut src = read_utf8_or_die(&abs_path);
+            let (offset, end_offset) = match (offset, end_offset) {
+                (Some(offset), Some(end_offset)) => (offset, end_offset),
+                _ => {
+                    src = remove_testing_footer(&src);
+                    let region = caret_finder::find_caret_region(&src)
+                        .expect("Could not find comment region containing `^^` in source.");
+                    src = caret_finder::remove_caret(&src);
+
+                    region
+                }
+            };
+
+            match add_type_annotation::add_type_annotation(&src, &abs_path, offset, end_offset) {
                 Ok(new_src) => {
                     print!("{new_src}");
                 }
@@ -1034,6 +1071,11 @@ mod tests {
     #[test]
     fn reftest_wrap_in_dbg() -> TestResult<()> {
         run_reftests("wrap_in_dbg")
+    }
+
+    #[test]
+    fn reftest_add_type_annotation() -> TestResult<()> {
+        run_reftests("add_type_annotation")
     }
 
     #[test]

--- a/src/test_files/add_type_annotation/local.gdn
+++ b/src/test_files/add_type_annotation/local.gdn
@@ -1,0 +1,11 @@
+fun bar() {
+  let total = 1 + 2
+//    ^^^^^
+}
+
+// args: reftest-add-type-annotation
+// expected stdout:
+// fun bar() {
+//   let total: Int = 1 + 2
+// }
+

--- a/src/test_files/add_type_annotation/no_annotation.gdn
+++ b/src/test_files/add_type_annotation/no_annotation.gdn
@@ -1,0 +1,8 @@
+fun bar() {
+  let x: Int = 1 + 2
+//             ^^^^^
+}
+
+// args: reftest-add-type-annotation
+// expected exit status: 10
+// expected stderr: No local, parameter or return type to annotate at the selected position.

--- a/src/test_files/add_type_annotation/parameter.gdn
+++ b/src/test_files/add_type_annotation/parameter.gdn
@@ -1,0 +1,11 @@
+fun bar() {
+  let f: Fun<(Int, Int), Int> = fun(x, y) { x + y }
+//                                  ^
+}
+
+// args: reftest-add-type-annotation
+// expected stdout:
+// fun bar() {
+//   let f: Fun<(Int, Int), Int> = fun(x: Int, y) { x + y }
+// }
+

--- a/src/test_files/add_type_annotation/return_type.gdn
+++ b/src/test_files/add_type_annotation/return_type.gdn
@@ -1,0 +1,11 @@
+fun calculate() {
+//  ^^^^^^^^^
+  1 + 2
+}
+
+// args: reftest-add-type-annotation
+// expected stdout:
+// fun calculate(): Int {
+//   1 + 2
+// }
+


### PR DESCRIPTION
Adds a new "Add type annotation" code action that infers and inserts type annotations for locals, function parameters, and return types.

The feature includes:
- New `add_type_annotation` module that uses type inference to suggest annotations at a given source location
- LSP code action integration via `build_add_type_annotation_action`
- CLI command `reftest-add-type-annotation` for testing
- Visitor-based candidate selection that prefers the most specific annotation location (e.g., a parameter over its enclosing function signature)
- Filtering to skip annotations for underscore bindings, already-annotated symbols, and unresolvable types
- Test coverage with four reftest cases covering locals, parameters, return types, and error cases

https://claude.ai/code/session_014LFdSEguwMzRL3BXeMCfUE