### PR TITLE
Track comma positions in VariantInfo and FieldInfo

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1540,15 +1540,18 @@ fn parse_enum_body(
             break;
         }
 
-        let variant = parse_variant(tokens, id_gen, diagnostics);
-        variants.push(variant);
+        let mut variant = parse_variant(tokens, id_gen, diagnostics);
 
         if let Some(token) = tokens.peek() {
             if token.text == "," {
+                variant.comma = Some(token.position);
+                variants.push(variant);
                 tokens.pop();
             } else if token.text == "}" {
+                variants.push(variant);
                 break;
             } else {
+                variants.push(variant);
                 diagnostics.push(ParseError::Invalid {
                     position: token.position,
                     message: ErrorMessage(vec![
@@ -1565,6 +1568,8 @@ fn parse_enum_body(
                 break;
             }
         } else {
+            variants.push(variant);
+
             let position = match tokens.prev() {
                 Some(prev_token) => prev_token.position.clone(),
                 None => Position::todo(&tokens.vfs_path),
@@ -1605,6 +1610,7 @@ fn parse_variant(
     VariantInfo {
         name_sym: name_symbol,
         payload_hint,
+        comma: None,
     }
 }
 
@@ -2239,16 +2245,17 @@ fn parse_struct_fields(
             break;
         }
 
-        if let Some(token) = tokens.peek() {
+        let mut field = if let Some(token) = tokens.peek() {
             let doc_comment = parse_doc_comment(&token);
             let sym = parse_symbol(tokens, id_gen, diagnostics, Some("struct name"));
             let hint = parse_colon_and(tokens, id_gen, diagnostics);
 
-            fields.push(FieldInfo {
+            FieldInfo {
                 sym,
                 hint,
                 doc_comment,
-            });
+                comma: None,
+            }
         } else {
             diagnostics.push(ParseError::Incomplete {
                 position: Position::todo(&tokens.vfs_path),
@@ -2259,14 +2266,18 @@ fn parse_struct_fields(
                 ]),
             });
             break;
-        }
+        };
 
         if let Some(token) = tokens.peek() {
             if token.text == "," {
+                field.comma = Some(token.position);
+                fields.push(field);
                 tokens.pop();
             } else if token.text == "}" {
+                fields.push(field);
                 break;
             } else {
+                fields.push(field);
                 diagnostics.push(ParseError::Invalid {
                     position: token.position,
                     message: ErrorMessage(vec![
@@ -2283,6 +2294,7 @@ fn parse_struct_fields(
                 break;
             }
         } else {
+            fields.push(field);
             diagnostics.push(ParseError::Incomplete {
                 position: Position::todo(&tokens.vfs_path),
                 message: ErrorMessage(vec![

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -819,19 +819,48 @@ impl PartialEq for TestInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub(crate) struct VariantInfo {
     pub(crate) name_sym: Symbol,
     /// If this variant is of the form `Foo(T)`, the type hint inside
     /// the parentheses.
     pub(crate) payload_hint: Option<TypeHint>,
+    /// The position of the comma after this variant, if present.
+    pub(crate) comma: Option<Position>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Structural equality: ignore comma position.
+impl PartialEq for VariantInfo {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            name_sym,
+            payload_hint,
+            comma: _,
+        } = self;
+        *name_sym == other.name_sym && *payload_hint == other.payload_hint
+    }
+}
+
+#[derive(Debug, Clone, Eq)]
 pub(crate) struct FieldInfo {
     pub(crate) sym: Symbol,
     pub(crate) hint: TypeHint,
     pub(crate) doc_comment: Option<String>,
+    /// The position of the comma after this field, if present.
+    pub(crate) comma: Option<Position>,
+}
+
+/// Structural equality: ignore comma position.
+impl PartialEq for FieldInfo {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sym,
+            hint,
+            doc_comment,
+            comma: _,
+        } = self;
+        *sym == other.sym && *hint == other.hint && *doc_comment == other.doc_comment
+    }
 }
 
 #[derive(Debug, Clone, Eq)]

--- a/src/test_files/parser/struct.gdn
+++ b/src/test_files/parser/struct.gdn
@@ -26,6 +26,9 @@ struct Foo<T> {
 //                 doc_comment: Some(
 //                     "Stuff.",
 //                 ),
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
 //             },
 //             FieldInfo {
 //                 sym: Symbol"foo_bar_baz",
@@ -35,6 +38,9 @@ struct Foo<T> {
 //                     position: Position { ... },
 //                 },
 //                 doc_comment: None,
+//                 comma: Some(
+//                     Position { ... },
+//                 ),
 //             },
 //         ],
 //     },

--- a/src/test_files/parser/struct_missing_name.gdn
+++ b/src/test_files/parser/struct_missing_name.gdn
@@ -18,6 +18,7 @@ struct { x: Int }
 //                     position: Position { ... },
 //                 },
 //                 doc_comment: None,
+//                 comma: None,
 //             },
 //         ],
 //     },


### PR DESCRIPTION
Store the position of trailing commas in enum variants and struct fields, enabling better error reporting and formatting. This adds a `comma: Option<Position>` field to both `VariantInfo` and `FieldInfo`.

- Added `comma` field to `VariantInfo` and `FieldInfo` to track trailing comma positions
- Implemented custom `PartialEq` for both types to ignore comma position in structural equality comparisons
- Updated enum and struct parsing to populate the comma field when a trailing comma is present
- Updated test expectations to reflect the new field in AST output

https://claude.ai/code/session_01VqLK48ADjbJkwtTzdBhU7T