### PR TITLE
Return error status when closing unknown nREPL session

### DIFF
--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -765,13 +765,13 @@ impl Connection {
         id
     }
 
-    fn close_session(&mut self, id: &str) {
+    fn close_session(&mut self, id: &str) -> bool {
         // Wake any in-progress eval so the worker shuts down
         // promptly once we drop the request channel.
         if let Some(s) = self.sessions.get(id) {
             s.interrupted.store(true, Ordering::SeqCst);
         }
-        self.sessions.remove(id);
+        self.sessions.remove(id).is_some()
     }
 
     fn send(&self, msg: Value) {
@@ -1175,14 +1175,20 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) {
             conn.send(Value::Dict(msg));
         }
         "close" => {
-            if let Some(s) = dict_get(request, "session").and_then(as_str) {
-                conn.close_session(s);
-            }
+            let session_id = dict_get(request, "session").and_then(as_str);
+            let closed = session_id.map(|s| conn.close_session(s)).unwrap_or(false);
             let mut msg = base;
-            msg.insert(
-                b"status".to_vec(),
-                Value::List(vec![bstr("done"), bstr("session-closed")]),
-            );
+            if closed {
+                msg.insert(
+                    b"status".to_vec(),
+                    Value::List(vec![bstr("done"), bstr("session-closed")]),
+                );
+            } else {
+                msg.insert(
+                    b"status".to_vec(),
+                    Value::List(vec![bstr("done"), bstr("error"), bstr("unknown-session")]),
+                );
+            }
             conn.send(Value::Dict(msg));
         }
         "ls-sessions" => {

--- a/src/test_files/nrepl/close_unknown_session.jsonl
+++ b/src/test_files/nrepl/close_unknown_session.jsonl
@@ -1,0 +1,21 @@
+{ "op": "close", "session": "garden-1" }
+{ "op": "close" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done",
+//     "error",
+//     "unknown-session"
+//   ]
+// }
+// {
+//   "status": [
+//     "done",
+//     "error",
+//     "unknown-session"
+//   ]
+// }
+


### PR DESCRIPTION
Modified the nREPL `close` operation to return an error status when attempting to close a non-existent session, instead of silently succeeding.

The `close_session` method now returns a `bool` indicating whether a session was actually closed. The `close` message handler checks this result and responds with either a `session-closed` status on success or an `unknown-session` error status on failure. Added a test case covering both closing a non-existent session and closing without providing a session ID.

https://claude.ai/code/session_011wNy9yn9yWKgd6WjYoQ9bQ