### PR TITLE
Add textDocument/references LSP support

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -21,6 +21,21 @@ use crate::pos_to_id::find_item_at;
 ///
 /// Returns an empty vector if there is no variable at that offset.
 pub(crate) fn highlight_occurrences(src: &str, path: &Path, offset: usize) -> Vec<Position> {
+    match occurrences_with_def(src, path, offset) {
+        Some((_, positions)) => positions,
+        None => vec![],
+    }
+}
+
+/// Find the definition position of the symbol at `offset`, along with
+/// all occurrences of that symbol (including the definition site).
+///
+/// Returns `None` if there is no symbol at that offset.
+pub(crate) fn occurrences_with_def(
+    src: &str,
+    path: &Path,
+    offset: usize,
+) -> Option<(Position, Vec<Position>)> {
     let mut id_gen = IdGenerator::default();
     let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
 
@@ -48,12 +63,10 @@ pub(crate) fn highlight_occurrences(src: &str, path: &Path, offset: usize) -> Ve
         }
     }
 
-    let Some(def_pos) = def_pos else {
-        return vec![];
-    };
+    let def_pos = def_pos?;
 
     let mut visitor = HighlightVisitor {
-        definition_pos: def_pos,
+        definition_pos: def_pos.clone(),
         id_to_pos: &summary.id_to_def_pos,
         positions: vec![],
     };
@@ -64,7 +77,7 @@ pub(crate) fn highlight_occurrences(src: &str, path: &Path, offset: usize) -> Ve
 
     let mut positions = visitor.positions;
     positions.sort_unstable_by_key(|p| p.start_offset);
-    positions
+    Some((def_pos, positions))
 }
 
 struct HighlightVisitor<'a> {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -8,10 +8,10 @@ use gen_lsp_types::{
     DocumentFormattingProvider, DocumentHighlight, DocumentHighlightParams,
     DocumentHighlightProvider, DocumentSymbol, DocumentSymbolParams, DocumentSymbolProvider,
     ErrorCodes, Hover, HoverParams, HoverProvider, InitializeParams, InitializeResult, Location,
-    MarkupContent, MarkupKind, Position, PublishDiagnosticsParams, Range, RenameParams,
-    RenameProvider, ServerCapabilities, ServerInfo, SignatureHelp, SignatureHelpOptions,
-    SignatureHelpParams, SymbolKind, TextDocumentSync, TextDocumentSyncKind, TextEdit, Uri,
-    WorkspaceEdit,
+    MarkupContent, MarkupKind, Position, PublishDiagnosticsParams, Range, ReferenceParams,
+    ReferencesProvider, RenameParams, RenameProvider, ServerCapabilities, ServerInfo,
+    SignatureHelp, SignatureHelpOptions, SignatureHelpParams, SymbolKind, TextDocumentSync,
+    TextDocumentSyncKind, TextEdit, Uri, WorkspaceEdit,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ use crate::env::Env;
 use crate::eval::load_toplevel_items;
 use crate::extract_function::extract_function;
 use crate::extract_variable::extract_variable;
-use crate::highlight::highlight_occurrences;
+use crate::highlight::{highlight_occurrences, occurrences_with_def};
 use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::position::Position as GardenPosition;
 use crate::parser::vfs::Vfs;
@@ -508,6 +508,7 @@ fn handle_initialize(
                 ]),
                 ..Default::default()
             })),
+            references_provider: Some(ReferencesProvider::Bool(true)),
             rename_provider: Some(RenameProvider::Bool(true)),
             ..Default::default()
         },
@@ -932,6 +933,46 @@ fn handle_code_action(
     }
 
     JsonRpcResponse::new(id, actions)
+}
+
+/// Handle a textDocument/references request.
+fn handle_references(
+    id: serde_json::Value,
+    params: ReferenceParams,
+    documents: &DocumentStore,
+) -> JsonRpcResponse<Option<Vec<Location>>> {
+    let uri = &params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+
+    let path = match uri.to_file_path() {
+        Ok(p) => p,
+        Err(_) => return JsonRpcResponse::new(id, None),
+    };
+
+    let src = match documents.get(&path) {
+        Some(content) => content.clone(),
+        None => match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => return JsonRpcResponse::new(id, None),
+        },
+    };
+
+    let offset = line_char_to_offset(&src, position.line as usize, position.character as usize);
+
+    let Some((def_pos, positions)) = occurrences_with_def(&src, &path, offset) else {
+        return JsonRpcResponse::new(id, None);
+    };
+
+    let locations: Vec<Location> = positions
+        .into_iter()
+        .filter(|pos| params.context.include_declaration || *pos != def_pos)
+        .map(|pos| Location {
+            uri: uri.clone(),
+            range: garden_pos_to_lsp_range(&pos),
+        })
+        .collect();
+
+    JsonRpcResponse::new(id, Some(locations))
 }
 
 /// Handle a textDocument/rename request.
