### PR TITLE
Implement textDocument/documentSymbol LSP request

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -6,11 +6,12 @@ use gen_lsp_types::{
     CodeActionResponse, CompletionItem, CompletionOptions, CompletionParams, Contents,
     DefinitionParams, DefinitionProvider, Diagnostic, DiagnosticSeverity, DocumentFormattingParams,
     DocumentFormattingProvider, DocumentHighlight, DocumentHighlightParams,
-    DocumentHighlightProvider, ErrorCodes, Hover, HoverParams, HoverProvider, InitializeParams,
-    InitializeResult, Location, MarkupContent, MarkupKind, Position, PublishDiagnosticsParams,
-    Range, RenameParams, RenameProvider, ServerCapabilities, ServerInfo, SignatureHelp,
-    SignatureHelpOptions, SignatureHelpParams, TextDocumentSync, TextDocumentSyncKind, TextEdit,
-    Uri, WorkspaceEdit,
+    DocumentHighlightProvider, DocumentSymbol, DocumentSymbolParams, DocumentSymbolProvider,
+    ErrorCodes, Hover, HoverParams, HoverProvider, InitializeParams, InitializeResult, Location,
+    MarkupContent, MarkupKind, Position, PublishDiagnosticsParams, Range, RenameParams,
+    RenameProvider, ServerCapabilities, ServerInfo, SignatureHelp, SignatureHelpOptions,
+    SignatureHelpParams, SymbolKind, TextDocumentSync, TextDocumentSyncKind, TextEdit, Uri,
+    WorkspaceEdit,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -33,7 +34,7 @@ use crate::eval::load_toplevel_items;
 use crate::extract_function::extract_function;
 use crate::extract_variable::extract_variable;
 use crate::highlight::highlight_occurrences;
-use crate::parser::ast::IdGenerator;
+use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::position::Position as GardenPosition;
 use crate::parser::vfs::Vfs;
 use crate::parser::{parse_toplevel_items, ParseError};
@@ -353,6 +354,130 @@ fn get_hover(src: &str, path: &PathBuf, offset: usize) -> Option<Hover> {
     })
 }
 
