### PR TITLE
Set namespace for definition-only source files

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7779,10 +7779,6 @@ pub(crate) fn eval_toplevel_exprs_then_stop(
         }
     }
 
-    let Some(last_expr) = exprs.last() else {
-        return Ok(None);
-    };
-
     // Switch the namespace of the toplevel stack frame to the
     // namespace given. This ensures that we can access whatever
     // toplevel items we've just loaded in that namespace.
@@ -7790,6 +7786,10 @@ pub(crate) fn eval_toplevel_exprs_then_stop(
         let top_stack = env.current_frame_mut();
         top_stack.namespace = namespace;
     }
+
+    let Some(last_expr) = exprs.last() else {
+        return Ok(None);
+    };
 
     let old_stop_at_expr_id = env.stop_at_expr_id;
     env.stop_at_expr_id = Some(last_expr.id);

--- a/src/test_files/nrepl/load_file_definitions_only_namespace.jsonl
+++ b/src/test_files/nrepl/load_file_definitions_only_namespace.jsonl
@@ -1,0 +1,37 @@
+{ "op": "clone" }
+{ "op": "load-file", "session": "garden-1", "file": "fun helper(): Int { 42 }", "file-path": "/tmp/mylib.gdn" }
+{ "op": "eval", "session": "garden-1", "code": "helper()" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "new-session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "ns": "mylib",
+//   "session": "garden-1",
+//   "value": "()"
+// }
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "ns": "mylib",
+//   "session": "garden-1",
+//   "value": "42"
+// }
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+


### PR DESCRIPTION
When loading a source file that contains only definitions (no top-level expressions to evaluate), the namespace was not being set on the evaluation environment. This caused subsequent evaluations in that namespace to fail.

The fix reorders the namespace-setting logic to occur before checking whether there are expressions to evaluate, ensuring the namespace is always set even for definition-only files.

A new test case verifies that a file containing only a function definition can be loaded and then called successfully.

https://claude.ai/code/session_01GvRvqBxTY4r9oet8zpwEc4