### PR TITLE
Add float literal support to static analysis checks

### DIFF
--- a/src/checks/same_literal_returns.rs
+++ b/src/checks/same_literal_returns.rs
@@ -1,3 +1,5 @@
+use ordered_float::OrderedFloat;
+
 use crate::diagnostics::{Diagnostic, Severity};
 use crate::parser::ast::{Block, Expression, Expression_, FunInfo, ToplevelItem};
 use crate::parser::diagnostics::ErrorMessage;
@@ -66,6 +68,7 @@ pub(crate) fn check_same_literal_returns(items: &[ToplevelItem]) -> Vec<Diagnost
 #[derive(Debug, Clone, PartialEq)]
 enum LiteralValue {
     Int(i64),
+    Float(OrderedFloat<f64>),
     String(String),
     EnumVariant(String),
 }
@@ -74,6 +77,7 @@ impl std::fmt::Display for LiteralValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LiteralValue::Int(n) => write!(f, "{}", n),
+            LiteralValue::Float(n) => write!(f, "{}", n),
             LiteralValue::String(s) => write!(f, "\"{}\"", s),
             LiteralValue::EnumVariant(name) => write!(f, "{}", name),
         }
@@ -83,6 +87,7 @@ impl std::fmt::Display for LiteralValue {
 fn expr_as_constant(expr: &Expression) -> Option<LiteralValue> {
     match &expr.expr_ {
         Expression_::IntLiteral(n) => Some(LiteralValue::Int(*n)),
+        Expression_::FloatLiteral(n) => Some(LiteralValue::Float(*n)),
         Expression_::StringLiteral(s) => Some(LiteralValue::String(s.clone())),
         Expression_::Variable(sym) => {
             let name = &sym.name.text;

--- a/src/checks/self_assign_compare.rs
+++ b/src/checks/self_assign_compare.rs
@@ -18,6 +18,7 @@ fn expr_key(expr: &Expression) -> Option<String> {
     match &expr.expr_ {
         Expression_::Variable(sym) => Some(sym.name.text.clone()),
         Expression_::IntLiteral(n) => Some(format!("int:{}", n)),
+        Expression_::FloatLiteral(f) => Some(format!("float:{}", f)),
         Expression_::StringLiteral(s) => Some(format!("str:{}", s)),
         Expression_::Parentheses(paren) => expr_key(&paren.expr),
         _ => None,

--- a/src/checks/unused_literals.rs
+++ b/src/checks/unused_literals.rs
@@ -41,6 +41,7 @@ impl<'a> UnusedLiteralVisitor<'a> {
         let is_literal = matches!(
             &expr.expr_,
             Expression_::IntLiteral(_)
+                | Expression_::FloatLiteral(_)
                 | Expression_::StringLiteral(_)
                 | Expression_::ListLiteral(_)
                 | Expression_::DictLiteral(_)

--- a/src/test_files/check/same_literal_returns.gdn
+++ b/src/test_files/check/same_literal_returns.gdn
@@ -6,6 +6,14 @@ public fun early_return_int(b: Bool): Int {
     1
 }
 
+// Should warn: all paths return the same float literal.
+public fun same_float(b: Bool): Float {
+    if b {
+        return 1.0
+    }
+    1.0
+}
+
 // Should warn: all explicit returns are the same literal.
 public fun all_explicit_returns(b: Bool): Int {
     if b {
@@ -90,93 +98,112 @@ public fun different_variants(b: Bool): Bool {
 // 6|     1
 // 7| }   ^ Note: Same value here.
 // 
-// Warning: All code paths in `all_explicit_returns()` return the same value `1`.
+// Warning: All code paths in `same_float()` return the same value `1`.
 // 
 // --| src/test_files/check/same_literal_returns.gdn:10:12
-//  9| // Should warn: all explicit returns are the same literal.
-// 10| public fun all_explicit_returns(b: Bool): Int {
-// 11|     if b { ^^^^^^^^^^^^^^^^^^^^
-// 12|         return 1
+//  9| // Should warn: all paths return the same float literal.
+// 10| public fun same_float(b: Bool): Float {
+// 11|     if b { ^^^^^^^^^^
+// 12|         return 1.0
 // --| src/test_files/check/same_literal_returns.gdn:12:16
-// 10| public fun all_explicit_returns(b: Bool): Int {
+// 10| public fun same_float(b: Bool): Float {
 // 11|     if b {
-// 12|         return 1
-// 13|     }          ^ Note: Same value here.
-// 14|     return 1
-// --| src/test_files/check/same_literal_returns.gdn:14:12
-// 12|         return 1
+// 12|         return 1.0
+// 13|     }          ^^^ Note: Same value here.
+// 14|     1.0
+// --| src/test_files/check/same_literal_returns.gdn:14:5
+// 12|         return 1.0
 // 13|     }
-// 14|     return 1
-// 15| }          ^ Note: Same value here.
+// 14|     1.0
+// 15| }   ^^^ Note: Same value here.
+// 
+// Warning: All code paths in `all_explicit_returns()` return the same value `1`.
+// 
+// --| src/test_files/check/same_literal_returns.gdn:18:12
+// 17| // Should warn: all explicit returns are the same literal.
+// 18| public fun all_explicit_returns(b: Bool): Int {
+// 19|     if b { ^^^^^^^^^^^^^^^^^^^^
+// 20|         return 1
+// --| src/test_files/check/same_literal_returns.gdn:20:16
+// 18| public fun all_explicit_returns(b: Bool): Int {
+// 19|     if b {
+// 20|         return 1
+// 21|     }          ^ Note: Same value here.
+// 22|     return 1
+// --| src/test_files/check/same_literal_returns.gdn:22:12
+// 20|         return 1
+// 21|     }
+// 22|     return 1
+// 23| }          ^ Note: Same value here.
 // 
 // Warning: All code paths in `if_else_same()` return the same value `1`.
 // 
-// --| src/test_files/check/same_literal_returns.gdn:18:12
-// 17| // Should warn: if/else branches return the same literal.
-// 18| public fun if_else_same(b: Bool): Int {
-// 19|     if b { ^^^^^^^^^^^^
-// 20|         1
-// --| src/test_files/check/same_literal_returns.gdn:20:9
-// 18| public fun if_else_same(b: Bool): Int {
-// 19|     if b {
-// 20|         1
+// --| src/test_files/check/same_literal_returns.gdn:26:12
+// 25| // Should warn: if/else branches return the same literal.
+// 26| public fun if_else_same(b: Bool): Int {
+// 27|     if b { ^^^^^^^^^^^^
+// 28|         1
+// --| src/test_files/check/same_literal_returns.gdn:28:9
+// 26| public fun if_else_same(b: Bool): Int {
+// 27|     if b {
+// 28|         1
 //   |         ^ Note: Same value here.
-// 21|     } else {
-// 22|         1
-// --| src/test_files/check/same_literal_returns.gdn:22:9
-// 20|         1
-// 21|     } else {
-// 22|         1
-// 23|     }   ^ Note: Same value here.
-// 24| }
+// 29|     } else {
+// 30|         1
+// --| src/test_files/check/same_literal_returns.gdn:30:9
+// 28|         1
+// 29|     } else {
+// 30|         1
+// 31|     }   ^ Note: Same value here.
+// 32| }
 // 
 // Warning: All code paths in `match_same()` return the same value `"yes"`.
 // 
-// --| src/test_files/check/same_literal_returns.gdn:27:12
-// 26| // Should warn: match arms return the same literal.
-// 27| public fun match_same(x: Option<Int>): String {
+// --| src/test_files/check/same_literal_returns.gdn:35:12
+// 34| // Should warn: match arms return the same literal.
+// 35| public fun match_same(x: Option<Int>): String {
 //   |            ^^^^^^^^^^
-// 28|     match x {
-// 29|         None => { "yes" }
-// --| src/test_files/check/same_literal_returns.gdn:29:19
-// 27| public fun match_same(x: Option<Int>): String {
-// 28|     match x {
-// 29|         None => { "yes" }
+// 36|     match x {
+// 37|         None => { "yes" }
+// --| src/test_files/check/same_literal_returns.gdn:37:19
+// 35| public fun match_same(x: Option<Int>): String {
+// 36|     match x {
+// 37|         None => { "yes" }
 //   |                   ^^^^^ Note: Same value here.
-// 30|         Some(_) => { "yes" }
-// 31|     }
-// --| src/test_files/check/same_literal_returns.gdn:30:22
-// 28|     match x {
-// 29|         None => { "yes" }
-// 30|         Some(_) => { "yes" }
-// 31|     }                ^^^^^ Note: Same value here.
-// 32| }
+// 38|         Some(_) => { "yes" }
+// 39|     }
+// --| src/test_files/check/same_literal_returns.gdn:38:22
+// 36|     match x {
+// 37|         None => { "yes" }
+// 38|         Some(_) => { "yes" }
+// 39|     }                ^^^^^ Note: Same value here.
+// 40| }
 // 
 // Warning: All code paths in `always_true()` return the same value `True`.
 // 
-// --| src/test_files/check/same_literal_returns.gdn:35:12
-// 34| // Should warn: all paths return the same enum variant.
-// 35| public fun always_true(b: Bool): Bool {
-// 36|     if b { ^^^^^^^^^^^
-// 37|         return True
-// --| src/test_files/check/same_literal_returns.gdn:37:16
-// 35| public fun always_true(b: Bool): Bool {
-// 36|     if b {
-// 37|         return True
-// 38|     }          ^^^^ Note: Same value here.
-// 39|     True
-// --| src/test_files/check/same_literal_returns.gdn:39:5
-// 37|         return True
-// 38|     }
-// 39|     True
-// 40| }   ^^^^ Note: Same value here.
+// --| src/test_files/check/same_literal_returns.gdn:43:12
+// 42| // Should warn: all paths return the same enum variant.
+// 43| public fun always_true(b: Bool): Bool {
+// 44|     if b { ^^^^^^^^^^^
+// 45|         return True
+// --| src/test_files/check/same_literal_returns.gdn:45:16
+// 43| public fun always_true(b: Bool): Bool {
+// 44|     if b {
+// 45|         return True
+// 46|     }          ^^^^ Note: Same value here.
+// 47|     True
+// --| src/test_files/check/same_literal_returns.gdn:47:5
+// 45|         return True
+// 46|     }
+// 47|     True
+// 48| }   ^^^^ Note: Same value here.
 // 
 // Warning: Unnecessary `return` at the end of a function body.
 // 
-// --| src/test_files/check/same_literal_returns.gdn:14:5
-// 12|         return 1
-// 13|     }
-// 14|     return 1
-// 15| }   ^^^^^^^^
+// --| src/test_files/check/same_literal_returns.gdn:22:5
+// 20|         return 1
+// 21|     }
+// 22|     return 1
+// 23| }   ^^^^^^^^
 
 // expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check/self_assign_compare.gdn
+++ b/src/test_files/check/self_assign_compare.gdn
@@ -24,6 +24,11 @@ public fun compare_literals(): Bool {
     1 == 1
 }
 
+// Self-comparison with float literals: should warn.
+public fun compare_float_literals(): Bool {
+    1.0 == 1.0
+}
+
 // Normal assignment: should not warn.
 public fun assign_different(x: Int): Int {
     let y = x
@@ -68,12 +73,12 @@ public fun compare_different(x: Int, y: Int): Bool {
 // expected stdout:
 // Warning: Unnecessary `let`, this value is immediately returned.
 // 
-// --| src/test_files/check/self_assign_compare.gdn:29:13
-// 27| // Normal assignment: should not warn.
-// 28| public fun assign_different(x: Int): Int {
-// 29|     let y = x
-// 30|     y       ^
-// 31| }
+// --| src/test_files/check/self_assign_compare.gdn:34:13
+// 32| // Normal assignment: should not warn.
+// 33| public fun assign_different(x: Int): Int {
+// 34|     let y = x
+// 35|     y       ^
+// 36| }
 // 
 // Warning: `x` is assigned to itself.
 // 
@@ -116,5 +121,13 @@ public fun compare_different(x: Int, y: Int): Bool {
 // 23| public fun compare_literals(): Bool {
 // 24|     1 == 1
 // 25| }   ^^^^^^
+// 
+// Warning: Both sides of `==` are identical.
+// 
+// --| src/test_files/check/self_assign_compare.gdn:29:5
+// 27| // Self-comparison with float literals: should warn.
+// 28| public fun compare_float_literals(): Bool {
+// 29|     1.0 == 1.0
+// 30| }   ^^^^^^^^^^
 
 // expected stderr: 2 issues can be fixed automatically (use `--fix`).

--- a/src/test_files/check/unused_literal.gdn
+++ b/src/test_files/check/unused_literal.gdn
@@ -1,5 +1,6 @@
 public fun example() {
   42
+  3.14
   "hello"
   [1, 2, 3]
   Dict[]
@@ -17,44 +18,54 @@ public fun example() {
 // 1| public fun example() {
 // 2|   42
 //  |   ^^
-// 3|   "hello"
-// 4|   [1, 2, 3]
+// 3|   3.14
+// 4|   "hello"
 // 
 // Warning: Unused value.
 // 
 // -| src/test_files/check/unused_literal.gdn:3:3
 // 1| public fun example() {
 // 2|   42
-// 3|   "hello"
-//  |   ^^^^^^^
-// 4|   [1, 2, 3]
-// 5|   Dict[]
+// 3|   3.14
+//  |   ^^^^
+// 4|   "hello"
+// 5|   [1, 2, 3]
 // 
 // Warning: Unused value.
 // 
 // -| src/test_files/check/unused_literal.gdn:4:3
 // 2|   42
-// 3|   "hello"
-// 4|   [1, 2, 3]
-//  |   ^^^^^^^^^
-// 5|   Dict[]
+// 3|   3.14
+// 4|   "hello"
+//  |   ^^^^^^^
+// 5|   [1, 2, 3]
+// 6|   Dict[]
 // 
 // Warning: Unused value.
 // 
 // -| src/test_files/check/unused_literal.gdn:5:3
-// 3|   "hello"
-// 4|   [1, 2, 3]
-// 5|   Dict[]
-// 6|   ^^^^^^
-// 7|   let x = 10
+// 3|   3.14
+// 4|   "hello"
+// 5|   [1, 2, 3]
+//  |   ^^^^^^^^^
+// 6|   Dict[]
+// 
+// Warning: Unused value.
+// 
+// -| src/test_files/check/unused_literal.gdn:6:3
+// 4|   "hello"
+// 5|   [1, 2, 3]
+// 6|   Dict[]
+// 7|   ^^^^^^
+// 8|   let x = 10
 // 
 // Warning: Unnecessary `let`, this value is immediately returned.
 // 
-// -| src/test_files/check/unused_literal.gdn:7:11
-// 5|   Dict[]
-// 6| 
-// 7|   let x = 10
-// 8|   x       ^^
-// 9| }
+// --| src/test_files/check/unused_literal.gdn:8:11
+//  6|   Dict[]
+//  7| 
+//  8|   let x = 10
+//  9|   x       ^^
+// 10| }
 
-// expected stderr: 6 issues can be fixed automatically (use `--fix`).
+// expected stderr: 7 issues can be fixed automatically (use `--fix`).


### PR DESCRIPTION
Extended three static analysis checks to handle float literals in addition to integers: `same_literal_returns`, `self_assign_compare`, and `unused_literals`.

- Added `Float(OrderedFloat<f64>)` variant to `LiteralValue` enum in `same_literal_returns.rs` to detect when all code paths return the same float literal
- Updated `self_assign_compare.rs` to recognize float literal comparisons (e.g., `1.0 == 1.0`) as self-comparisons
- Modified `unused_literals.rs` to flag unused float literals alongside other unused literal types

Updated test expectations in `same_literal_returns.gdn`, `unused_literal.gdn`, and `self_assign_compare.gdn` to reflect the new warnings for float literals.

https://claude.ai/code/session_01EMKWgJbWz5rvVa9X2QestE