### PR TITLE
Only check unused literals in statement position

### DIFF
--- a/src/checks/unused_literals.rs
+++ b/src/checks/unused_literals.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Autofix, Diagnostic, Severity};
 use crate::env::Env;
-use crate::parser::ast::{Block, Expression, Expression_, ToplevelItem};
+use crate::parser::ast::{Block, Expression, Expression_, LetDestination, ToplevelItem};
 use crate::parser::diagnostics::ErrorMessage;
 use crate::parser::diagnostics::MessagePart::*;
 use crate::parser::position::Position;
@@ -104,5 +104,26 @@ impl Visitor for UnusedLiteralVisitor<'_> {
 
             self.visit_expr(expr);
         }
+    }
+
+    fn visit_expr_while(&mut self, cond: &Expression, body: &Block) {
+        // A loop evaluates to Unit, so its body's final value is also
+        // discarded.
+        if let Some(last) = body.exprs.last() {
+            self.check_expression(last);
+        }
+
+        self.visit_expr(cond);
+        self.visit_block(body);
+    }
+
+    fn visit_expr_for_in(&mut self, dest: &LetDestination, iteree: &Expression, body: &Block) {
+        if let Some(last) = body.exprs.last() {
+            self.check_expression(last);
+        }
+
+        self.visit_dest(dest);
+        self.visit_expr(iteree);
+        self.visit_block(body);
     }
 }

--- a/src/checks/unused_literals.rs
+++ b/src/checks/unused_literals.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Autofix, Diagnostic, Severity};
 use crate::env::Env;
-use crate::parser::ast::{Expression, Expression_, ToplevelItem};
+use crate::parser::ast::{Block, Expression, Expression_, ToplevelItem};
 use crate::parser::diagnostics::ErrorMessage;
 use crate::parser::diagnostics::MessagePart::*;
 use crate::parser::position::Position;
@@ -33,11 +33,6 @@ impl<'a> UnusedLiteralVisitor<'a> {
     }
 
     fn check_expression(&mut self, expr: &Expression) {
-        // Only check expressions whose values are not used
-        if expr.value_is_used {
-            return;
-        }
-
         let is_literal = matches!(
             &expr.expr_,
             Expression_::IntLiteral(_)
@@ -95,8 +90,19 @@ impl<'a> UnusedLiteralVisitor<'a> {
 }
 
 impl Visitor for UnusedLiteralVisitor<'_> {
-    fn visit_expr(&mut self, expr: &Expression) {
-        self.check_expression(expr);
-        self.visit_expr_(&expr.expr_);
+    fn visit_block(&mut self, block: &Block) {
+        let exprs_len = block.exprs.len();
+        for (i, expr) in block.exprs.iter().enumerate() {
+            // A literal written as a statement (any expression in a
+            // block except the last) has its value discarded, so it
+            // serves no purpose. The final expression is the block's
+            // value, so we leave it alone.
+            let is_last = i + 1 == exprs_len;
+            if !is_last {
+                self.check_expression(expr);
+            }
+
+            self.visit_expr(expr);
+        }
     }
 }

--- a/src/test_files/check/type_error_if.gdn
+++ b/src/test_files/check/type_error_if.gdn
@@ -23,14 +23,6 @@ public fun stuff(): String {
 // args: check
 // expected exit status: 1
 // expected stdout:
-// Warning: Unused value.
-// 
-// -| src/test_files/check/type_error_if.gdn:5:5
-// 3|     string_repr(1234)
-// 4|   } else {
-// 5|     ""
-// 6|   } ^^
-// 
 // Error: Expected a `Bool` but got an `Int`.
 // 
 // -| src/test_files/check/type_error_if.gdn:2:6
@@ -58,4 +50,3 @@ public fun stuff(): String {
 // 20|   } ^^^
 // 21| }
 
-// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check/type_error_if_without_else.gdn
+++ b/src/test_files/check/type_error_if_without_else.gdn
@@ -7,15 +7,6 @@ public fun foo(b: Bool): Int {
 // args: check
 // expected exit status: 1
 // expected stdout:
-// Warning: Unused value.
-// 
-// -| src/test_files/check/type_error_if_without_else.gdn:3:9
-// 1| public fun foo(b: Bool): Int {
-// 2|     if b {
-// 3|         123
-// 4|     }   ^^^
-// 5| }
-// 
 // Error: Expected an `Int` but got `Unit`.
 // 
 // -| src/test_files/check/type_error_if_without_else.gdn:2:5
@@ -28,4 +19,3 @@ public fun foo(b: Bool): Int {
 //  | ^^^^^
 // 5| }
 
-// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check/unused_literal_loop.gdn
+++ b/src/test_files/check/unused_literal_loop.gdn
@@ -1,0 +1,32 @@
+public fun example() {
+  let i = 0
+  while i < 3 {
+    i += 1
+    42
+  }
+
+  for _ in [1, 2, 3] {
+    "hello"
+  }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: Unused value.
+// 
+// -| src/test_files/check/unused_literal_loop.gdn:5:5
+// 3|   while i < 3 {
+// 4|     i += 1
+// 5|     42
+// 6|   } ^^
+// 
+// Warning: Unused value.
+// 
+// --| src/test_files/check/unused_literal_loop.gdn:9:5
+//  8|   for _ in [1, 2, 3] {
+//  9|     "hello"
+// 10|   } ^^^^^^^
+// 11| }
+
+// expected stderr: 2 issues can be fixed automatically (use `--fix`).


### PR DESCRIPTION
The unused literal check now only reports literals that appear as statements (expressions in a block whose value is discarded), rather than all unused expressions. This aligns with the actual problem: a literal written as a standalone statement serves no purpose, but a literal that's part of a larger expression or is the final value of a block is intentional.

Changes made:
- Modified `UnusedLiteralVisitor` to override `visit_block` instead of `visit_expr`, checking only non-final expressions in a block
- Removed the `value_is_used` check from `check_expression` since the visitor now only calls it for expressions in statement position
- Updated test expectations to remove spurious unused literal warnings that were incorrectly reported for the final expression in conditional blocks

https://claude.ai/code/session_01M8M9XGRXtuXKMLRrfnMrr5