### PR TITLE
Fix LSP contentChanges handling for batched document updates

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -441,11 +441,13 @@ fn handle_did_change(
     let text_document = params.get("textDocument")?;
     let uri = text_document.get("uri")?.as_str()?;
 
-    // Get the new text from contentChanges (full document sync)
+    // Get the new text from contentChanges (full document sync). When a
+    // client batches multiple changes, the last one is the final document
+    // state.
     let text = params
         .get("contentChanges")?
         .as_array()?
-        .first()?
+        .last()?
         .get("text")?
         .as_str()?;
 


### PR DESCRIPTION
When a client batches multiple document changes in a single `didChange` notification, the LSP handler was incorrectly using the first change instead of the last one. This caused the editor to use stale document state when multiple edits were sent together.

Changed `contentChanges` array access from `.first()` to `.last()` to correctly retrieve the final document state, which is the authoritative version when batching occurs.

https://claude.ai/code/session_01AoNYuYPkuyRdouVfspVvud