@@ -1465,6 +1506,17 @@ fn handle_message(
                     id,
                     "textDocument/codeAction",
                     |id, params| handle_code_action(id, params, documents),
+                );
+            }
+        }
+        Some("textDocument/references") => {
+            if let Some(id) = parsed.id {
+                push_request_response(
+                    &mut outgoing,
+                    message,
+                    id,
+                    "textDocument/references",
+                    |id, params| handle_references(id, params, documents),
                 );
             }
         }

--- a/src/test_files/lsp/initialize.jsonl
+++ b/src/test_files/lsp/initialize.jsonl
@@ -28,6 +28,7 @@
 //       "documentHighlightProvider": true,
 //       "documentSymbolProvider": true,
 //       "hoverProvider": true,
+//       "referencesProvider": true,
 //       "renameProvider": true,
 //       "signatureHelpProvider": {
 //         "triggerCharacters": [

--- a/src/test_files/lsp/protocol_errors.jsonl
+++ b/src/test_files/lsp/protocol_errors.jsonl
@@ -11,8 +11,8 @@
 // expected stdout:
 // {
 //   "error": {
-//     "code": -32601,
-//     "message": "Unsupported method textDocument/references."
+//     "code": -32602,
+//     "message": "Could not parse parameters for textDocument/references."
 //   },
 //   "id": 1,
 //   "jsonrpc": "2.0"

--- a/src/test_files/lsp/references.jsonl
+++ b/src/test_files/lsp/references.jsonl
@@ -1,0 +1,94 @@
+// Find all references to a user-defined function. The first request
+// includes the declaration, the second excludes it.
+{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {"textDocument": {"uri": "file:///references.gdn", "languageId": "garden", "version": 1, "text": "fun add_one(i: Int): Int {\n  i + 1\n}\n\nadd_one(2)\nadd_one(3)\n"}}}
+{"jsonrpc": "2.0", "id": 1, "method": "textDocument/references", "params": {"textDocument": {"uri": "file:///references.gdn"}, "position": {"line": 4, "character": 1}, "context": {"includeDeclaration": true}}}
+{"jsonrpc": "2.0", "id": 2, "method": "textDocument/references", "params": {"textDocument": {"uri": "file:///references.gdn"}, "position": {"line": 4, "character": 1}, "context": {"includeDeclaration": false}}}
+
+// args: reftest-lsp
+// expected stdout:
+// {
+//   "jsonrpc": "2.0",
+//   "method": "textDocument/publishDiagnostics",
+//   "params": {
+//     "diagnostics": [],
+//     "uri": "file:///references.gdn"
+//   }
+// }
+// {
+//   "id": 1,
+//   "jsonrpc": "2.0",
+//   "result": [
+//     {
+//       "range": {
+//         "end": {
+//           "character": 11,
+//           "line": 0
+//         },
+//         "start": {
+//           "character": 4,
+//           "line": 0
+//         }
+//       },
+//       "uri": "file:///references.gdn"
+//     },
+//     {
+//       "range": {
+//         "end": {
+//           "character": 7,
+//           "line": 4
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 4
+//         }
+//       },
+//       "uri": "file:///references.gdn"
+//     },
+//     {
+//       "range": {
+//         "end": {
+//           "character": 7,
+//           "line": 5
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 5
+//         }
+//       },
+//       "uri": "file:///references.gdn"
+//     }
+//   ]
+// }
+// {
+//   "id": 2,
+//   "jsonrpc": "2.0",
+//   "result": [
+//     {
+//       "range": {
+//         "end": {
+//           "character": 7,
+//           "line": 4
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 4
+//         }
+//       },
+//       "uri": "file:///references.gdn"
+//     },
+//     {
+//       "range": {
+//         "end": {
+//           "character": 7,
+//           "line": 5
+//         },
+//         "start": {
+//           "character": 0,
+//           "line": 5
+//         }
+//       },
+//       "uri": "file:///references.gdn"
+//     }
+//   ]
+// }
+


### PR DESCRIPTION
Implement the textDocument/references LSP request to find all references to a symbol at a given position.

The implementation:
- Refactors `highlight_occurrences` to extract a new `occurrences_with_def` function that returns both the definition position and all occurrences, enabling filtering based on the `includeDeclaration` context parameter
- Adds `handle_references` to process reference requests and return locations filtered by the include_declaration flag
- Registers the references provider in server capabilities
- Adds a test case demonstrating the feature with and without declaration inclusion

https://claude.ai/code/session_013RYFpLKK814kAdE1sTNUmz