### PR TITLE
Report error for unknown types in lambda return hints

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -2469,7 +2469,7 @@ impl TypeCheckVisitor<'_> {
 
                 if let Some(hint) = &fun_info.return_hint {
                     let hint_ty =
-                        Type::from_hint(hint, &self.env.types, type_bindings).unwrap_or(Type::Any);
+                        Type::from_hint(hint, &self.env.types, type_bindings).unwrap_or_err_ty();
                     self.save_hint_ty_id(hint, &hint_ty);
 
                     if !is_subtype(&block_ty, &hint_ty) {


### PR DESCRIPTION
When a lambda expression has a return type hint that references an unknown type, the type checker now reports an error instead of silently treating it as `Any`. This ensures that typos and missing type definitions in lambda return hints are caught during type checking.

The change replaces `unwrap_or(Type::Any)` with `unwrap_or_err_ty()` when resolving lambda return type hints, making the behavior consistent with how unknown types are handled elsewhere in the type checker.

https://claude.ai/code/session_01PQGpKMntJB77TDSmNm5ysL