### PR TITLE
Redesign code snippets and add table of contents

### DIFF
--- a/website/build_site.gdn
+++ b/website/build_site.gdn
@@ -413,80 +413,60 @@ fun build_site(): Unit {
   }
 }
 
-/// Convert `["a", "b", "c"]` to `"a, b and c"`.
-fun join_with_commas_and(items: List<String>): String {
-  let last_item = match items.last() {
-    Some(item) => item,
-    None => return "",
-  }
-
-  let but_last = items.slice(0, -1)
-  if but_last.is_empty() {
-    return last_item
-  }
-
-  " and ".join([", ".join(but_last), last_item ^ "."])
+/// Escape `<` and `>` so operator names render correctly in HTML,
+/// and `*` so it isn't treated as markdown emphasis.
+fun escape_html(s: String): String {
+  s.replace("<", "&lt;").replace(">", "&gt;").replace("*", "&#42;")
 }
 
-/// Helper function to create markdown links of the form
-//
-/// ```text
-/// [`foo`](bar.html)
-/// ```
-fun code_link(text: String, url: String): String {
-  "[`" ^ text ^ "`](" ^ url ^ ")"
+/// An HTML link to `url`, with `text` rendered as code.
+fun grid_link(text: String, url: String): String {
+  "<a href=\"" ^ url ^ "\"><code>" ^ escape_html(text) ^ "</code></a>"
+}
+
+/// Render `links` as a single HTML grid block.
+fun link_grid(links: List<String>): String {
+  "<div class=\"link-grid\">" ^ "".join(links) ^ "</div>"
 }
 
 /// Replace all __FOO strings in markdown `src` with runtime values.
 fun substitute_shorthand(website_dir: Path, src: String): String {
-  let keyword_links = reflect::keywords().map(fun(keyword: String) {
-    code_link(keyword, "./keyword:" ^ keyword ^ ".html")
-  })
+  let keyword_links = link_grid(reflect::keywords().map(fun(keyword: String) {
+      grid_link(keyword, "./keyword:" ^ keyword ^ ".html")
+  }))
 
-  let keyword_links = join_with_commas_and(keyword_links)
+  let operator_links = link_grid(reflect::operators().map(fun(operator: String) {
+      let page_name = ops::url_safe_name(operator)
+      grid_link(operator, "./operator:" ^ page_name ^ ".html")
+  }))
 
-  let operator_links = reflect::operators().map(fun(operator: String) {
-    let page_name = ops::url_safe_name(operator)
-    code_link(operator, "./operator:" ^ page_name ^ ".html")
-  })
+  let type_links = link_grid(reflect::prelude_types().map(fun(name: String) {
+      grid_link(name, "./type:" ^ name ^ ".html")
+  }))
 
-  let operator_links = join_with_commas_and(operator_links)
+  let prelude_funs = link_grid(reflect::namespace_functions(prelude).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
+  }))
 
-  let type_links = reflect::prelude_types().map(fun(name: String) {
-    code_link(name, "./type:" ^ name ^ ".html")
-  })
+  let fs_funs = link_grid(reflect::namespace_functions(fs).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
+  }))
 
-  let type_links = join_with_commas_and(type_links)
+  let random_funs = link_grid(reflect::namespace_functions(random).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
+  }))
 
-  let prelude_funs = reflect::namespace_functions(prelude).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__prelude.gdn::" ^ name ^ ".html")
-  })
-  let prelude_funs = join_with_commas_and(prelude_funs)
+  let reflect_funs = link_grid(reflect::namespace_functions(reflect).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
+  }))
 
-  let fs_funs = reflect::namespace_functions(fs).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__fs.gdn::" ^ name ^ ".html")
-  })
-  let fs_funs = join_with_commas_and(fs_funs)
+  let shell_funs = link_grid(reflect::namespace_functions(shell).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__shell.gdn::" ^ name ^ ".html")
+  }))
 