+/// Build the document symbols for a single toplevel item, or `None`
+/// for items that don't introduce a named symbol (such as bare
+/// expressions or blocks).
+fn toplevel_item_symbol(item: &ToplevelItem) -> Option<DocumentSymbol> {
+    let range = garden_pos_to_lsp_range(&item.position());
+
+    match item {
+        ToplevelItem::Fun(name_sym, _, _) => Some(document_symbol(
+            name_sym.name.text.clone(),
+            SymbolKind::Function,
+            range,
+            garden_pos_to_lsp_range(&name_sym.position),
+            None,
+        )),
+        ToplevelItem::Method(method_info, _) => Some(document_symbol(
+            method_info.full_name(),
+            SymbolKind::Method,
+            range,
+            garden_pos_to_lsp_range(&method_info.name_sym.position),
+            None,
+        )),
+        ToplevelItem::Test(test_info) => Some(document_symbol(
+            test_info.name_sym.name.text.clone(),
+            SymbolKind::Function,
+            range,
+            garden_pos_to_lsp_range(&test_info.name_sym.position),
+            None,
+        )),
+        ToplevelItem::Enum(enum_info) => {
+            let variants = enum_info
+                .variants
+                .iter()
+                .map(|variant| {
+                    let variant_range = garden_pos_to_lsp_range(&variant.name_sym.position);
+                    document_symbol(
+                        variant.name_sym.name.text.clone(),
+                        SymbolKind::EnumMember,
+                        variant_range,
+                        variant_range,
+                        None,
+                    )
+                })
+                .collect();
+
+            Some(document_symbol(
+                enum_info.name_sym.name.text.clone(),
+                SymbolKind::Enum,
+                range,
+                garden_pos_to_lsp_range(&enum_info.name_sym.position),
+                Some(variants),
+            ))
+        }
+        ToplevelItem::Struct(struct_info) => {
+            let fields = struct_info
+                .fields
+                .iter()
+                .map(|field| {
+                    let field_range = garden_pos_to_lsp_range(&field.sym.position);
+                    document_symbol(
+                        field.sym.name.text.clone(),
+                        SymbolKind::Field,
+                        field_range,
+                        field_range,
+                        None,
+                    )
+                })
+                .collect();
+
+            Some(document_symbol(
+                struct_info.name_sym.name.text.clone(),
+                SymbolKind::Struct,
+                range,
+                garden_pos_to_lsp_range(&struct_info.name_sym.position),
+                Some(fields),
+            ))
+        }
+        ToplevelItem::Import(import_info) => {
+            let name_sym = import_info.namespace_sym.as_ref()?;
+            Some(document_symbol(
+                name_sym.name.text.clone(),
+                SymbolKind::Namespace,
+                range,
+                garden_pos_to_lsp_range(&name_sym.position),
+                None,
+            ))
+        }
+        ToplevelItem::Expr(_) | ToplevelItem::Block(_) => None,
+    }
+}
+
+/// Construct a `DocumentSymbol` with no detail or tags.
+fn document_symbol(
+    name: String,
+    kind: SymbolKind,
+    range: Range,
+    selection_range: Range,
+    children: Option<Vec<DocumentSymbol>>,
+) -> DocumentSymbol {
+    DocumentSymbol::new(
+        name,
+        None,
+        kind,
+        None,
+        None,
+        range,
+        selection_range,
+        children,
+    )
+}
+
+/// Get the document symbols (outline) for a file.
+fn get_document_symbols(src: &str, path: &PathBuf) -> Vec<DocumentSymbol> {
+    let mut id_gen = IdGenerator::default();
+    let (_vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
+
+    let (items, _errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
+
+    items
+        .iter()
+        .filter(|item| !item.is_invalid_or_placeholder())
+        .filter_map(toplevel_item_symbol)
+        .collect()
+}
+
 /// Handle an initialize request.
 fn handle_initialize(
     id: serde_json::Value,
@@ -373,6 +498,7 @@ fn handle_initialize(
             text_document_sync: Some(TextDocumentSync::Kind(TextDocumentSyncKind::Full)),
             document_formatting_provider: Some(DocumentFormattingProvider::Bool(true)),
             document_highlight_provider: Some(DocumentHighlightProvider::Bool(true)),
+            document_symbol_provider: Some(DocumentSymbolProvider::Bool(true)),
             code_action_provider: Some(CodeActionProvider::CodeActionOptions(CodeActionOptions {
                 code_action_kinds: Some(vec![
                     CodeActionKind::QuickFix,
@@ -661,6 +787,32 @@ fn handle_document_highlight(
         .collect();
 
     JsonRpcResponse::new(id, highlights)
+}
+
+/// Handle a textDocument/documentSymbol request.
+fn handle_document_symbol(
+    id: serde_json::Value,
+    params: DocumentSymbolParams,
+    documents: &DocumentStore,
+) -> JsonRpcResponse<Vec<DocumentSymbol>> {
+    let uri = &params.text_document.uri;
+
+    let path = match uri.to_file_path() {
+        Ok(p) => p,
+        Err(_) => return JsonRpcResponse::new(id, vec![]),
+    };
+
+    let src = match documents.get(&path) {
+        Some(content) => content.clone(),
+        None => match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => return JsonRpcResponse::new(id, vec![]),
+        },
+    };
+
+    let symbols = get_document_symbols(&src, &path);
+
+    JsonRpcResponse::new(id, symbols)
 }
 
 /// Handle a textDocument/formatting request.
@@ -1232,6 +1384,17 @@ fn handle_message(
                     id,
                     "textDocument/documentHighlight",
                     |id, params| handle_document_highlight(id, params, documents),
+                );
+            }
+        }
+        Some("textDocument/documentSymbol") => {
+            if let Some(id) = parsed.id {
+                push_request_response(
+                    &mut outgoing,
+                    message,
+                    id,
+                    "textDocument/documentSymbol",
+                    |id, params| handle_document_symbol(id, params, documents),
                 );
             }
         }

--- a/src/test_files/lsp/document_symbol.jsonl
+++ b/src/test_files/lsp/document_symbol.jsonl
@@ -1,0 +1,265 @@
+// Document symbols (outline) lists toplevel definitions, with struct
+// fields and enum variants nested as children.
+{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {"textDocument": {"uri": "file:///symbols.gdn", "languageId": "garden", "version": 1, "text": "struct Point {\n  x: Int,\n  y: Int,\n}\n\nenum Color {\n  Red,\n  Green,\n  Custom(String),\n}\n\npublic fun add_one(i: Int): Int {\n  i + 1\n}\n\npublic method magnitude(this: Point): Int {\n  this.x + this.y\n}\n\ntest add_one_works {\n  assert(add_one(2) == 3)\n}\n"}}}
+{"jsonrpc": "2.0", "id": 1, "method": "textDocument/documentSymbol", "params": {"textDocument": {"uri": "file:///symbols.gdn"}}}
+
+// args: reftest-lsp
+// expected stdout:
+// {
+//   "jsonrpc": "2.0",
+//   "method": "textDocument/publishDiagnostics",
+//   "params": {
+//     "diagnostics": [],
+//     "uri": "file:///symbols.gdn"
+//   }
+// }
+// {
+//   "id": 1,
+//   "jsonrpc": "2.0",
+//   "result": [
+//     {
+//       "children": [
+//         {
+//           "kind": 8,
+//           "name": "x",
+//           "range": {
+//             "end": {
+//               "character": 3,
+//               "line": 1
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 1
+//             }
+//           },
+//           "selectionRange": {
+//             "end": {
+//               "character": 3,
+//               "line": 1
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 1
+//             }
+//           }
+//         },
+//         {
+//           "kind": 8,
+//           "name": "y",
+//           "range": {
+//             "end": {
+//               "character": 3,
+//               "line": 2
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 2
+//             }
+//           },
+//           "selectionRange": {
+//             "end": {
+//               "character": 3,
+//               "line": 2
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 2
+//             }
+//           }
+//         }
+//       ],
+//       "kind": 23,
+//       "name": "Point",
+//       "range": {
+//         "end": {
+//           "character": 1,
+//           "line": 3
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 0
+//         }
+//       },
+//       "selectionRange": {
+//         "end": {
+//           "character": 12,
+//           "line": 0
+//         },
+//         "start": {
+//           "character": 7,
+//           "line": 0
+//         }
+//       }
+//     },
+//     {
+//       "children": [
+//         {
+//           "kind": 22,
+//           "name": "Red",
+//           "range": {
+//             "end": {
+//               "character": 5,
+//               "line": 6
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 6
+//             }
+//           },
+//           "selectionRange": {
+//             "end": {
+//               "character": 5,
+//               "line": 6
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 6
+//             }
+//           }
+//         },
+//         {
+//           "kind": 22,
+//           "name": "Green",
+//           "range": {
+//             "end": {
+//               "character": 7,
+//               "line": 7
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 7
+//             }
+//           },
+//           "selectionRange": {
+//             "end": {
+//               "character": 7,
+//               "line": 7
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 7
+//             }
+//           }
+//         },
+//         {
+//           "kind": 22,
+//           "name": "Custom",
+//           "range": {
+//             "end": {
+//               "character": 8,
+//               "line": 8
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 8
+//             }
+//           },
+//           "selectionRange": {
+//             "end": {
+//               "character": 8,
+//               "line": 8
+//             },
+//             "start": {
+//               "character": 2,
+//               "line": 8
+//             }
+//           }
+//         }
+//       ],
+//       "kind": 10,
+//       "name": "Color",
+//       "range": {
+//         "end": {
+//           "character": 1,
+//           "line": 9
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 5
+//         }
+//       },
+//       "selectionRange": {
+//         "end": {
+//           "character": 10,
+//           "line": 5
+//         },
+//         "start": {
+//           "character": 5,
+//           "line": 5
+//         }
+//       }
+//     },
+//     {
+//       "kind": 12,
+//       "name": "add_one",
+//       "range": {
+//         "end": {
+//           "character": 1,
+//           "line": 13
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 11
+//         }
+//       },
+//       "selectionRange": {
+//         "end": {
+//           "character": 18,
+//           "line": 11
+//         },
+//         "start": {
+//           "character": 11,
+//           "line": 11
+//         }
+//       }
+//     },
+//     {
+//       "kind": 6,
+//       "name": "Point::magnitude",
+//       "range": {
+//         "end": {
+//           "character": 1,
+//           "line": 17
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 15
+//         }
+//       },
+//       "selectionRange": {
+//         "end": {
+//           "character": 23,
+//           "line": 15
+//         },
+//         "start": {
+//           "character": 14,
+//           "line": 15
+//         }
+//       }
+//     },
+//     {
+//       "kind": 12,
+//       "name": "add_one_works",
+//       "range": {
+//         "end": {
+//           "character": 1,
+//           "line": 21
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 19
+//         }
+//       },
+//       "selectionRange": {
+//         "end": {
+//           "character": 18,
+//           "line": 19
+//         },
+//         "start": {
+//           "character": 5,
+//           "line": 19
+//         }
+//       }
+//     }
+//   ]
+// }

--- a/src/test_files/lsp/initialize.jsonl
+++ b/src/test_files/lsp/initialize.jsonl
@@ -26,6 +26,7 @@
 //       "definitionProvider": true,
 //       "documentFormattingProvider": true,
 //       "documentHighlightProvider": true,
+//       "documentSymbolProvider": true,
 //       "hoverProvider": true,
 //       "renameProvider": true,
 //       "signatureHelpProvider": {

--- a/src/test_files/lsp/protocol_errors.jsonl
+++ b/src/test_files/lsp/protocol_errors.jsonl
@@ -2,7 +2,7 @@
 // unsupported, the params are malformed, or the message itself
 // doesn't parse: a client that receives nothing will wait
 // indefinitely. Unknown notifications are ignored.
-{"jsonrpc": "2.0", "id": 1, "method": "textDocument/documentSymbol", "params": {"textDocument": {"uri": "file:///test.gdn"}}}
+{"jsonrpc": "2.0", "id": 1, "method": "textDocument/references", "params": {"textDocument": {"uri": "file:///test.gdn"}}}
 {"jsonrpc": "2.0", "method": "$/setTrace", "params": {"value": "off"}}
 {"jsonrpc": "2.0", "id": 2, "method": "textDocument/hover", "params": {"position": {"line": 0}}}
 {"id": 3, "method": "shutdown"}
@@ -12,7 +12,7 @@
 // {
 //   "error": {
 //     "code": -32601,
-//     "message": "Unsupported method textDocument/documentSymbol."
+//     "message": "Unsupported method textDocument/references."
 //   },
 //   "id": 1,
 //   "jsonrpc": "2.0"


### PR DESCRIPTION
Add support for the `textDocument/documentSymbol` LSP request, which provides an outline of top-level definitions in a Garden source file.

The implementation:
- Parses top-level items and converts them to `DocumentSymbol` objects with appropriate `SymbolKind` values
- Nests struct fields and enum variants as children of their parent types
- Includes proper range and selection range information for each symbol
- Registers the new capability in the server's initialize response
- Adds a comprehensive test case covering structs, enums, functions, methods, and tests

https://claude.ai/code/session_01Pw964878ENdnj4WpDUHAmu