### PR TITLE
Add signature help support to LSP server

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -8,8 +8,9 @@ use gen_lsp_types::{
     DocumentFormattingProvider, DocumentHighlight, DocumentHighlightParams,
     DocumentHighlightProvider, ErrorCodes, Hover, HoverParams, HoverProvider, InitializeParams,
     InitializeResult, Location, MarkupContent, MarkupKind, Position, PublishDiagnosticsParams,
-    Range, RenameParams, RenameProvider, ServerCapabilities, ServerInfo, TextDocumentSync,
-    TextDocumentSyncKind, TextEdit, Uri, WorkspaceEdit,
+    Range, RenameParams, RenameProvider, ServerCapabilities, ServerInfo, SignatureHelp,
+    SignatureHelpOptions, SignatureHelpParams, TextDocumentSync, TextDocumentSyncKind, TextEdit,
+    Uri, WorkspaceEdit,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -360,6 +361,10 @@ fn handle_initialize(
                 trigger_characters: Some(vec![".".to_owned(), "::".to_owned()]),
                 ..Default::default()
             }),
+            signature_help_provider: Some(SignatureHelpOptions {
+                trigger_characters: Some(vec!["(".to_owned(), ",".to_owned()]),
+                ..Default::default()
+            }),
             text_document_sync: Some(TextDocumentSync::Kind(TextDocumentSyncKind::Full)),
             document_formatting_provider: Some(DocumentFormattingProvider::Bool(true)),
             document_highlight_provider: Some(DocumentHighlightProvider::Bool(true)),
@@ -566,6 +571,35 @@ fn handle_hover(
     let hover = get_hover(&src, &path, offset);
 
     JsonRpcResponse::new(id, hover)
+}
+
+/// Handle a textDocument/signatureHelp request.
+fn handle_signature_help(
+    id: serde_json::Value,
+    params: SignatureHelpParams,
+    documents: &DocumentStore,
+) -> JsonRpcResponse<Option<SignatureHelp>> {
+    let uri = &params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+
+    let path = match uri.to_file_path() {
+        Ok(p) => p,
+        Err(_) => return JsonRpcResponse::new(id, None),
+    };
+
+    let src = match documents.get(&path) {
+        Some(content) => content.clone(),
+        None => match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => return JsonRpcResponse::new(id, None),
+        },
+    };
+
+    let offset = line_char_to_offset(&src, position.line as usize, position.character as usize);
+
+    let help = crate::signature_help::signature_help(&src, &path, offset);
+
+    JsonRpcResponse::new(id, help)
 }
 
 /// Handle a textDocument/documentHighlight request.
