### PR TITLE
Add extract variable code action to LSP tests

### DIFF
--- a/src/test_files/lsp/code_action.jsonl
+++ b/src/test_files/lsp/code_action.jsonl
@@ -97,6 +97,29 @@
 //         "changes": {
 //           "file:///code_action.gdn": [
 //             {
+//               "newText": "fun main() {\n  let extracted = Path{ p: \"/foo\" }.existts()\n  extracted\n}\n",
+//               "range": {
+//                 "end": {
+//                   "character": 0,
+//                   "line": 3
+//                 },
+//                 "start": {
+//                   "character": 0,
+//                   "line": 0
+//                 }
+//               }
+//             }
+//           ]
+//         }
+//       },
+//       "kind": "refactor.extract",
+//       "title": "Extract variable"
+//     },
+//     {
+//       "edit": {
+//         "changes": {
+//           "file:///code_action.gdn": [
+//             {
 //               "newText": "fun main() {\n  dbg(Path{ p: \"/foo\" }.existts())\n}\n",
 //               "range": {
 //                 "end": {

--- a/src/test_files/lsp/extract_function.jsonl
+++ b/src/test_files/lsp/extract_function.jsonl
@@ -59,6 +59,29 @@
 //         "changes": {
 //           "file:///extract_function.gdn": [
 //             {
+//               "newText": "fun foo() {\n  let extracted = 1 + 2\n  let _ = extracted\n}\n",
+//               "range": {
+//                 "end": {
+//                   "character": 0,
+//                   "line": 3
+//                 },
+//                 "start": {
+//                   "character": 0,
+//                   "line": 0
+//                 }
+//               }
+//             }
+//           ]
+//         }
+//       },
+//       "kind": "refactor.extract",
+//       "title": "Extract variable"
+//     },
+//     {
+//       "edit": {
+//         "changes": {
+//           "file:///extract_function.gdn": [
+//             {
 //               "newText": "fun foo() {\n  let _ = dbg(1 + 2)\n}\n",
 //               "range": {
 //                 "end": {


### PR DESCRIPTION
Updated LSP test expectations to include the "Extract variable" code action, which is now offered alongside existing refactoring options in both code_action and extract_function test cases.

https://claude.ai/code/session_011Ymcna2v3FV2UY1Hc8QSYX