### PR TITLE
Skip type checking when method call has wrong arity

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1451,19 +1451,22 @@ impl TypeCheckVisitor<'_> {
                     .map(|param_decl_ty| substitute_ty_vars(param_decl_ty, &ty_var_env))
                     .collect::<Vec<_>>();
 
-                for (param_ty, (arg_ty, arg_pos, _)) in params.iter().zip(&arg_tys) {
-                    if !is_subtype(arg_ty, param_ty) {
-                        self.diagnostics.push(Diagnostic {
-                            notes: vec![],
-                            fixes: vec![],
-                            severity: Severity::Error,
-                            message: format_type_mismatch(param_ty, arg_ty),
-                            position: arg_pos.clone(),
-                        });
+                if fun_info.params.params.len() == paren_args.arguments.len() {
+                    // Only check argument types if we have the right number of
+                    // arguments. Otherwise, it's likely that the types are valid,
+                    // but there were missing previous arguments.
+                    for (param_ty, (arg_ty, arg_pos, _)) in params.iter().zip(&arg_tys) {
+                        if !is_subtype(arg_ty, param_ty) {
+                            self.diagnostics.push(Diagnostic {
+                                notes: vec![],
+                                fixes: vec![],
+                                severity: Severity::Error,
+                                message: format_type_mismatch(param_ty, arg_ty),
+                                position: arg_pos.clone(),
+                            });
+                        }
                     }
-                }
-
-                if fun_info.params.params.len() != paren_args.arguments.len() {
+                } else {
                     let name = format!("{}::{}", receiver_ty_name, sym.name);
                     self.arity_diagnostics(Some(&name), &params, &arg_tys, paren_args);
                 }

--- a/src/test_files/check/method_arity_wrong_type.gdn
+++ b/src/test_files/check/method_arity_wrong_type.gdn
@@ -1,0 +1,18 @@
+{
+  let x = [1, 2]
+  // Too few arguments, and the argument has the wrong type. Only the
+  // arity error should be reported, not a type mismatch.
+  x.slice("a")
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: `List::slice` requires an additional `Int` argument.
+// 
+// -| src/test_files/check/method_arity_wrong_type.gdn:5:14
+// 3|   // Too few arguments, and the argument has the wrong type. Only the
+// 4|   // arity error should be reported, not a type mismatch.
+// 5|   x.slice("a")
+// 6| }            ^
+


### PR DESCRIPTION
When a method call has the wrong number of arguments, skip type checking the arguments. This prevents duplicate diagnostics — an arity error is more helpful than a type mismatch error when arguments are missing or extra.

The type checker now only validates argument types if the argument count matches the parameter count. When there's an arity mismatch, only the arity diagnostic is reported.

A test case is added to verify that a method call with too few arguments and a type mismatch only reports the arity error.

https://claude.ai/code/session_015fVGKWpCtPiTN36MSiJaEn