@@ -1094,6 +1128,17 @@ fn handle_message(
                     id,
                     "textDocument/hover",
                     |id, params| handle_hover(id, params, documents),
+                );
+            }
+        }
+        Some("textDocument/signatureHelp") => {
+            if let Some(id) = parsed.id {
+                push_request_response(
+                    &mut outgoing,
+                    message,
+                    id,
+                    "textDocument/signatureHelp",
+                    |id, params| handle_signature_help(id, params, documents),
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ mod prompt;
 mod rename;
 mod run_code_blocks;
 mod sandboxed_playground;
+mod signature_help;
 mod syntax_check;
 mod syntax_highlighter;
 mod temp_built_in_files;

--- a/src/signature_help.rs
+++ b/src/signature_help.rs
@@ -1,0 +1,198 @@
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+use gen_lsp_types::{
+    ActiveParameter, Documentation, ParameterInformation, ParameterInformationLabel, SignatureHelp,
+    SignatureInformation,
+};
+
+use crate::checks::type_checker::{check_types, TCSummary};
+use crate::env::Env;
+use crate::eval::load_toplevel_items;
+use crate::namespaces::NamespaceInfo;
+use crate::parser::ast::{
+    Expression, Expression_, FunInfo, IdGenerator, ParenthesizedArguments, ToplevelItem,
+};
+use crate::parser::parse_toplevel_items;
+use crate::parser::visitor::Visitor;
+use crate::values::Value_;
+use crate::Vfs;
+
+/// Compute signature help for the call enclosing `offset`, if any.
+pub(crate) fn signature_help(src: &str, path: &Path, offset: usize) -> Option<SignatureHelp> {
+    let mut id_gen = IdGenerator::default();
+    let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
+
+    let (items, _errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
+
+    let mut env = Env::new(id_gen, vfs);
+    let ns = env.get_or_create_namespace(path);
+    load_toplevel_items(&items, &mut env, Rc::clone(&ns));
+
+    let summary = check_types(&vfs_path, &items, &env, Rc::clone(&ns));
+
+    let call = enclosing_call(&items, offset)?;
+    let paren_args = call_arguments(&call)?;
+
+    let (fun_info, name) = resolve_fun_info(&call, &env, &ns, &summary)?;
+
+    let active_param = active_param_index(paren_args, offset);
+    let signature = build_signature(&fun_info, &name, active_param);
+
+    Some(SignatureHelp {
+        signatures: vec![signature],
+        active_signature: Some(0),
+        active_parameter: Some(ActiveParameter::Int(active_param)),
+    })
+}
+
+/// The innermost call or method call whose argument list contains
+/// `offset`.
+fn enclosing_call(items: &[ToplevelItem], offset: usize) -> Option<Expression> {
+    let mut finder = CallFinder {
+        offset,
+        calls: vec![],
+    };
+    for item in items {
+        finder.visit_toplevel_item(item);
+    }
+
+    // Prefer the innermost call, i.e. the one whose argument list
+    // starts latest.
+    finder
+        .calls
+        .into_iter()
+        .max_by_key(|call| match call_arguments(call) {
+            Some(args) => args.open_paren.start_offset,
+            None => 0,
+        })
+}
+
+struct CallFinder {
+    offset: usize,
+    calls: Vec<Expression>,
+}
+
+impl Visitor for CallFinder {
+    fn visit_expr(&mut self, expr: &Expression) {
+        if let Some(paren_args) = call_arguments(expr) {
+            // The cursor must be inside the parentheses, i.e. after the
+            // opening `(` and no later than the closing `)`.
+            if self.offset > paren_args.open_paren.start_offset
+                && self.offset <= paren_args.close_paren.end_offset
+            {
+                self.calls.push(expr.clone());
+            }
+        }
+
+        self.visit_expr_(&expr.expr_);
+    }
+}
+
+/// The parenthesized arguments of a call or method call expression.
+fn call_arguments(expr: &Expression) -> Option<&ParenthesizedArguments> {
+    match &expr.expr_ {
+        Expression_::Call(_, paren_args) | Expression_::MethodCall(_, _, paren_args) => {
+            Some(paren_args)
+        }
+        _ => None,
+    }
+}
+
+/// Resolve the function definition and display name for `call`.
+fn resolve_fun_info(
+    call: &Expression,
+    env: &Env,
+    ns: &Rc<RefCell<NamespaceInfo>>,
+    summary: &TCSummary,
+) -> Option<(FunInfo, String)> {
+    match &call.expr_ {
+        Expression_::Call(callee, _) => match &callee.expr_ {
+            Expression_::Variable(sym) => {
+                let ns = ns.borrow();
+                let value = ns.values.get(&sym.name)?;
+                let fun_info = value.fun_info()?.clone();
+                Some((fun_info, sym.name.text.clone()))
+            }
+            Expression_::NamespaceAccess(recv, sym) => {
+                let Expression_::Variable(ns_sym) = &recv.expr_ else {
+                    return None;
+                };
+
+                let ns = ns.borrow();
+                let value = ns.values.get(&ns_sym.name)?;
+                let Value_::Namespace { ns_info, .. } = value.as_ref() else {
+                    return None;
+                };
+
+                let ns_info = ns_info.borrow();
+                let target = ns_info.values.get(&sym.name)?;
+                let fun_info = target.fun_info()?.clone();
+                Some((fun_info, sym.name.text.clone()))
+            }
+            _ => None,
+        },
+        Expression_::MethodCall(recv, sym, _) => {
+            let recv_ty = summary.id_to_ty.get(&recv.id)?;
+            let type_name = recv_ty.type_name()?;
+            let method_info = env.types.get(&type_name)?.methods.get(&sym.name)?;
+            let fun_info = method_info.fun_info()?.clone();
+            Some((fun_info, sym.name.text.clone()))
+        }
+        _ => None,
+    }
+}
+
+/// The index of the parameter the cursor is currently on, determined by
+/// counting the argument commas before `offset`.
+fn active_param_index(paren_args: &ParenthesizedArguments, offset: usize) -> u32 {
+    let mut index = 0;
+    for arg in &paren_args.arguments {
+        if let Some(comma) = &arg.comma {
+            if comma.end_offset <= offset {
+                index += 1;
+            }
+        }
+    }
+    index
+}
+
+/// Build the signature information for `fun_info`, rendering its
+/// parameters and return type.
+fn build_signature(fun_info: &FunInfo, name: &str, active_param: u32) -> SignatureInformation {
+    let mut label = String::new();
+    label.push_str(name);
+    label.push('(');
+
+    let mut parameters = vec![];
+    for (i, param) in fun_info.params.params.iter().enumerate() {
+        if i > 0 {
+            label.push_str(", ");
+        }
+
+        let param_label = match &param.hint {
+            Some(hint) => format!("{}: {}", param.symbol.name, hint.as_src()),
+            None => param.symbol.name.text.clone(),
+        };
+
+        parameters.push(ParameterInformation {
+            label: ParameterInformationLabel::String(param_label.clone()),
+            documentation: None,
+        });
+        label.push_str(&param_label);
+    }
+    label.push(')');
+
+    if let Some(return_hint) = &fun_info.return_hint {
+        label.push_str(": ");
+        label.push_str(&return_hint.as_src());
+    }
+
+    SignatureInformation {
+        label,
+        documentation: fun_info.doc_comment.clone().map(Documentation::String),
+        parameters: Some(parameters),
+        active_parameter: Some(ActiveParameter::Int(active_param)),
+    }
+}

--- a/src/test_files/lsp/initialize.jsonl
+++ b/src/test_files/lsp/initialize.jsonl
@@ -28,6 +28,12 @@
 //       "documentHighlightProvider": true,
 //       "hoverProvider": true,
 //       "renameProvider": true,
+//       "signatureHelpProvider": {
+//         "triggerCharacters": [
+//           "(",
+//           ","
+//         ]
+//       },
 //       "textDocumentSync": 1
 //     },
 //     "serverInfo": {

--- a/src/test_files/lsp/signature_help.jsonl
+++ b/src/test_files/lsp/signature_help.jsonl
@@ -1,0 +1,60 @@
+// Signature help on a call to a user-defined function shows the
+// function signature and highlights the active parameter.
+{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {"textDocument": {"uri": "file:///signature_help.gdn", "languageId": "garden", "version": 1, "text": "fun add(x: Int, y: Int): Int {\n  x + y\n}\n\nadd(1, 2)\n"}}}
+{"jsonrpc": "2.0", "id": 1, "method": "textDocument/signatureHelp", "params": {"textDocument": {"uri": "file:///signature_help.gdn"}, "position": {"line": 4, "character": 4}}}
+{"jsonrpc": "2.0", "id": 2, "method": "textDocument/signatureHelp", "params": {"textDocument": {"uri": "file:///signature_help.gdn"}, "position": {"line": 4, "character": 7}}}
+
+// args: reftest-lsp
+// expected stdout:
+// {
+//   "jsonrpc": "2.0",
+//   "method": "textDocument/publishDiagnostics",
+//   "params": {
+//     "diagnostics": [],
+//     "uri": "file:///signature_help.gdn"
+//   }
+// }
+// {
+//   "id": 1,
+//   "jsonrpc": "2.0",
+//   "result": {
+//     "activeParameter": 0,
+//     "activeSignature": 0,
+//     "signatures": [
+//       {
+//         "activeParameter": 0,
+//         "label": "add(x: Int, y: Int): Int",
+//         "parameters": [
+//           {
+//             "label": "x: Int"
+//           },
+//           {
+//             "label": "y: Int"
+//           }
+//         ]
+//       }
+//     ]
+//   }
+// }
+// {
+//   "id": 2,
+//   "jsonrpc": "2.0",
+//   "result": {
+//     "activeParameter": 1,
+//     "activeSignature": 0,
+//     "signatures": [
+//       {
+//         "activeParameter": 1,
+//         "label": "add(x: Int, y: Int): Int",
+//         "parameters": [
+//           {
+//             "label": "x: Int"
+//           },
+//           {
+//             "label": "y: Int"
+//           }
+//         ]
+//       }
+//     ]
+//   }
+// }


### PR DESCRIPTION
Implement the textDocument/signatureHelp LSP request to display function signatures and highlight the active parameter when the cursor is inside a function call.

The implementation includes:
- New `signature_help` module that resolves function definitions and builds signature information for both regular function calls and method calls
- Visitor-based call finder to locate the innermost call expression containing the cursor position
- Active parameter tracking by counting argument commas before the cursor
- LSP server integration with signature help provider registration and request handling
- Test coverage for signature help on user-defined functions with type hints

https://claude.ai/code/session_019VGSxMSP83m8YFCkTD3ASd