### PR TITLE
Specify Debian bookworm variant for Rust base image

### DIFF
--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,5 +1,5 @@
 # Separate stage for building the Garden binary.
-FROM rust:1.95 AS garden-builder
+FROM rust:1.95-bookworm AS garden-builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY src/ ./src/


### PR DESCRIPTION
Updated the Rust base image in the playground Dockerfile to use the `bookworm` variant explicitly, ensuring a consistent and predictable build environment.

https://claude.ai/code/session_01U1kS2mD6psSRXGpVpchWvm