-  let random_funs = reflect::namespace_functions(random).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__random.gdn::" ^ name ^ ".html")
-  })
-  let random_funs = join_with_commas_and(random_funs)
-
-  let reflect_funs = reflect::namespace_functions(reflect).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__reflect.gdn::" ^ name ^ ".html")
-  })
-  let reflect_funs = join_with_commas_and(reflect_funs)
-
-  let shell_funs = reflect::namespace_functions(shell).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__shell.gdn::" ^ name ^ ".html")
-  })
-  let shell_funs = join_with_commas_and(shell_funs)
-
-  let time_funs = reflect::namespace_functions(time).map(fun(name: String) {
-    code_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
-  })
-  let time_funs = join_with_commas_and(time_funs)
+  let time_funs = link_grid(reflect::namespace_functions(time).map(fun(name: String) {
+      grid_link(name ^ "()", "./fun:__time.gdn::" ^ name ^ ".html")
+  }))
 
   let blog_links: List<String> = []
   for post in blog_posts(website_dir) {

--- a/website/keyword:test.md
+++ b/website/keyword:test.md
@@ -11,6 +11,6 @@ test arithmetic {
 To run all the tests in a file, run the `garden` interpreter with the
 `test` command.
 
-```text title:"Running tests"
+```shell title:"Running tests"
 $ garden test my_file.gdn
 ```

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -706,6 +706,12 @@ fun render_emphasis(src: String): String {
 }
 
 fun render_paragraph(src: String, self_url: Option<String>): String {
+  if src.starts_with("<div") {
+    // A raw HTML block. Don't wrap it in <p>, because <div> isn't
+    // allowed inside <p>.
+    return render_inline(src, self_url)
+  }
+
   "<p>" ^ render_inline(src, self_url) ^ "</p>"
 }
 
@@ -861,6 +867,10 @@ test render_thematic_break {
 
 test render_html {
   assert(render("<script></script>", None, None) == "<p><script></script></p>")
+}
+
+test render_html_div_block {
+  assert(render("<div class=\"foo\"><a href=\"#\">x</a></div>", None, None) == "<div class=\"foo\"><a href=\"#\">x</a></div>")
 }
 
 test render_html_comment {

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -769,13 +769,34 @@ fun render_bullets(items: List<String>, self_url: Option<String>): String {
   "<ul>\n" ^ "\n".join(rendered_items) ^ "\n</ul>"
 }
 
+/// Render a sidebar table of contents from `toc_entries`, a list of
+/// rendered `<li>` items.
+fun render_toc(toc_entries: List<String>): String {
+  "".join([
+    "<nav class=\"toc\"><span class=\"toc-title\">On this page</span><ul>\n",
+    "\n".join(toc_entries),
+    "\n</ul></nav>"])
+}
+
 public fun render(src: String, file: Option<Path>, self_url: Option<String>): String {
   let html_parts: List<String> = []
+  let toc_entries: List<String> = []
 
   for part in parse_markdown(src, file) {
     match part {
       Heading(heading) => {
         html_parts = html_parts.append(render_heading(heading, self_url))
+
+        if heading.starts_with("## ") {
+          let content = heading.strip_prefix("##").trim()
+          let entry = "".join([
+            "<li><a href=\"#",
+            heading_slug(content),
+            "\">",
+            render_inline(content, self_url),
+            "</a></li>"])
+          toc_entries = toc_entries.append(entry)
+        }
       }
       Paragraph(paragraph) => {
         html_parts = html_parts.append(render_paragraph(paragraph, self_url))
@@ -790,6 +811,12 @@ public fun render(src: String, file: Option<Path>, self_url: Option<String>): St
         html_parts = html_parts.append("<hr />")
       }
     }
+  }
+
+  // Only show a table of contents on pages with enough sections for
+  // it to be useful.
+  if toc_entries.len() >= 3 {
+    html_parts = [render_toc(toc_entries)].concat(html_parts)
   }
 
   "\n".join(html_parts)
@@ -816,6 +843,21 @@ test render_paragraph {
 
 test render_paragraph_escape_angle_brackets {
   assert(render("foo bar<", None, None) == "<p>foo bar&lt;</p>")
+}
+
+test render_table_of_contents {
+  assert(render("## a\n\n## b\n\n## c", None, None) == "<nav class=\"toc\"><span class=\"toc-title\">On this page</span><ul>
+<li><a href=\"#a\">a</a></li>
+<li><a href=\"#b\">b</a></li>
+<li><a href=\"#c\">c</a></li>
+</ul></nav>
+<h2 id=\"a\">a</h2>
+<h2 id=\"b\">b</h2>
+<h2 id=\"c\">c</h2>")
+}
+
+test render_no_table_of_contents_for_few_headings {
+  assert(render("## a\n\n## b", None, None) == "<h2 id=\"a\">a</h2>\n<h2 id=\"b\">b</h2>")
 }
 
 test render_paragraph_after_heading {

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -166,6 +166,49 @@ fun parse_markdown(src: String, file: Option<Path>): List<MarkdownPart> {
   parts
 }
 
+/// Convert heading text to an HTML id, e.g. `Built-in Types` to
+/// `built-in-types`.
+fun heading_slug(content: String): String {
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let digits = "0123456789"
+
+  let slug_chars: List<String> = []
+
+  // Treat the start as a dash, so we never emit a leading dash.
+  let prev_was_dash = True
+
+  for char in content.chars() {
+    let slug_char = if lower.contains(char) || digits.contains(char) {
+      char
+    } else {
+      match upper.index_of(char) {
+        Some(i) => lower.substring(i, i + 1)
+        None => "-"
+      }
+    }
+
+    if slug_char == "-" {
+      if prev_was_dash {
+        continue
+      }
+      prev_was_dash = True
+    } else {
+      prev_was_dash = False
+    }
+
+    slug_chars = slug_chars.append(slug_char)
+  }
+
+  "".join(slug_chars).strip_suffix("-")
+}
+
+test heading_slug {
+  assert(heading_slug("Built-in Types") == "built-in-types")
+  assert(heading_slug("`==` and `!=` Operators") == "and-operators")
+  assert(heading_slug("Shell `__shell.gdn`") == "shell-shell-gdn")
+}
+
 /// Render a "# Foo" heading.
 fun render_heading(src: String, self_url: Option<String>): String {
   let h_count = 0
@@ -180,10 +223,12 @@ fun render_heading(src: String, self_url: Option<String>): String {
     return "<p>" ^ src ^ "</p>"
   }
 
-  let open_tag = "<h" ^ string_repr(h_count) ^ ">"
+  let content = content.trim()
+
+  let open_tag = "<h" ^ string_repr(h_count) ^ " id=\"" ^ heading_slug(content) ^ "\">"
   let close_tag = "</h" ^ string_repr(h_count) ^ ">"
 
-  open_tag ^ render_inline(content.trim(), self_url) ^ close_tag
+  open_tag ^ render_inline(content, self_url) ^ close_tag
 }
 
 /// We want to find " < ", which requires trailing whitespace on the
@@ -755,11 +800,11 @@ test render_paragraph_newlines {
 }
 
 test render_headings {
-  assert(render("# foo", None, None) == "<h1>foo</h1>")
-  assert(render("#  foo ", None, None) == "<h1>foo</h1>")
+  assert(render("# foo", None, None) == "<h1 id=\"foo\">foo</h1>")
+  assert(render("#  foo ", None, None) == "<h1 id=\"foo\">foo</h1>")
 
-  assert(render("## foo", None, None) == "<h2>foo</h2>")
-  assert(render("###### foo", None, None) == "<h6>foo</h6>")
+  assert(render("## foo", None, None) == "<h2 id=\"foo\">foo</h2>")
+  assert(render("###### foo", None, None) == "<h6 id=\"foo\">foo</h6>")
 
   assert(render("#foo", None, None) == "<p>#foo</p>")
   assert(render("####### foo", None, None) == "<p>####### foo</p>")
@@ -774,7 +819,7 @@ test render_paragraph_escape_angle_brackets {
 }
 
 test render_paragraph_after_heading {
-  assert(render("# foo\n\nbar", None, None) == "<h1>foo</h1>\n<p>bar</p>")
+  assert(render("# foo\n\nbar", None, None) == "<h1 id=\"foo\">foo</h1>\n<p>bar</p>")
 }
 
 test render_backtick {
@@ -794,7 +839,7 @@ test render_strong_escape_angle_brackets {
 }
 
 test render_backtick_in_heading {
-  assert(render("# `foo`", None, None) == "<h1><code>foo</code></h1>")
+  assert(render("# `foo`", None, None) == "<h1 id=\"foo\"><code>foo</code></h1>")
 }
 
 test render_link {

--- a/website/markdown.gdn
+++ b/website/markdown.gdn
@@ -214,6 +214,8 @@ fun render_code_block(snippet: Snippet, self_url: Option<String>): String {
 
   let (inner, output_div) = if is_garden {
     (render_garden_code(snippet, self_url), "<div class=\"snippet-output\" hidden></div>")
+  } else if snippet.labels.contains("shell") {
+    (render_shell_code(snippet.content), "")
   } else {
     ("<code>" ^ escape_angle_brackets(snippet.content) ^ "</code>", "")
   }
@@ -232,6 +234,28 @@ fun render_code_block(snippet: Snippet, self_url: Option<String>): String {
   }
 
   "<div class=\"snippet\">" ^ header ^ "<pre>" ^ inner ^ "</pre>" ^ buttons ^ output_div ^ "</div>"
+}
+
+/// Render a shell session. Lines starting with `$ ` are commands,
+/// and other lines are program output.
+//
+/// The `$ ` prompt is marked up separately so CSS can make it
+/// unselectable, keeping commands easy to copy-paste.
+fun render_shell_code(content: String): String {
+  let rendered_lines: List<String> = []
+
+  for line in content.lines() {
+    let rendered_line = if line.starts_with("$ ") {
+      let command = escape_angle_brackets(line.strip_prefix("$ "))
+      "<span class=\"prompt\">$ </span><span class=\"command\">" ^ command ^ "</span>"
+    } else {
+      "<span class=\"shell-output\">" ^ escape_angle_brackets(line) ^ "</span>"
+    }
+
+    rendered_lines = rendered_lines.append(rendered_line)
+  }
+
+  "<code>" ^ "\n".join(rendered_lines) ^ "</code>"
 }
 
 fun check_source(src: String, path: Option<Path>): Unit {
@@ -801,6 +825,10 @@ test render_triple_backtick_keyword {
 
 test render_triple_backtick_comment {
   assert(render("```garden nocheck\nfoo // bar\n```", None, None) == "<div class=\"snippet\"><pre><code>foo <span class=\"comment\">// bar</span></code></pre><button class=\"run-snippet\">Run</button><button class=\"edit-snippet\">Edit</button><div class=\"snippet-output\" hidden></div></div>")
+}
+
+test render_shell_block {
+  assert(render("```shell\n$ garden run foo.gdn\nHello\n```", None, None) == "<div class=\"snippet\"><pre><code><span class=\"prompt\">$ </span><span class=\"command\">garden run foo.gdn</span>\n<span class=\"shell-output\">Hello</span></code></pre></div>")
 }
 
 test render_asterisk_bullet {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -390,6 +390,35 @@ button:hover {
   color: #3c4534;
 }
 
+/* Grids of related links, e.g. on the manual page. Inspired by the
+   category grid on lib.rs. */
+.link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
+  margin: 16px 0 26px 0;
+}
+
+.link-grid a {
+  display: block;
+  padding: 5px 10px;
+  background-color: #f4f6ee;
+  border: 1px solid #00000022;
+  border-radius: 5px;
+  overflow-wrap: break-word;
+}
+
+.link-grid a:hover {
+  border-color: var(--green-primary);
+  border-bottom: 1px solid var(--green-primary);
+}
+
+.link-grid code {
+  border: none;
+  padding: 0;
+  font-size: 15px;
+}
+
 hr {
   border: none;
   border-top: 3px solid #00000030;

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -342,17 +342,17 @@ button:hover {
 }
 
 .code-title {
-  padding: 4px 8px;
-  position: absolute;
-  top: -24px;
-  right: 12px;
+  display: block;
+  padding: 6px 12px;
 
-  background: var(--cream);
-  border: 3px solid #00000038;
-  border-radius: 5px;
+  background: #dde3cd;
+  border-bottom: 1px solid #00000022;
+  border-radius: 4px 4px 0 0;
 
   font-family: "Lora", serif;
   font-weight: initial;
+  font-size: 15px;
+  color: #3c4534;
 }
 
 hr {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -253,8 +253,9 @@ header a {
 }
 
 #playground-wrapper {
-  border: 3px solid #00000030;
+  border: 1px solid #00000022;
   border-radius: 5px;
+  background-color: #f4f6ee;
 }
 
 #playground-wrapper .cm-editor {
@@ -279,14 +280,14 @@ textarea {
 
 #playground-output {
   padding: 10px;
-  border-top: 3px solid #00000030;
+  border-top: 1px solid #00000022;
   white-space: pre;
 }
 
 .snippet-output {
   white-space: pre;
   padding: 10px;
-  border-top: 3px solid #00000030;
+  border-top: 1px solid #00000022;
 }
 
 .snippet-output .stderr,
@@ -300,22 +301,21 @@ textarea {
 }
 
 .snippet {
-  border: 3px solid #00000030;
+  border: 1px solid #00000022;
   border-radius: 5px;
+  background-color: #f4f6ee;
 
   padding: 0;
   margin: 30px 0px 20px 0px;
 
   position: relative;
-  top: -2px;
-  left: -2px;
 
   z-index: 1;
 }
 
 .snippet pre {
-  font-weight: 700;
-  margin: 10px;
+  margin: 0;
+  padding: 12px;
 }
 
 .snippet .snippet-output {
@@ -403,7 +403,7 @@ ul ul {
   line-height: 20px;
   border: none;
   outline: none;
-  background-color: var(--cream);
+  background-color: transparent;
 }
 
 .cm-scroller {
@@ -428,8 +428,8 @@ ul ul {
 }
 
 .snippet .cm-editor {
-  font-weight: 700;
-  margin: 10px;
+  margin: 0;
+  padding: 2px;
 }
 
 .cm-line {
@@ -438,7 +438,7 @@ ul ul {
 
 /* Gutters (line numbers, etc) */
 .cm-gutters {
-  background-color: var(--cream);
+  background-color: transparent;
   border-right: 1px solid #00000030;
 }
 

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -341,6 +341,26 @@ button:hover {
   background-color: #dfe2d5;
 }
 
+/* Run/Edit buttons on code snippets are quiet text buttons, so they
+   don't compete with the code itself. */
+.snippet button {
+  border: none;
+  border-radius: 3px;
+  min-width: 0;
+
+  padding: 2px 8px;
+  margin: 0 0 8px 8px;
+
+  background-color: transparent;
+  color: var(--green-primary);
+  font-size: 15px;
+  font-family: "Lora", serif;
+}
+
+.snippet button:hover {
+  background-color: #dfe2d5;
+}
+
 .code-title {
   display: block;
   padding: 6px 12px;

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -322,6 +322,21 @@ textarea {
   white-space: pre;
 }
 
+/* Shell sessions: the prompt is pale and unselectable so commands
+   copy-paste cleanly, and output is dimmer than commands. */
+.snippet .prompt {
+  color: #98a18c;
+  user-select: none;
+}
+
+.snippet .command {
+  font-weight: 700;
+}
+
+.snippet .shell-output {
+  color: #5c6553;
+}
+
 button {
   border: 3px solid #00000030;
   border-radius: 5px;

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -460,6 +460,57 @@ ul ul {
   }
 }
 
+/* "On this page" table of contents. Shown beside the content on
+   wide screens, like docs.astral.sh, and hidden otherwise. */
+.toc {
+  display: none;
+}
+
+@media (min-width: 1200px) {
+  .toc {
+    display: block;
+    position: fixed;
+    top: 110px;
+    left: calc(50% + 380px);
+    width: 210px;
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+
+    font-size: 15px;
+  }
+
+  .toc .toc-title {
+    display: block;
+    margin-bottom: 10px;
+    font-family: "Protest Riot", sans-serif;
+  }
+
+  .toc ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+  }
+
+  .toc ul li {
+    margin-bottom: 8px;
+    line-height: 1.4;
+  }
+
+  .toc a {
+    border-bottom: none;
+  }
+
+  .toc a:hover {
+    border-bottom: 2px solid var(--green-primary);
+  }
+
+  .toc code {
+    border: none;
+    padding: 0;
+    font-size: 14px;
+  }
+}
+
 /* CodeMirror Integration */
 .cm-editor {
   font-family: monospace;


### PR DESCRIPTION
Redesigned the visual presentation of code snippets with a cleaner border style, background color, and improved typography. Added support for shell session code blocks with syntax highlighting for prompts and output. Implemented automatic table of contents generation for pages with multiple sections, displayed in a sidebar on wide screens.

Key changes:
- Updated snippet styling: thinner borders, lighter color scheme, and adjusted padding/margins
- Added shell code block rendering with CSS classes for prompts, commands, and output
- Implemented `heading_slug()` function to generate URL-safe heading IDs
- Added heading IDs to all rendered headings for anchor linking
- Generated table of contents from level-2 headings (shown only when 3+ sections exist)
- Created `.link-grid` CSS component for displaying related links in a grid layout
- Refactored link generation in `build_site.gdn` to use the new grid component
- Added support for raw HTML `<div>` blocks in markdown without wrapping in `<p>` tags
- Updated CodeMirror styling to use transparent backgrounds for better integration

https://claude.ai/code/session_013X4JuNev95aLvoZCcatYAs