### PR TITLE
Safely handle missing first argument in Fun type hints

### DIFF
--- a/src/checks/hints.rs
+++ b/src/checks/hints.rs
@@ -124,21 +124,22 @@ impl Visitor for HintVisitor<'_> {
                         }
 
                         if matches!(b, BuiltInType::Fun) {
-                            let first_arg = &type_hint.args[0];
-                            if first_arg.sym.name.text != "Tuple" {
-                                self.diagnostics.push(Diagnostic {
-                                    notes: vec![],
-                                    severity: Severity::Error,
-                                    message: ErrorMessage(vec![
-                                        msgtext!("Expected a tuple here, e.g. "),
-                                        msgcode!("Fun<(Int, Int), String>"),
-                                        msgtext!(" but got "),
-                                        msgcode!("{}", first_arg.sym.name),
-                                        msgtext!("."),
-                                    ]),
-                                    position: first_arg.position.clone(),
-                                    fixes: vec![],
-                                });
+                            if let Some(first_arg) = type_hint.args.first() {
+                                if first_arg.sym.name.text != "Tuple" {
+                                    self.diagnostics.push(Diagnostic {
+                                        notes: vec![],
+                                        severity: Severity::Error,
+                                        message: ErrorMessage(vec![
+                                            msgtext!("Expected a tuple here, e.g. "),
+                                            msgcode!("Fun<(Int, Int), String>"),
+                                            msgtext!(" but got "),
+                                            msgcode!("{}", first_arg.sym.name),
+                                            msgtext!("."),
+                                        ]),
+                                        position: first_arg.position.clone(),
+                                        fixes: vec![],
+                                    });
+                                }
                             }
                         }
                     }

--- a/src/test_files/check/bare_fun_arity.gdn
+++ b/src/test_files/check/bare_fun_arity.gdn
@@ -1,0 +1,11 @@
+public fun apply(_g: Fun) {}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Fun takes 2 type arguments, but got 0 arguments.
+// 
+// -| src/test_files/check/bare_fun_arity.gdn:1:22
+// 1| public fun apply(_g: Fun) {}
+// 2|                      ^^^
+


### PR DESCRIPTION
Refactored the Fun type hint validation to safely handle cases where the type arguments list is empty, preventing potential panics. Changed from direct indexing to using `first()` with pattern matching.

- Wrapped `type_hint.args[0]` access in `if let Some(first_arg)` to safely handle empty argument lists
- Added test case `bare_fun_arity.gdn` to verify the checker correctly reports when `Fun` is used without type arguments

https://claude.ai/code/session_01PcouWuNZzXZ1fFojh2jLpF