### PR TITLE
Extract go-to-definition logic into reusable function

### DIFF
--- a/src/go_to_def.rs
+++ b/src/go_to_def.rs
@@ -6,12 +6,16 @@ use crate::env::Env;
 use crate::eval::load_toplevel_items;
 use crate::parser::ast::IdGenerator;
 use crate::parser::parse_toplevel_items;
+use crate::parser::position::Position;
 use crate::parser::vfs::{to_project_relative, Vfs};
 use crate::pos_to_id::find_item_at;
 
-/// Print the position of the definition associated with the
-/// expression at `offset`.
-pub(crate) fn print_pos(src: &str, path: &Path, offset: usize, in_test_suite: bool) {
+/// Find the position of the definition associated with the expression
+/// at `offset`, if any.
+///
+/// Also returns the project root, so callers can render paths
+/// relative to it.
+pub(crate) fn find_def_pos(src: &str, path: &Path, offset: usize) -> (Option<Position>, PathBuf) {
     let mut id_gen = IdGenerator::default();
     let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
 
@@ -37,39 +41,51 @@ pub(crate) fn print_pos(src: &str, path: &Path, offset: usize, in_test_suite: bo
 
     for id in ids_at_query_pos.iter().rev() {
         if let Some(pos) = summary.id_to_def_pos.get(&id.id()) {
-            let mut pos_s = serde_json::to_string(&pos).unwrap();
-
-            // For Garden's test suite we don't want to use absolute
-            // paths in the expected output.
-            if in_test_suite {
-                let mut placeholder_pos = pos.clone();
-                // Positions in the prelude tend to change a lot. Use
-                // a placeholder value so the tests don't change every
-                // time we fix a typo in the prelude.
-                //
-                // TODO: the proper solution would be placeholders in
-                // the reftest output, like LLVM's lit.
-                if pos.path.ends_with("__prelude.gdn") {
-                    placeholder_pos.start_offset = 12345;
-                    placeholder_pos.end_offset = 12345;
-                    placeholder_pos.line_number = 12345;
-                    placeholder_pos.end_line_number = 12345;
-                    placeholder_pos.column = 12345;
-                    placeholder_pos.end_column = 12345;
-                }
-
-                let mut path = PathBuf::from("GDN_TEST_ROOT");
-                path.push(to_project_relative(&pos.path, &env.project_root));
-                placeholder_pos.path = Rc::new(path);
-
-                pos_s = serde_json::to_string(&placeholder_pos).unwrap();
-                pos_s = pos_s.replace("12345", "GDN_TEST_POS");
-            }
-
-            println!("{}", pos_s);
-            return;
+            return (Some(pos.clone()), env.project_root);
         }
     }
 
-    println!("null");
+    (None, env.project_root)
+}
+
+/// Print the position of the definition associated with the
+/// expression at `offset`.
+pub(crate) fn print_pos(src: &str, path: &Path, offset: usize, in_test_suite: bool) {
+    let (pos, project_root) = find_def_pos(src, path, offset);
+
+    let Some(pos) = pos else {
+        println!("null");
+        return;
+    };
+
+    let mut pos_s = serde_json::to_string(&pos).unwrap();
+
+    // For Garden's test suite we don't want to use absolute
+    // paths in the expected output.
+    if in_test_suite {
+        let mut placeholder_pos = pos.clone();
+        // Positions in the prelude tend to change a lot. Use
+        // a placeholder value so the tests don't change every
+        // time we fix a typo in the prelude.
+        //
+        // TODO: the proper solution would be placeholders in
+        // the reftest output, like LLVM's lit.
+        if pos.path.ends_with("__prelude.gdn") {
+            placeholder_pos.start_offset = 12345;
+            placeholder_pos.end_offset = 12345;
+            placeholder_pos.line_number = 12345;
+            placeholder_pos.end_line_number = 12345;
+            placeholder_pos.column = 12345;
+            placeholder_pos.end_column = 12345;
+        }
+
+        let mut path = PathBuf::from("GDN_TEST_ROOT");
+        path.push(to_project_relative(&pos.path, &project_root));
+        placeholder_pos.path = Rc::new(path);
+
+        pos_s = serde_json::to_string(&placeholder_pos).unwrap();
+        pos_s = pos_s.replace("12345", "GDN_TEST_POS");
+    }
+
+    println!("{}", pos_s);
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -269,31 +269,8 @@ fn get_completions(src: &str, path: &Path, offset: usize) -> Vec<CompletionItem>
 }
 
 /// Get the definition position for a symbol at the given offset.
-fn get_definition(src: &str, path: &PathBuf, offset: usize) -> Option<GardenPosition> {
-    let mut id_gen = IdGenerator::default();
-    let (vfs, vfs_path) = Vfs::singleton(path.to_owned(), src.to_owned());
-
-    let (items, _errors) = parse_toplevel_items(&vfs_path, src, &mut id_gen);
-
-    let mut env = Env::new(id_gen, vfs);
-    let ns = env.get_or_create_namespace(path);
-    load_toplevel_items(&items, &mut env, Rc::clone(&ns));
-
-    let summary = check_types(&vfs_path, &items, &env, ns);
-
-    let mut ids_at_query_pos = vec![];
-    if offset > 0 {
-        ids_at_query_pos.extend(find_item_at(&items, offset - 1, offset - 1));
-    }
-    ids_at_query_pos.extend(find_item_at(&items, offset, offset));
-
-    for id in ids_at_query_pos.iter().rev() {
-        if let Some(pos) = summary.id_to_def_pos.get(&id.id()) {
-            return Some(pos.clone());
-        }
-    }
-
-    None
+fn get_definition(src: &str, path: &Path, offset: usize) -> Option<GardenPosition> {
+    crate::go_to_def::find_def_pos(src, path, offset).0
 }
 
 /// Get hover information for a symbol at the given offset.


### PR DESCRIPTION
Refactor the definition-finding logic in `go_to_def.rs` into a separate `find_def_pos` function that returns the position and project root, allowing it to be reused by the LSP module without duplication.

- Created `find_def_pos()` that encapsulates the core logic for locating a definition at a given offset
- Updated `print_pos()` to call `find_def_pos()` and handle formatting/output
- Simplified `get_definition()` in `lsp.rs` to use the new shared function instead of duplicating the lookup logic
- Added import for `Position` type in `go_to_def.rs`

https://claude.ai/code/session_01RaZrXi88JTh7KSSVgtArjw