### PR TITLE
[codex] Annotate eval_up_to value path

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1001,6 +1001,178 @@ pub(crate) enum EvalUpToErr {
     NoValueAvailable,
 }
 
+fn annotate_block_value_path(block: &mut Block, target_id: SyntaxId) -> bool {
+    let mut found = false;
+    for expr in &mut block.exprs {
+        let expr = Rc::make_mut(expr);
+        if annotate_expr_value_path(expr, target_id) {
+            expr.value_is_used = true;
+            found = true;
+        }
+    }
+
+    found
+}
+
+fn annotate_parenthesized_args_value_path(
+    args: &mut ParenthesizedArguments,
+    target_id: SyntaxId,
+) -> bool {
+    let mut found = false;
+    for arg in &mut args.arguments {
+        if annotate_expr_value_path(Rc::make_mut(&mut arg.expr), target_id) {
+            found = true;
+        }
+    }
+
+    found
+}
+
+fn annotate_expr_value_path(expr: &mut Expression, target_id: SyntaxId) -> bool {
+    if expr.id == target_id {
+        expr.value_is_used = true;
+        return true;
+    }
+
+    let found = match &mut expr.expr_ {
+        Expression_::Match(scrutinee, cases) => {
+            let mut found = annotate_expr_value_path(Rc::make_mut(scrutinee), target_id);
+            for (_, block) in cases {
+                if annotate_block_value_path(block, target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::If(condition, then_body, else_body) => {
+            let mut found = annotate_expr_value_path(Rc::make_mut(condition), target_id);
+            if annotate_block_value_path(then_body, target_id) {
+                found = true;
+            }
+            if let Some(else_body) = else_body {
+                if annotate_block_value_path(else_body, target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::While(condition, body) => {
+            annotate_expr_value_path(Rc::make_mut(condition), target_id)
+                || annotate_block_value_path(body, target_id)
+        }
+        Expression_::ForIn(_, iterable, body) => {
+            annotate_expr_value_path(Rc::make_mut(iterable), target_id)
+                || annotate_block_value_path(body, target_id)
+        }
+        Expression_::Try(try_body, _, catch_body) => {
+            annotate_block_value_path(try_body, target_id)
+                || annotate_block_value_path(catch_body, target_id)
+        }
+        Expression_::Assign(_, rhs)
+        | Expression_::AssignUpdate(_, _, rhs)
+        | Expression_::Let(_, _, rhs)
+        | Expression_::Assert(rhs) => annotate_expr_value_path(Rc::make_mut(rhs), target_id),
+        Expression_::Return(Some(return_expr)) => {
+            annotate_expr_value_path(Rc::make_mut(return_expr), target_id)
+        }
+        Expression_::Return(None) => false,
+        Expression_::ListLiteral(items) => {
+            let mut found = false;
+            for item in items {
+                if annotate_expr_value_path(Rc::make_mut(&mut item.expr), target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::DictLiteral(items) => {
+            let mut found = false;
+            for item in items {
+                if annotate_expr_value_path(Rc::make_mut(&mut item.key), target_id) {
+                    found = true;
+                }
+                if annotate_expr_value_path(Rc::make_mut(&mut item.value), target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::TupleLiteral(items) => {
+            let mut found = false;
+            for item in items {
+                if annotate_expr_value_path(Rc::make_mut(item), target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::StructLiteral(_, field_exprs) => {
+            let mut found = false;
+            for (_, field_expr) in field_exprs {
+                if annotate_expr_value_path(Rc::make_mut(field_expr), target_id) {
+                    found = true;
+                }
+            }
+            found
+        }
+        Expression_::BinaryOperator(lhs, _, rhs) => {
+            annotate_expr_value_path(Rc::make_mut(lhs), target_id)
+                || annotate_expr_value_path(Rc::make_mut(rhs), target_id)
+        }
+        Expression_::Call(receiver, args) => {
+            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
+                || annotate_parenthesized_args_value_path(args, target_id)
+        }
+        Expression_::MethodCall(receiver, _, args) => {
+            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
+                || annotate_parenthesized_args_value_path(args, target_id)
+        }
+        Expression_::DotAccess(receiver, _) | Expression_::NamespaceAccess(receiver, _) => {
+            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
+        }
+        Expression_::FunLiteral(fun_info) => {
+            annotate_block_value_path(&mut fun_info.body, target_id)
+        }
+        Expression_::Parentheses(paren) => {
+            annotate_expr_value_path(Rc::make_mut(&mut paren.expr), target_id)
+        }
+        Expression_::Break
+        | Expression_::Continue
+        | Expression_::IntLiteral(_)
+        | Expression_::FloatLiteral(_)
+        | Expression_::StringLiteral(_)
+        | Expression_::Variable(_)
+        | Expression_::Invalid => false,
+    };
+
+    if found {
+        expr.value_is_used = true;
+    }
+
+    found
+}
+
+fn annotate_item_value_path(item: &mut ToplevelItem, target_id: SyntaxId) -> bool {
+    match item {
+        ToplevelItem::Fun(_, fun_info, _) => {
+            annotate_block_value_path(&mut fun_info.body, target_id)
+        }
+        ToplevelItem::Method(method_info, _) => match &mut method_info.kind {
+            MethodKind::BuiltinMethod(_, Some(fun_info))
+            | MethodKind::UserDefinedMethod(fun_info) => {
+                annotate_block_value_path(&mut fun_info.body, target_id)
+            }
+            MethodKind::BuiltinMethod(_, None) => false,
+        },
+        ToplevelItem::Test(test) => annotate_block_value_path(&mut test.body, target_id),
+        ToplevelItem::Expr(toplevel_expression) => {
+            annotate_expr_value_path(&mut toplevel_expression.0, target_id)
+        }
+        ToplevelItem::Block(block) => annotate_block_value_path(block, target_id),
+        ToplevelItem::Enum(_) | ToplevelItem::Struct(_) | ToplevelItem::Import(_) => false,
+    }
+}
+
 /// Try to evaluate items up to the syntax ID specified.
 ///
 /// Returns None if we couldn't find anything to evaluate (not an error).
@@ -1051,10 +1223,14 @@ pub(crate) fn eval_up_to(
     // destructuring tuple, we want to return the tuple element and
     // position.
 
+    let mut item = item.clone();
+    let found_target = annotate_item_value_path(&mut item, expr_id);
+    debug_assert!(found_target);
+
     let mut res: Result<_, EvalError> = match &item {
         ToplevelItem::Fun(name_sym, fun_info, _) => {
             let ns = env.current_namespace();
-            load_toplevel_items(std::slice::from_ref(item), env, ns);
+            load_toplevel_items(std::slice::from_ref(&item), env, ns);
 
             let args = match env
                 .prev_call_args
@@ -1076,7 +1252,7 @@ pub(crate) fn eval_up_to(
         }
         ToplevelItem::Method(method_info, _) => {
             let ns = env.current_namespace();
-            load_toplevel_items(std::slice::from_ref(item), env, ns);
+            load_toplevel_items(std::slice::from_ref(&item), env, ns);
 
             let type_name = &method_info.receiver_hint.sym.name;
 
@@ -1118,7 +1294,7 @@ pub(crate) fn eval_up_to(
         ToplevelItem::Expr(_) | ToplevelItem::Block(_) => {
             env.stop_at_expr_id = Some(expr_id);
 
-            let res = eval_toplevel_items(vfs_path, std::slice::from_ref(item), env, session);
+            let res = eval_toplevel_items(vfs_path, std::slice::from_ref(&item), env, session);
             env.stop_at_expr_id = None;
 
             match res {
@@ -6398,8 +6574,7 @@ fn eval_expr(
     expr_state: &mut ExpressionState,
 ) -> Result<Option<StackFrame>, (RestoreValues, EvalError)> {
     let expr_position = outer_expr.position.clone();
-    let expr_value_is_used =
-        outer_expr.value_is_used || env.stop_at_expr_id.as_ref() == Some(&outer_expr.id);
+    let expr_value_is_used = outer_expr.value_is_used;
 
     match &outer_expr.expr_ {
         Expression_::Match(scrutinee, cases) => match expr_state {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -32,6 +32,7 @@ use crate::parser::diagnostics::MessagePart::*;
 use crate::parser::diagnostics::{ErrorMessage, MessagePart};
 use crate::parser::position::Position;
 use crate::parser::vfs::{Vfs, VfsPathBuf};
+use crate::parser::visitor::{Visitor, VisitorMut};
 use crate::parser::{lex, parse_toplevel_items, placeholder_symbol};
 use crate::pos_to_id::{find_expr_of_id, find_item_at};
 use crate::type_defs::TypeDef;
@@ -1001,176 +1002,60 @@ pub(crate) enum EvalUpToErr {
     NoValueAvailable,
 }
 
-fn annotate_block_value_path(block: &mut Block, target_id: SyntaxId) -> bool {
-    let mut found = false;
-    for expr in &mut block.exprs {
-        let expr = Rc::make_mut(expr);
-        if annotate_expr_value_path(expr, target_id) {
-            expr.value_is_used = true;
-            found = true;
-        }
-    }
-
-    found
-}
-
-fn annotate_parenthesized_args_value_path(
-    args: &mut ParenthesizedArguments,
+struct EvalUpToValuePathFinder {
     target_id: SyntaxId,
-) -> bool {
-    let mut found = false;
-    for arg in &mut args.arguments {
-        if annotate_expr_value_path(Rc::make_mut(&mut arg.expr), target_id) {
-            found = true;
-        }
-    }
-
-    found
+    current_path: Vec<SyntaxId>,
+    target_path: Option<Vec<SyntaxId>>,
 }
 
-fn annotate_expr_value_path(expr: &mut Expression, target_id: SyntaxId) -> bool {
-    if expr.id == target_id {
-        expr.value_is_used = true;
-        return true;
+impl Visitor for EvalUpToValuePathFinder {
+    fn visit_expr(&mut self, expr: &Expression) {
+        if self.target_path.is_some() {
+            return;
+        }
+
+        self.current_path.push(expr.id);
+        if expr.id == self.target_id {
+            self.target_path = Some(self.current_path.clone());
+        } else {
+            self.visit_expr_(&expr.expr_);
+        }
+        self.current_path.pop();
     }
+}
 
-    let found = match &mut expr.expr_ {
-        Expression_::Match(scrutinee, cases) => {
-            let mut found = annotate_expr_value_path(Rc::make_mut(scrutinee), target_id);
-            for (_, block) in cases {
-                if annotate_block_value_path(block, target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::If(condition, then_body, else_body) => {
-            let mut found = annotate_expr_value_path(Rc::make_mut(condition), target_id);
-            if annotate_block_value_path(then_body, target_id) {
-                found = true;
-            }
-            if let Some(else_body) = else_body {
-                if annotate_block_value_path(else_body, target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::While(condition, body) => {
-            annotate_expr_value_path(Rc::make_mut(condition), target_id)
-                || annotate_block_value_path(body, target_id)
-        }
-        Expression_::ForIn(_, iterable, body) => {
-            annotate_expr_value_path(Rc::make_mut(iterable), target_id)
-                || annotate_block_value_path(body, target_id)
-        }
-        Expression_::Try(try_body, _, catch_body) => {
-            annotate_block_value_path(try_body, target_id)
-                || annotate_block_value_path(catch_body, target_id)
-        }
-        Expression_::Assign(_, rhs)
-        | Expression_::AssignUpdate(_, _, rhs)
-        | Expression_::Let(_, _, rhs)
-        | Expression_::Assert(rhs) => annotate_expr_value_path(Rc::make_mut(rhs), target_id),
-        Expression_::Return(Some(return_expr)) => {
-            annotate_expr_value_path(Rc::make_mut(return_expr), target_id)
-        }
-        Expression_::Return(None) => false,
-        Expression_::ListLiteral(items) => {
-            let mut found = false;
-            for item in items {
-                if annotate_expr_value_path(Rc::make_mut(&mut item.expr), target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::DictLiteral(items) => {
-            let mut found = false;
-            for item in items {
-                if annotate_expr_value_path(Rc::make_mut(&mut item.key), target_id) {
-                    found = true;
-                }
-                if annotate_expr_value_path(Rc::make_mut(&mut item.value), target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::TupleLiteral(items) => {
-            let mut found = false;
-            for item in items {
-                if annotate_expr_value_path(Rc::make_mut(item), target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::StructLiteral(_, field_exprs) => {
-            let mut found = false;
-            for (_, field_expr) in field_exprs {
-                if annotate_expr_value_path(Rc::make_mut(field_expr), target_id) {
-                    found = true;
-                }
-            }
-            found
-        }
-        Expression_::BinaryOperator(lhs, _, rhs) => {
-            annotate_expr_value_path(Rc::make_mut(lhs), target_id)
-                || annotate_expr_value_path(Rc::make_mut(rhs), target_id)
-        }
-        Expression_::Call(receiver, args) => {
-            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
-                || annotate_parenthesized_args_value_path(args, target_id)
-        }
-        Expression_::MethodCall(receiver, _, args) => {
-            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
-                || annotate_parenthesized_args_value_path(args, target_id)
-        }
-        Expression_::DotAccess(receiver, _) | Expression_::NamespaceAccess(receiver, _) => {
-            annotate_expr_value_path(Rc::make_mut(receiver), target_id)
-        }
-        Expression_::FunLiteral(fun_info) => {
-            annotate_block_value_path(&mut fun_info.body, target_id)
-        }
-        Expression_::Parentheses(paren) => {
-            annotate_expr_value_path(Rc::make_mut(&mut paren.expr), target_id)
-        }
-        Expression_::Break
-        | Expression_::Continue
-        | Expression_::IntLiteral(_)
-        | Expression_::FloatLiteral(_)
-        | Expression_::StringLiteral(_)
-        | Expression_::Variable(_)
-        | Expression_::Invalid => false,
-    };
+struct ValuePathAnnotator {
+    value_used_ids: FxHashSet<SyntaxId>,
+}
 
-    if found {
-        expr.value_is_used = true;
+impl VisitorMut for ValuePathAnnotator {
+    fn visit_expr_mut(&mut self, expr: &mut Expression) {
+        if self.value_used_ids.contains(&expr.id) {
+            expr.value_is_used = true;
+        }
+
+        self.visit_expr_mut_default(expr);
     }
-
-    found
 }
 
 fn annotate_item_value_path(item: &mut ToplevelItem, target_id: SyntaxId) -> bool {
-    match item {
-        ToplevelItem::Fun(_, fun_info, _) => {
-            annotate_block_value_path(&mut fun_info.body, target_id)
-        }
-        ToplevelItem::Method(method_info, _) => match &mut method_info.kind {
-            MethodKind::BuiltinMethod(_, Some(fun_info))
-            | MethodKind::UserDefinedMethod(fun_info) => {
-                annotate_block_value_path(&mut fun_info.body, target_id)
-            }
-            MethodKind::BuiltinMethod(_, None) => false,
-        },
-        ToplevelItem::Test(test) => annotate_block_value_path(&mut test.body, target_id),
-        ToplevelItem::Expr(toplevel_expression) => {
-            annotate_expr_value_path(&mut toplevel_expression.0, target_id)
-        }
-        ToplevelItem::Block(block) => annotate_block_value_path(block, target_id),
-        ToplevelItem::Enum(_) | ToplevelItem::Struct(_) | ToplevelItem::Import(_) => false,
-    }
+    let mut finder = EvalUpToValuePathFinder {
+        target_id,
+        current_path: vec![],
+        target_path: None,
+    };
+    finder.visit_toplevel_item(item);
+
+    let Some(target_path) = finder.target_path else {
+        return false;
+    };
+
+    let mut annotator = ValuePathAnnotator {
+        value_used_ids: target_path.into_iter().collect(),
+    };
+    annotator.visit_toplevel_item_mut(item);
+
+    true
 }
 
 /// Try to evaluate items up to the syntax ID specified.

--- a/src/parser/visitor.rs
+++ b/src/parser/visitor.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::parser::ast::ToplevelExpression;
 use crate::parser::{
     Block, EnumInfo, Expression, Expression_, FunInfo, ImportInfo, LetDestination, MethodInfo,
-    Pattern, StructInfo, Symbol, TestInfo, ToplevelItem, TypeHint, TypeSymbol,
+    MethodKind, Pattern, StructInfo, Symbol, TestInfo, ToplevelItem, TypeHint, TypeSymbol,
 };
 
 /// A visitor for ASTs.
@@ -353,4 +353,356 @@ pub(crate) trait Visitor {
     fn visit_symbol(&mut self, _: &Symbol) {}
 
     fn visit_type_symbol(&mut self, _: &TypeSymbol) {}
+}
+
+/// A mutable visitor for ASTs.
+///
+/// This mirrors `Visitor`, but walks mutable AST nodes. It is useful
+/// for focused AST rewrites that still want the central traversal
+/// logic to live in one place.
+pub(crate) trait VisitorMut {
+    fn visit_toplevel_item_mut(&mut self, item: &mut ToplevelItem) {
+        self.visit_toplevel_item_mut_default(item);
+    }
+
+    fn visit_toplevel_item_mut_default(&mut self, item: &mut ToplevelItem) {
+        match item {
+            ToplevelItem::Fun(_, fun_info, _) => self.visit_fun_info_mut(fun_info),
+            ToplevelItem::Method(method_info, _) => self.visit_method_info_mut(method_info),
+            ToplevelItem::Test(test_info) => self.visit_test_info_mut(test_info),
+            ToplevelItem::Enum(enum_info) => self.visit_enum_info_mut(enum_info),
+            ToplevelItem::Struct(struct_info) => self.visit_struct_info_mut(struct_info),
+            ToplevelItem::Expr(toplevel_expression) => {
+                self.visit_toplevel_expr_mut(toplevel_expression)
+            }
+            ToplevelItem::Block(block) => self.visit_block_mut(block),
+            ToplevelItem::Import(import_info) => self.visit_import_info_mut(import_info),
+        }
+    }
+
+    fn visit_toplevel_expr_mut(&mut self, toplevel_expr: &mut ToplevelExpression) {
+        self.visit_expr_mut(&mut toplevel_expr.0);
+    }
+
+    fn visit_method_info_mut(&mut self, method_info: &mut MethodInfo) {
+        self.visit_method_info_mut_default(method_info);
+    }
+
+    fn visit_method_info_mut_default(&mut self, method_info: &mut MethodInfo) {
+        self.visit_type_hint_mut(&mut method_info.receiver_hint);
+        self.visit_symbol_mut(&mut method_info.receiver_sym);
+        self.visit_symbol_mut(&mut method_info.name_sym);
+
+        match &mut method_info.kind {
+            MethodKind::BuiltinMethod(_, Some(fun_info))
+            | MethodKind::UserDefinedMethod(fun_info) => self.visit_fun_info_mut(fun_info),
+            MethodKind::BuiltinMethod(_, None) => {}
+        }
+    }
+
+    fn visit_test_info_mut(&mut self, test_info: &mut TestInfo) {
+        self.visit_symbol_mut(&mut test_info.name_sym);
+        self.visit_block_mut(&mut test_info.body);
+    }
+
+    fn visit_enum_info_mut(&mut self, enum_info: &mut EnumInfo) {
+        self.visit_enum_info_mut_default(enum_info);
+    }
+
+    fn visit_enum_info_mut_default(&mut self, enum_info: &mut EnumInfo) {
+        self.visit_type_symbol_mut(&mut enum_info.name_sym);
+        for type_param in &mut enum_info.type_params {
+            self.visit_type_symbol_mut(type_param);
+        }
+        for variant in &mut enum_info.variants {
+            self.visit_symbol_mut(&mut variant.name_sym);
+            if let Some(hint) = &mut variant.payload_hint {
+                self.visit_type_hint_mut(hint);
+            }
+        }
+    }
+
+    fn visit_import_info_mut(&mut self, import_info: &mut ImportInfo) {
+        self.visit_import_info_mut_default(import_info);
+    }
+
+    fn visit_import_info_mut_default(&mut self, import_info: &mut ImportInfo) {
+        if let Some(namespace_sym) = &mut import_info.namespace_sym {
+            self.visit_symbol_mut(namespace_sym);
+        }
+    }
+
+    fn visit_struct_info_mut(&mut self, struct_info: &mut StructInfo) {
+        self.visit_struct_info_mut_default(struct_info);
+    }
+
+    fn visit_struct_info_mut_default(&mut self, struct_info: &mut StructInfo) {
+        self.visit_type_symbol_mut(&mut struct_info.name_sym);
+        for type_param in &mut struct_info.type_params {
+            self.visit_type_symbol_mut(type_param);
+        }
+        for field in &mut struct_info.fields {
+            self.visit_symbol_mut(&mut field.sym);
+            self.visit_type_hint_mut(&mut field.hint);
+        }
+    }
+
+    fn visit_fun_info_mut(&mut self, fun_info: &mut FunInfo) {
+        self.visit_fun_info_mut_default(fun_info);
+    }
+
+    fn visit_fun_info_mut_default(&mut self, fun_info: &mut FunInfo) {
+        if let Some(name_sym) = &mut fun_info.name_sym {
+            self.visit_symbol_mut(name_sym);
+        }
+
+        for type_param in &mut fun_info.type_params {
+            self.visit_type_symbol_mut(type_param);
+        }
+
+        for param in &mut fun_info.params.params {
+            self.visit_symbol_mut(&mut param.symbol);
+
+            if let Some(param_hint) = &mut param.hint {
+                self.visit_type_hint_mut(param_hint);
+            }
+        }
+
+        if let Some(return_hint) = &mut fun_info.return_hint {
+            self.visit_type_hint_mut(return_hint);
+        }
+
+        self.visit_block_mut(&mut fun_info.body);
+    }
+
+    fn visit_type_hint_mut(&mut self, type_hint: &mut TypeHint) {
+        self.visit_type_symbol_mut(&mut type_hint.sym);
+        for arg in &mut type_hint.args {
+            self.visit_type_hint_mut(arg);
+        }
+    }
+
+    fn visit_block_mut(&mut self, block: &mut Block) {
+        for expr in &mut block.exprs {
+            self.visit_expr_mut(Rc::make_mut(expr));
+        }
+    }
+
+    fn visit_expr_mut(&mut self, expr: &mut Expression) {
+        self.visit_expr_mut_default(expr);
+    }
+
+    fn visit_expr_mut_default(&mut self, expr: &mut Expression) {
+        self.visit_expr_variant_mut(&mut expr.expr_);
+    }
+
+    fn visit_expr_variant_mut(&mut self, expr_: &mut Expression_) {
+        match expr_ {
+            Expression_::Match(scrutinee, cases) => {
+                self.visit_expr_match_mut(Rc::make_mut(scrutinee), cases);
+            }
+            Expression_::If(cond, then_body, else_body) => {
+                self.visit_expr_if_mut(Rc::make_mut(cond), then_body, else_body.as_mut());
+            }
+            Expression_::While(cond, body) => {
+                self.visit_expr_while_mut(Rc::make_mut(cond), body);
+            }
+            Expression_::ForIn(sym, expr, body) => {
+                self.visit_expr_for_in_mut(sym, Rc::make_mut(expr), body);
+            }
+            Expression_::Try(try_body, catch_sym, catch_body) => {
+                self.visit_expr_try_mut(try_body, catch_sym, catch_body);
+            }
+            Expression_::Break => {}
+            Expression_::Continue => {}
+            Expression_::Assign(sym, expr) => {
+                self.visit_expr_assign_mut(sym, Rc::make_mut(expr));
+            }
+            Expression_::AssignUpdate(sym, _, expr) => {
+                self.visit_expr_assign_update_mut(sym, Rc::make_mut(expr));
+            }
+            Expression_::Let(dest, hint, expr) => {
+                self.visit_expr_let_mut(dest, hint.as_mut(), Rc::make_mut(expr));
+            }
+            Expression_::Return(expr) => {
+                if let Some(expr) = expr {
+                    self.visit_expr_mut(Rc::make_mut(expr));
+                }
+            }
+            Expression_::ListLiteral(exprs) => {
+                for expr in exprs {
+                    self.visit_expr_mut(Rc::make_mut(&mut expr.expr));
+                }
+            }
+            Expression_::DictLiteral(pairs) => {
+                for pair in pairs {
+                    self.visit_expr_mut(Rc::make_mut(&mut pair.key));
+                    self.visit_expr_mut(Rc::make_mut(&mut pair.value));
+                }
+            }
+            Expression_::TupleLiteral(exprs) => {
+                for expr in exprs {
+                    self.visit_expr_mut(Rc::make_mut(expr));
+                }
+            }
+            Expression_::StructLiteral(name_sym, field_exprs) => {
+                self.visit_expr_struct_literal_mut(name_sym, field_exprs);
+            }
+            Expression_::BinaryOperator(lhs, _, rhs) => {
+                self.visit_expr_mut(Rc::make_mut(lhs));
+                self.visit_expr_mut(Rc::make_mut(rhs));
+            }
+            Expression_::Variable(var) => {
+                self.visit_expr_variable_mut(var);
+            }
+            Expression_::Call(recv, paren_args) => {
+                self.visit_expr_mut(Rc::make_mut(recv));
+                for arg in &mut paren_args.arguments {
+                    self.visit_expr_mut(Rc::make_mut(&mut arg.expr));
+                }
+            }
+            Expression_::MethodCall(recv, meth_name, paren_args) => {
+                self.visit_symbol_mut(meth_name);
+                self.visit_expr_mut(Rc::make_mut(recv));
+                for arg in &mut paren_args.arguments {
+                    self.visit_expr_mut(Rc::make_mut(&mut arg.expr));
+                }
+            }
+            Expression_::FunLiteral(fun_info) => {
+                self.visit_expr_fun_literal_mut(fun_info);
+            }
+            Expression_::IntLiteral(_) => {}
+            Expression_::FloatLiteral(_) => {}
+            Expression_::StringLiteral(_) => {}
+            Expression_::DotAccess(recv, field_sym) => {
+                self.visit_symbol_mut(field_sym);
+                self.visit_expr_mut(Rc::make_mut(recv));
+            }
+            Expression_::NamespaceAccess(recv, sym) => {
+                self.visit_symbol_mut(sym);
+                self.visit_expr_mut(Rc::make_mut(recv));
+            }
+            Expression_::Assert(expr) => {
+                self.visit_expr_mut(Rc::make_mut(expr));
+            }
+            Expression_::Parentheses(paren) => {
+                self.visit_expr_mut(Rc::make_mut(&mut paren.expr));
+            }
+            Expression_::Invalid => {}
+        }
+    }
+
+    fn visit_expr_struct_literal_mut(
+        &mut self,
+        type_symbol: &mut TypeSymbol,
+        field_exprs: &mut [(Symbol, Rc<Expression>)],
+    ) {
+        self.visit_type_symbol_mut(type_symbol);
+        for (sym, expr) in field_exprs {
+            self.visit_symbol_mut(sym);
+            self.visit_expr_mut(Rc::make_mut(expr));
+        }
+    }
+
+    fn visit_expr_match_mut(&mut self, scrutinee: &mut Expression, cases: &mut [(Pattern, Block)]) {
+        self.visit_expr_mut(scrutinee);
+        for (pattern, case_expr) in cases {
+            self.visit_symbol_mut(&mut pattern.variant_sym);
+            if let Some(dest) = &mut pattern.payload {
+                self.visit_dest_mut(dest);
+            }
+
+            self.visit_block_mut(case_expr);
+        }
+    }
+
+    fn visit_expr_if_mut(
+        &mut self,
+        cond: &mut Expression,
+        then_body: &mut Block,
+        else_body: Option<&mut Block>,
+    ) {
+        self.visit_expr_mut(cond);
+        self.visit_block_mut(then_body);
+        if let Some(else_body) = else_body {
+            self.visit_block_mut(else_body);
+        }
+    }
+
+    fn visit_expr_while_mut(&mut self, cond: &mut Expression, body: &mut Block) {
+        self.visit_expr_mut(cond);
+        self.visit_block_mut(body);
+    }
+
+    fn visit_expr_for_in_mut(
+        &mut self,
+        dest: &mut LetDestination,
+        expr: &mut Expression,
+        body: &mut Block,
+    ) {
+        self.visit_dest_mut(dest);
+        self.visit_expr_mut(expr);
+        self.visit_block_mut(body);
+    }
+
+    fn visit_expr_try_mut(
+        &mut self,
+        try_body: &mut Block,
+        catch_sym: &mut Symbol,
+        catch_body: &mut Block,
+    ) {
+        self.visit_block_mut(try_body);
+        self.visit_symbol_mut(catch_sym);
+        self.visit_block_mut(catch_body);
+    }
+
+    fn visit_expr_variable_mut(&mut self, symbol: &mut Symbol) {
+        self.visit_symbol_mut(symbol);
+    }
+
+    fn visit_dest_mut(&mut self, dest: &mut LetDestination) {
+        match dest {
+            LetDestination::Symbol(symbol) => {
+                self.visit_symbol_mut(symbol);
+            }
+            LetDestination::Destructure(symbols) => {
+                for symbol in symbols {
+                    self.visit_symbol_mut(symbol);
+                }
+            }
+        }
+    }
+
+    fn visit_expr_let_mut(
+        &mut self,
+        dest: &mut LetDestination,
+        hint: Option<&mut TypeHint>,
+        expr: &mut Expression,
+    ) {
+        self.visit_expr_mut(expr);
+
+        self.visit_dest_mut(dest);
+
+        if let Some(hint) = hint {
+            self.visit_type_hint_mut(hint);
+        }
+    }
+
+    fn visit_expr_assign_mut(&mut self, symbol: &mut Symbol, expr: &mut Expression) {
+        self.visit_symbol_mut(symbol);
+        self.visit_expr_mut(expr);
+    }
+
+    fn visit_expr_assign_update_mut(&mut self, symbol: &mut Symbol, expr: &mut Expression) {
+        self.visit_symbol_mut(symbol);
+        self.visit_expr_mut(expr);
+    }
+
+    fn visit_expr_fun_literal_mut(&mut self, fun_info: &mut FunInfo) {
+        self.visit_fun_info_mut(fun_info);
+    }
+
+    fn visit_symbol_mut(&mut self, _: &mut Symbol) {}
+
+    fn visit_type_symbol_mut(&mut self, _: &mut TypeSymbol) {}
 }

--- a/src/test_files/eval_up_to/discarded_call.gdn
+++ b/src/test_files/eval_up_to/discarded_call.gdn
@@ -1,0 +1,12 @@
+fun value(): Int {
+  9
+}
+
+{
+  value()
+  //   ^
+  0
+}
+
+// args: reftest-eval-up-to
+// expected stdout: src/test_files/eval_up_to/discarded_call.gdn:6: 9

--- a/src/test_files/eval_up_to/discarded_function_inner_block.gdn
+++ b/src/test_files/eval_up_to/discarded_function_inner_block.gdn
@@ -1,0 +1,16 @@
+fun add_two(i: Int): Int {
+  if True {
+    i + 2
+  //  ^
+  } else {
+    0
+  }
+  0
+}
+
+{
+  add_two(5)
+}
+
+// args: reftest-eval-up-to
+// expected stdout: src/test_files/eval_up_to/discarded_function_inner_block.gdn:3: 7

--- a/src/test_files/eval_up_to/discarded_if_branch.gdn
+++ b/src/test_files/eval_up_to/discarded_if_branch.gdn
@@ -1,0 +1,12 @@
+{
+  if True {
+    7
+  //^
+  } else {
+    8
+  }
+  0
+}
+
+// args: reftest-eval-up-to
+// expected stdout: src/test_files/eval_up_to/discarded_if_branch.gdn:3: 7


### PR DESCRIPTION
eval_up_to now annotates a cloned target item so discarded expressions along the target path can produce values without the stop-at value-use override. Added reftests for discarded branch, call, and function-body values.