### PR TITLE
Include "done" status in nREPL error response for missing op

### DIFF
--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -1267,7 +1267,10 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) {
         }
         "" => {
             let mut msg = base;
-            msg.insert(b"status".to_vec(), Value::List(vec![bstr("error")]));
+            msg.insert(
+                b"status".to_vec(),
+                Value::List(vec![bstr("done"), bstr("error")]),
+            );
             msg.insert(b"err".to_vec(), bstr("Missing 'op' in request.\n"));
             conn.send(Value::Dict(msg));
         }

--- a/src/test_files/nrepl/missing_op.jsonl
+++ b/src/test_files/nrepl/missing_op.jsonl
@@ -6,6 +6,7 @@
 //   "err": "Missing 'op' in request.\n",
 //   "id": "1",
 //   "status": [
+//     "done",
 //     "error"
 //   ]
 // }


### PR DESCRIPTION
When an nREPL request is missing the required 'op' field, the error response now includes both "done" and "error" in the status list, rather than just "error". This aligns the error response format with the nREPL protocol expectation that responses include a "done" status to signal completion.

https://claude.ai/code/session_01WCjQuBqfwWxBY2HLES9uSb