### PR TITLE
Keep the first solution when unifying generic type parameters

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -2795,7 +2795,18 @@ fn substitute_ty_vars(ty: &Type, ty_var_env: &TypeVarEnv) -> Type {
 fn unify_and_solve_ty(decl_ty: &Type, solved_ty: &Type, ty_var_env: &mut TypeVarEnv) {
     match (decl_ty, solved_ty) {
         (Type::TypeParameter(n), _) => {
-            ty_var_env.insert(n.clone(), Some(solved_ty.clone()));
+            // Keep the first solution we found for this type variable.
+            // This matches unify_and_solve_hint: a later occurrence that
+            // disagrees is then reported against the argument that's
+            // inconsistent, rather than silently overwriting the solution
+            // and blaming an earlier argument. Replace a previous NoValue
+            // solution, since a more specific type is more useful.
+            match ty_var_env.get(n) {
+                Some(Some(existing)) if !existing.is_no_value() => {}
+                _ => {
+                    ty_var_env.insert(n.clone(), Some(solved_ty.clone()));
+                }
+            }
         }
         (
             Type::Fun {

--- a/src/test_files/check/generic_struct_literal_mismatch.gdn
+++ b/src/test_files/check/generic_struct_literal_mismatch.gdn
@@ -10,10 +10,10 @@ public fun make_pair(): Pair<String> {
 // args: check
 // expected exit status: 1
 // expected stdout:
-// Error: Expected an `Int` for this field but got a `String`.
+// Error: Expected a `String` for this field but got an `Int`.
 // 
-// -| src/test_files/check/generic_struct_literal_mismatch.gdn:7:16
+// -| src/test_files/check/generic_struct_literal_mismatch.gdn:7:31
 // 6| public fun make_pair(): Pair<String> {
 // 7|   Pair{ first: "foo", second: 1 }
-// 8| }              ^^^^^
+// 8| }                             ^
 

--- a/src/test_files/check/type_error_generic_arg_consistency.gdn
+++ b/src/test_files/check/type_error_generic_arg_consistency.gdn
@@ -1,0 +1,18 @@
+fun pick<T>(x: T, _y: T): T {
+  x
+}
+
+{
+  pick(1, "hello")
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Error: Expected an `Int` but got a `String`.
+// 
+// -| src/test_files/check/type_error_generic_arg_consistency.gdn:6:11
+// 5| {
+// 6|   pick(1, "hello")
+// 7| }         ^^^^^^^
+

--- a/src/test_files/check/type_error_solve_generics.gdn
+++ b/src/test_files/check/type_error_solve_generics.gdn
@@ -13,10 +13,11 @@ public fun takes_options<T>(_x: Option<T>, _y: Option<T>) {}
 // args: check
 // expected exit status: 1
 // expected stdout:
-// Error: Expected an `Option<Int>` but got an `Option<String>`.
+// Error: Expected an `Option<String>` but got an `Option<Int>`.
 // 
-// --| src/test_files/check/type_error_solve_generics.gdn:10:19
+// --| src/test_files/check/type_error_solve_generics.gdn:10:32
 //  8|     // takes_options(Some(123), None)
 //  9| 
 // 10|     takes_options(Some("foo"), Some(123))
-// 11| }                 ^^^^^^^^^^^
+// 11| }                              ^^^^^^^^^
+


### PR DESCRIPTION
`unify_and_solve_ty` overwrote an already-solved type variable with each later occurrence, so an inconsistent generic call like `pick(1, "hello")` (where `pick<T>(x: T, y: T)`) reported the mismatch against the first argument and with the direction reversed. It now keeps the first solution (replacing only a `NoValue` solution), matching `unify_and_solve_hint`, so the error points at the argument that actually disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE5z2WSP2gw4t1wVJyCngj)_