### PR TITLE
Report duplicate struct fields and enum variants

### DIFF
--- a/src/json_session.rs
+++ b/src/json_session.rs
@@ -239,6 +239,7 @@ fn as_error_response(errors: Vec<ParseError>, vfs: &Vfs, project_root: &Path) ->
                 position,
                 message,
                 notes,
+                ..
             } => {
                 let stack = Some(format_diagnostic(
                     &message,
@@ -299,6 +300,7 @@ fn handle_eval_up_to_request(
                 position,
                 message,
                 notes,
+                ..
             } => {
                 let stack = Some(format_diagnostic(
                     &message,

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -276,7 +276,13 @@ fn get_fixes(src: &str, path: &PathBuf) -> Vec<Autofix> {
     let mut id_gen = IdGenerator::default();
     let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
 
-    let (items, _errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
+    let (items, errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
+
+    for e in errors {
+        if let ParseError::Invalid { fixes: e_fixes, .. } = e {
+            fixes.extend(e_fixes);
+        }
+    }
 
     let mut env = Env::new(id_gen, vfs);
     let ns = env.get_or_create_namespace(path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -842,6 +842,7 @@ fn reftest_ast(src: &str, path: &Path) {
                 position,
                 message: e,
                 notes,
+                ..
             } => {
                 eprintln!(
                     "{}",
@@ -890,6 +891,7 @@ fn parse_toplevel_items_or_die(
                     position,
                     message: e,
                     notes,
+                    ..
                 } => eprintln!(
                     "{}",
                     format_diagnostic(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1592,7 +1592,48 @@ fn parse_enum_body(
         }
     }
 
-    variants
+    // Drop duplicate variants, reporting an error with an autofix that
+    // removes the later definition.
+    let variant_ends: Vec<Position> = variants
+        .iter()
+        .map(|v| match &v.comma {
+            Some(comma) => comma.clone(),
+            None => match &v.payload_hint {
+                Some(hint) => hint.position.clone(),
+                None => v.name_sym.position.clone(),
+            },
+        })
+        .collect();
+    let mut seen: FxHashMap<String, Position> = FxHashMap::default();
+    let mut deduped = Vec::with_capacity(variants.len());
+
+    for (i, variant) in variants.into_iter().enumerate() {
+        let name = variant.name_sym.name.text.clone();
+        if let Some(prev_pos) = seen.get(&name) {
+            diagnostics.push(ParseError::Invalid {
+                position: variant.name_sym.position.clone(),
+                message: ErrorMessage(vec![
+                    msgtext!("Duplicate enum variant "),
+                    msgcode!("{}", name),
+                    msgtext!("."),
+                ]),
+                notes: vec![(
+                    ErrorMessage(vec![msgtext!("The previous occurrence is here.")]),
+                    prev_pos.clone(),
+                )],
+                fixes: vec![Autofix {
+                    description: format!("Remove duplicate variant `{name}`"),
+                    position: removal_span(&variant_ends[i - 1], &variant_ends[i]),
+                    new_text: String::new(),
+                }],
+            });
+        } else {
+            seen.insert(name, variant.name_sym.position.clone());
+            deduped.push(variant);
+        }
+    }
+
+    deduped
 }
 
 /// Parse enum variant, e.g. `Some(T)`.
@@ -2244,6 +2285,24 @@ fn parse_parameters(
     }
 }
 
+/// A position spanning from the end of `prev` to the end of `last`.
+///
+/// When `prev` and `last` are the comma positions of two consecutive
+/// list items, deleting this span removes the second item along with
+/// its own trailing comma and the whitespace before it.
+fn removal_span(prev: &Position, last: &Position) -> Position {
+    Position {
+        start_offset: prev.end_offset,
+        end_offset: last.end_offset,
+        line_number: prev.end_line_number,
+        end_line_number: last.end_line_number,
+        column: prev.end_column,
+        end_column: last.end_column,
+        path: Rc::clone(&last.path),
+        vfs_path: last.vfs_path.clone(),
+    }
+}
+
 fn parse_struct_fields(
     tokens: &mut TokenStream,
     id_gen: &mut IdGenerator,
@@ -2320,9 +2379,50 @@ fn parse_struct_fields(
         }
     }
 
-    // TODO: error on duplicate fields
+    // Drop duplicate fields, reporting an error with an autofix that
+    // removes the later definition.
+    let field_ends: Vec<Position> = fields
+        .iter()
+        .map(|f| match &f.comma {
+            Some(comma) => comma.clone(),
+            None => f.hint.position.clone(),
+        })
+        .collect();
+    let mut seen: FxHashMap<String, Position> = FxHashMap::default();
+    let mut deduped = Vec::with_capacity(fields.len());
 
-    fields
+    for (i, field) in fields.into_iter().enumerate() {
+        if field.sym.name.is_underscore() {
+            deduped.push(field);
+            continue;
+        }
+
+        let name = field.sym.name.text.clone();
+        if let Some(prev_pos) = seen.get(&name) {
+            diagnostics.push(ParseError::Invalid {
+                position: field.sym.position.clone(),
+                message: ErrorMessage(vec![
+                    msgtext!("Duplicate field "),
+                    msgcode!("{}", name),
+                    msgtext!("."),
+                ]),
+                notes: vec![(
+                    ErrorMessage(vec![msgtext!("The previous occurrence is here.")]),
+                    prev_pos.clone(),
+                )],
+                fixes: vec![Autofix {
+                    description: format!("Remove duplicate field `{name}`"),
+                    position: removal_span(&field_ends[i - 1], &field_ends[i]),
+                    new_text: String::new(),
+                }],
+            });
+        } else {
+            seen.insert(name, field.sym.position.clone());
+            deduped.push(field);
+        }
+    }
+
+    deduped
 }
 
 fn parse_block(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,7 @@ use rustc_hash::FxHashMap;
 use vfs::VfsPathBuf;
 use visitor::MutVisitor;
 
+use crate::diagnostics::Autofix;
 use crate::{msgcode, msglink, msgtext};
 
 // TODO: implement precedence using Pratt parsing, as discussed in
@@ -31,6 +32,8 @@ pub(crate) enum ParseError {
         /// Extra information that's relevant to why we have an error in the
         /// primary position.
         notes: Vec<(ErrorMessage, Position)>,
+        /// Autofixes that resolve this error, if any.
+        fixes: Vec<Autofix>,
     },
     Incomplete {
         message: ErrorMessage,
@@ -122,6 +125,7 @@ fn check_required_token<'a>(
                         msgtext!(" after this."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 ok = false;
 
@@ -186,6 +190,7 @@ fn parse_integer(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
 
                 Expression::new(
@@ -205,6 +210,7 @@ fn parse_integer(
                 msgtext!("."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
 
         // Choose an arbitrary value that's hopefully unlikely to
@@ -242,6 +248,7 @@ fn parse_float(
                 msgtext!("."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
 
         // Choose an arbitrary value that's hopefully unlikely to
@@ -313,6 +320,7 @@ fn parse_tuple_literal_or_parentheses(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
 
                 break;
@@ -420,6 +428,7 @@ fn parse_dict_literal_items(
                         msgtext!(" after this."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
 
                 continue;
@@ -521,6 +530,7 @@ fn parse_assert(
                 msgtext!("."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
 
         return Expression::new(position, Expression_::Invalid, id_gen.next());
@@ -742,6 +752,7 @@ fn unescape_string(token: &Token<'_>) -> (Vec<ParseError>, String) {
                             msgtext!(" are supported."),
                         ]),
                         notes: vec![],
+                        fixes: vec![],
                     });
 
                     // Treat \z as \\z.
@@ -838,6 +849,7 @@ fn parse_simple_expression(
             position: error_position,
             message: ErrorMessage(vec![msgtext!("Expected an expression after this.")]),
             notes: vec![],
+            fixes: vec![],
         });
 
         return Expression::new(token.position, Expression_::Invalid, id_gen.next());
@@ -1108,6 +1120,7 @@ fn parse_comma_separated_exprs(
                         msgtext!(" after this."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
 
                 // Attempt to recover a reasonable AST.
@@ -1263,6 +1276,7 @@ fn parse_expression(
                             "Expected a method or field name after this."
                         )]),
                         notes: vec![],
+                        fixes: vec![],
                     });
 
                     let variable = placeholder_symbol(token.position, id_gen);
@@ -1300,6 +1314,7 @@ fn parse_expression(
                             "Expected a namespace symbol after this."
                         )]),
                         notes: vec![],
+                        fixes: vec![],
                     });
 
                     let variable = placeholder_symbol(token.position, id_gen);
@@ -1499,6 +1514,7 @@ fn parse_definition(
             position: token.position,
             message: ErrorMessage(vec![Text("Expected a definition".to_owned())]),
             notes: vec![],
+            fixes: vec![],
         });
         return None;
     }
@@ -1550,6 +1566,7 @@ fn parse_enum_body(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 break;
             }
@@ -1715,6 +1732,7 @@ fn parse_test(
                     msgtext!("."),
                 ]),
                 notes: vec![],
+                fixes: vec![],
             });
         }
     }
@@ -1852,6 +1870,7 @@ fn parse_type_arguments(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 break token.position;
             }
@@ -1915,6 +1934,7 @@ fn parse_type_params(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 break;
             }
@@ -2046,6 +2066,7 @@ fn parse_type_hint(
                 msgtext!(" instead."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
     }
 
@@ -2088,6 +2109,7 @@ fn parse_colon_and_hint_opt(
                 msgtext!(" before this type hint."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
 
         let type_hint = parse_type_hint(tokens, id_gen, diagnostics);
@@ -2161,6 +2183,7 @@ fn parse_parameters(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 break;
             }
@@ -2207,6 +2230,7 @@ fn parse_parameters(
                     ErrorMessage(vec![msgtext!("The previous occurrence is here.")]),
                     (*prev_pos).clone(),
                 )],
+                fixes: vec![],
             });
         } else {
             seen.insert(param_name, &param.symbol.position);
@@ -2276,6 +2300,7 @@ fn parse_struct_fields(
                         msgtext!("."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 break;
             }
@@ -2624,6 +2649,7 @@ fn parse_method(
                 msgtext!("."),
             ]),
             notes: vec![],
+            fixes: vec![],
         });
 
         // Use placeholders so we can continue parsing.
@@ -2834,6 +2860,7 @@ fn parse_let_destination(
                         ErrorMessage(vec![msgtext!("The previous occurrence is here.")]),
                         (*prev_pos).clone(),
                     )],
+                    fixes: vec![],
                 });
             } else {
                 seen.insert(name, &symbol.position);
@@ -2878,12 +2905,14 @@ fn parse_symbol(
                     msgtext!("."),
                 ]),
                 notes: vec![],
+                fixes: vec![],
             });
         } else {
             diagnostics.push(ParseError::Invalid {
                 position: prev_token_pos,
                 message: ErrorMessage(vec![msgtext!("Expected a {description} after this.")]),
                 notes: vec![],
+                fixes: vec![],
             });
         }
         tokens.unpop();
