### PR TITLE
Report inferred type for match expressions in hover

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -765,7 +765,13 @@ impl TypeCheckVisitor<'_> {
                     ));
                 }
                 _ => {
-                    self.check_block(expected_ty, case_expr, type_bindings, expected_return_ty);
+                    // Even though we're checking against a concrete
+                    // expected type, keep the inferred case type so we
+                    // can record the more specific type below.
+                    case_tys.push((
+                        self.check_block(expected_ty, case_expr, type_bindings, expected_return_ty),
+                        case_value_pos,
+                    ));
                 }
             }
 
@@ -884,8 +890,16 @@ impl TypeCheckVisitor<'_> {
                 }
             },
             _ => {
-                debug_assert_eq!(case_tys.len(), 0);
-                expected_ty.clone()
+                // Return the inferred type of the cases rather than
+                // the widened expected type, so that hover and
+                // extract-function report the precise type. Any
+                // mismatches have already been reported by
+                // check_block above, so fall back to the expected type
+                // if the cases don't unify.
+                match unify_all(&case_tys) {
+                    Ok(ty) if !ty.is_no_value() => ty,
+                    _ => expected_ty.clone(),
+                }
             }
         };
 

--- a/src/test_files/hover/match_checked_type.gdn
+++ b/src/test_files/hover/match_checked_type.gdn
@@ -1,0 +1,15 @@
+fun foo(b: Bool): Option<Int> {
+  match b {
+//^
+    True => None
+    False => None
+  }
+}
+
+// The match is checked against the declared return type `Option<Int>`,
+// but every case evaluates to `None`, so the inferred type of the match
+// is `Option<NoValue>`. Hover should report the inferred type rather
+// than the widened expected type.
+
+// args: reftest-hover
+// expected stdout: Option<NoValue>


### PR DESCRIPTION
When a match expression is type-checked against an expected type (e.g., a function's return type), the type checker now records the inferred type of the cases rather than discarding it. This allows hover information and extract-function to report the precise inferred type instead of the widened expected type.

For example, a match expression checked against `Option<Int>` where all cases evaluate to `None` will now report `Option<NoValue>` on hover, rather than `Option<Int>`.

Key changes:
- Modified the default case handler in `check_block` to collect inferred case types instead of discarding them
- Updated the match type resolution logic to unify the inferred case types and fall back to the expected type only if unification fails
- Added a test case demonstrating the behavior with a match expression returning `None` values

https://claude.ai/code/session_012jfuQwzsxpREXW1eYkjvEB