### PR TITLE
Fix loop bindings block leak causing quadratic variable lookups

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -154,6 +154,13 @@ pub(crate) struct Env {
     /// If set, print the call stack every 10,000 ticks for basic
     /// profiling.
     pub(crate) profile: bool,
+
+    /// The maximum number of bindings blocks present in any single
+    /// stack frame at any point during evaluation (a high-water mark).
+    /// It grows with lexical nesting. Used only by tests, see
+    /// `test_loops_do_not_leak_bindings_blocks`.
+    #[cfg(test)]
+    pub(crate) peak_binding_depth: usize,
 }
 
 impl Env {
@@ -201,6 +208,8 @@ impl Env {
             initial_state: None,
             cli_args: vec![],
             profile: false,
+            #[cfg(test)]
+            peak_binding_depth: 0,
         };
 
         let prelude_namespace = fresh_prelude(&mut env, &prelude_vfs_path);
@@ -383,6 +392,22 @@ impl Env {
 
     pub(crate) fn current_frame_mut(&mut self) -> &mut StackFrame {
         self.stack.0.last_mut().unwrap()
+    }
+
+    /// Push a new bindings block onto the current stack frame.
+    ///
+    /// All bindings blocks entered during evaluation should go through
+    /// here so that, in test builds, `peak_binding_depth` reflects the
+    /// true maximum nesting.
+    pub(crate) fn push_binding_block(&mut self) {
+        let frame = self.current_frame_mut();
+        frame.bindings.push_block();
+
+        #[cfg(test)]
+        {
+            let depth = frame.bindings.block_bindings.len();
+            self.peak_binding_depth = self.peak_binding_depth.max(depth);
+        }
     }
 
     /// If `path` is a subdirectory of the current project, convert it

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1629,7 +1629,7 @@ fn eval_if(
             eval_block(env, branch_value_used, else_body);
         } else {
             // Ensure we always push a bindings block.
-            env.current_frame_mut().bindings.push_block();
+            env.push_binding_block();
         }
     } else {
         return Err((
@@ -1752,7 +1752,7 @@ fn eval_for_in(
         // Push a bindings block and an EvaluatedSubexpressions
         // state so the loop expression evaluates to Unit and its
         // outer EvaluatedSubexpressions pops a balancing block.
-        env.current_frame_mut().bindings.push_block();
+        env.push_binding_block();
         env.push_expr_to_eval(
             ExpressionState::EvaluatedSubexpressions,
             Rc::clone(&outer_expr),
@@ -1763,18 +1763,12 @@ fn eval_for_in(
         return Ok(());
     }
 
-    // After each iteration's body, we want to pop the iteration's
-    // bindings block (pushed by `eval_block`), so schedule an
-    // EvaluatedSubexpressions state for this iteration.
+    // After this iteration's body, run a DoneRunBlock step (see the
+    // `ForIn` dispatch) that pops this iteration's bindings block
+    // (pushed by `eval_block`) before scheduling the next iteration,
+    // mirroring while loops.
     env.push_expr_to_eval(
-        ExpressionState::EvaluatedSubexpressions,
-        Rc::clone(&outer_expr),
-    );
-
-    // After an iteration the loop body, evaluate again. We don't
-    // re-evaluate the iteree expression though.
-    env.push_expr_to_eval(
-        ExpressionState::PartiallyEvaluated(BlockState::WillRunBlock),
+        ExpressionState::PartiallyEvaluated(BlockState::DoneRunBlock),
         Rc::clone(&outer_expr),
     );
 
@@ -6514,21 +6508,40 @@ fn eval_expr(
                     // that we want to iterate over.
                     env.push_expr_to_eval(ExpressionState::NotEvaluated, Rc::clone(expr));
                 }
-                ExpressionState::PartiallyEvaluated(_) => {
-                    eval_for_in(
-                        env,
-                        expr_value_is_used,
-                        sym,
-                        &expr.position,
-                        Rc::clone(&outer_expr),
-                        body,
-                    )?;
+                ExpressionState::PartiallyEvaluated(block_state) => {
+                    match block_state {
+                        BlockState::WillRunBlock => {
+                            // Run the next iteration: bind the loop
+                            // variable, push a bindings block, and
+                            // evaluate the body (or terminate).
+                            eval_for_in(
+                                env,
+                                expr_value_is_used,
+                                sym,
+                                &expr.position,
+                                Rc::clone(&outer_expr),
+                                body,
+                            )?;
+                        }
+                        BlockState::DoneRunBlock => {
+                            // Finished an iteration's body. Pop the
+                            // bindings block it pushed, then schedule
+                            // the next iteration.
+                            env.current_frame_mut().bindings.pop_block();
+
+                            env.push_expr_to_eval(
+                                ExpressionState::PartiallyEvaluated(BlockState::WillRunBlock),
+                                Rc::clone(&outer_expr),
+                            );
+                        }
+                        BlockState::NotBlock => unreachable!(),
+                    }
                 }
                 ExpressionState::EvaluatedSubexpressions => {
-                    // Pop the bindings block for this iteration (or
-                    // the terminal block pushed in `eval_for_in`).
-                    // The loop's overall value is pushed by
-                    // `eval_for_in` in the terminating branch.
+                    // Pop the terminal bindings block pushed in
+                    // `eval_for_in` when the loop finished. The loop's
+                    // overall value is pushed by `eval_for_in` in the
+                    // terminating branch.
                     env.current_frame_mut().bindings.pop_block();
                 }
             }
@@ -7247,9 +7260,9 @@ pub(crate) fn eval(env: &mut Env, session: &Session) -> Result<Value, EvalError>
 }
 
 fn eval_block(env: &mut Env, expr_value_is_used: bool, block: &Block) {
-    let stack_frame = env.current_frame_mut();
-    stack_frame.bindings.push_block();
+    env.push_binding_block();
 
+    let stack_frame = env.current_frame_mut();
     let bindings_next_block = std::mem::take(&mut stack_frame.bindings_next_block);
     for (sym, expr) in bindings_next_block {
         stack_frame.bindings.add_new(&sym, expr);
@@ -7937,6 +7950,36 @@ mod tests {
         let mut env = Env::new(id_gen, vfs);
         let value = eval_exprs(&exprs, &mut env).unwrap();
         assert_eq!(value, Value::new(Value_::Int(3)));
+    }
+
+    /// Evaluate a `for` loop that accumulates into an enclosing-scope
+    /// variable and return the peak bindings-block depth reached.
+    fn peak_binding_depth_for_loop(iterations: i64) -> usize {
+        let mut id_gen = IdGenerator::default();
+        let mut vfs = Vfs::default();
+        let src =
+            format!("let total = 0\nfor i in range(0, {iterations}) {{\n  total = total + i\n}}");
+        let exprs = parse_exprs_from_str(&src, &mut vfs, &mut id_gen);
+
+        let mut env = Env::new(id_gen, vfs);
+        eval_exprs(&exprs, &mut env).unwrap();
+        env.peak_binding_depth
+    }
+
+    #[test]
+    fn test_loops_do_not_leak_bindings_blocks() {
+        // The peak bindings-block depth depends only on lexical
+        // nesting, so a short loop and a long loop reach the same
+        // depth.
+        let small = peak_binding_depth_for_loop(10);
+        let large = peak_binding_depth_for_loop(10000);
+
+        assert_eq!(
+            small, large,
+            "peak binding depth grew with iteration count ({small} vs {large}), \
+             a loop is leaking a bindings block per iteration"
+        );
+        assert!(large < 8, "unexpectedly deep bindings nesting: {large}");
     }
 
     #[test]


### PR DESCRIPTION
A `for` loop pushed a bindings block per iteration but deferred every pop until the loop finished, so the binding-frame stack grew with the iteration count. Variable lookups in enclosing scopes scan that stack, so loops that touched an enclosing variable ran in O(n²). The per-iteration pop now happens before the next iteration runs, mirroring how `while` loops already work.

A unit test asserts the peak bindings-block depth is independent of iteration count, backed by a test-only high-water mark on `Env`.

https://claude.ai/code/session_019GnF4mfSSfhg6X7Sj2puQ1