@@ -2909,6 +2938,7 @@ fn parse_symbol(
                         msgtext!(" is a keyword and cannot be used as a variable name."),
                     ]),
                     notes: vec![],
+                    fixes: vec![],
                 });
             } else {
                 // We expected a name, but we just saw a keyword on a later
@@ -2925,6 +2955,7 @@ fn parse_symbol(
                     position: prev_token_pos,
                     message: ErrorMessage(vec![msgtext!("Expected a symbol after this.")]),
                     notes: vec![],
+                    fixes: vec![],
                 });
                 tokens.unpop();
             }
@@ -3012,6 +3043,7 @@ fn parse_assign_update(
                     msgtext!("."),
                 ]),
                 notes: vec![],
+                fixes: vec![],
             });
             AssignUpdateKind::Add
         }

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -316,6 +316,7 @@ pub(crate) fn lex_between<'a>(
                     // TODO: include previous string position, which
                     // was probably not closed correctly.
                     notes: vec![],
+                    fixes: vec![],
                 });
 
                 tokens.push(Token {
@@ -376,6 +377,7 @@ pub(crate) fn lex_between<'a>(
                     msgcode!("{}", &s[0..1]),
                 ]),
                 notes: vec![],
+                fixes: vec![],
             });
 
             offset += 1;

--- a/src/run_code_blocks.rs
+++ b/src/run_code_blocks.rs
@@ -200,6 +200,7 @@ fn eval_code_block(
                     position,
                     message,
                     notes: _,
+                    ..
                 } => {
                     let adjusted_pos = position.clone();
                     // Use the actual file path

--- a/src/syntax_check.rs
+++ b/src/syntax_check.rs
@@ -77,7 +77,10 @@ pub(crate) fn check(
                 position,
                 message,
                 notes,
+                fixes,
             } => {
+                all_fixes.extend(fixes);
+
                 // Expose line numbers as 1-indexed.
                 diagnostics.push(CheckDiagnostic {
                     position: position.clone(),

--- a/src/test_files/check/enum_duplicate_variant.gdn
+++ b/src/test_files/check/enum_duplicate_variant.gdn
@@ -1,0 +1,24 @@
+enum Shape {
+    Circle,
+    Square,
+    Circle,
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Duplicate enum variant `Circle`.
+// 
+// -| src/test_files/check/enum_duplicate_variant.gdn:4:5
+// 2|     Circle,
+// 3|     Square,
+// 4|     Circle,
+// 5| }   ^^^^^^
+// -| src/test_files/check/enum_duplicate_variant.gdn:2:5
+// 1| enum Shape {
+// 2|     Circle,
+//  |     ^^^^^^ Note: The previous occurrence is here.
+// 3|     Square,
+// 4|     Circle,
+
+// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check/struct_duplicate_field.gdn
+++ b/src/test_files/check/struct_duplicate_field.gdn
@@ -1,0 +1,24 @@
+struct Point {
+    x: Int,
+    y: Int,
+    x: Int,
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Duplicate field `x`.
+// 
+// -| src/test_files/check/struct_duplicate_field.gdn:4:5
+// 2|     x: Int,
+// 3|     y: Int,
+// 4|     x: Int,
+// 5| }   ^
+// -| src/test_files/check/struct_duplicate_field.gdn:2:5
+// 1| struct Point {
+// 2|     x: Int,
+//  |     ^ Note: The previous occurrence is here.
+// 3|     y: Int,
+// 4|     x: Int,
+
+// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check_fix/enum_duplicate_variant.gdn
+++ b/src/test_files/check_fix/enum_duplicate_variant.gdn
@@ -1,0 +1,13 @@
+enum Shape {
+    Circle,
+    Square,
+    Circle,
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// enum Shape {
+//     Circle,
+//     Square,
+// }
+

--- a/src/test_files/check_fix/struct_duplicate_field.gdn
+++ b/src/test_files/check_fix/struct_duplicate_field.gdn
@@ -1,0 +1,13 @@
+struct Point {
+    x: Int,
+    y: Int,
+    x: Int,
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// struct Point {
+//     x: Int,
+//     y: Int,
+// }
+

--- a/src/test_files/parser/duplicate_enum_variant.gdn
+++ b/src/test_files/parser/duplicate_enum_variant.gdn
@@ -1,0 +1,49 @@
+enum Shape {
+    Circle,
+    Square,
+    Circle,
+}
+
+// args: reftest-ast
+// expected stdout:
+// Enum(
+//     EnumInfo {
+//         pos: Position { ... },
+//         visibility: CurrentFile,
+//         doc_comment: None,
+//         name_sym: TypeSymbol"Shape",
+//         type_params: [],
+//         variants: [
+//             VariantInfo {
+//                 name_sym: Symbol"Circle",
+//                 payload_hint: None,
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
+//             },
+//             VariantInfo {
+//                 name_sym: Symbol"Square",
+//                 payload_hint: None,
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
+//             },
+//         ],
+//     },
+// )
+
+// expected stderr:
+// Error: Parse error: Duplicate enum variant `Circle`.
+// 
+// -| src/test_files/parser/duplicate_enum_variant.gdn:4:5
+// 2|     Circle,
+// 3|     Square,
+// 4|     Circle,
+// 5| }   ^^^^^^
+// -| src/test_files/parser/duplicate_enum_variant.gdn:2:5
+// 1| enum Shape {
+// 2|     Circle,
+//  |     ^^^^^^ Note: The previous occurrence is here.
+// 3|     Square,
+// 4|     Circle,
+

--- a/src/test_files/parser/duplicate_struct_field.gdn
+++ b/src/test_files/parser/duplicate_struct_field.gdn
@@ -1,0 +1,59 @@
+struct Point {
+    x: Int,
+    y: Int,
+    x: Int,
+}
+
+// args: reftest-ast
+// expected stdout:
+// Struct(
+//     StructInfo {
+//         pos: Position { ... },
+//         visibility: CurrentFile,
+//         doc_comment: None,
+//         name_sym: TypeSymbol"Point",
+//         type_params: [],
+//         fields: [
+//             FieldInfo {
+//                 sym: Symbol"x",
+//                 hint: TypeHint {
+//                     sym: TypeSymbol"Int",
+//                     args: [],
+//                     position: Position { ... },
+//                 },
+//                 doc_comment: None,
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
+//             },
+//             FieldInfo {
+//                 sym: Symbol"y",
+//                 hint: TypeHint {
+//                     sym: TypeSymbol"Int",
+//                     args: [],
+//                     position: Position { ... },
+//                 },
+//                 doc_comment: None,
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
+//             },
+//         ],
+//     },
+// )
+
+// expected stderr:
+// Error: Parse error: Duplicate field `x`.
+// 
+// -| src/test_files/parser/duplicate_struct_field.gdn:4:5
+// 2|     x: Int,
+// 3|     y: Int,
+// 4|     x: Int,
+// 5| }   ^
+// -| src/test_files/parser/duplicate_struct_field.gdn:2:5
+// 1| struct Point {
+// 2|     x: Int,
+//  |     ^ Note: The previous occurrence is here.
+// 3|     y: Int,
+// 4|     x: Int,
+


### PR DESCRIPTION
Duplicate struct fields (`struct S { x: Int, x: Int }`) and enum variants (`enum E { A, A }`) used to parse silently. They're now reported as parse errors, each with a note pointing to the first occurrence and an autofix that removes the duplicate and its trailing comma. The later definition is dropped from the parsed item so the rest of checking runs against a clean struct/enum.

The first commit adds the ability for parse errors to carry autofixes; the second adds the duplicate detection on top.

https://claude.ai/code/session_018yjXhmxDEJcxmHGoQNAN9y