### PR TITLE
Warn when match `_` case is redundant

### DIFF
--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -3036,6 +3036,11 @@ fn check_match_exhaustive(
 
     if !enum_info.variants.is_empty() {
         let mut underscore_pos: Option<&Position> = None;
+        // The `_` case's block and the end of the case before it, used
+        // to delete a redundant `_` case (including its leading
+        // separator).
+        let mut underscore_block: Option<&Block> = None;
+        let mut underscore_prev_end: Option<&Position> = None;
         // The end of the previous case's block, used to delete an
         // unreachable case (including its leading separator).
         let mut prev_case_end: Option<&Position> = None;
@@ -3087,12 +3092,15 @@ fn check_match_exhaustive(
                 continue;
             }
 
-            prev_case_end = Some(&block.close_brace);
-
             if pattern.variant_sym.name.is_underscore() {
                 underscore_pos = Some(&pattern.variant_sym.position);
+                underscore_block = Some(block);
+                underscore_prev_end = prev_case_end;
+                prev_case_end = Some(&block.close_brace);
                 continue;
             }
+
+            prev_case_end = Some(&block.close_brace);
 
             match variants_remaining.remove(&pattern.variant_sym.name) {
                 Some(_) => {
@@ -3113,7 +3121,43 @@ fn check_match_exhaustive(
         }
 
         // If any cases are _, this match is exhaustive.
-        if underscore_pos.is_some() {
+        if let Some(underscore_pos) = underscore_pos {
+            // If every variant has already been matched explicitly, the
+            // `_` case can never be reached and is redundant.
+            if variants_remaining.is_empty() {
+                let fixes = match (underscore_prev_end, underscore_block) {
+                    (Some(prev_end), Some(block)) => vec![Autofix {
+                        description: "Remove redundant case".to_owned(),
+                        position: Position {
+                            start_offset: prev_end.end_offset,
+                            end_offset: block.close_brace.end_offset,
+                            line_number: prev_end.end_line_number,
+                            end_line_number: block.close_brace.end_line_number,
+                            column: prev_end.end_column,
+                            end_column: block.close_brace.end_column,
+                            path: Rc::clone(&block.close_brace.path),
+                            vfs_path: block.close_brace.vfs_path.clone(),
+                        },
+                        new_text: String::new(),
+                    }],
+                    _ => vec![],
+                };
+
+                diagnostics.push(Diagnostic {
+                    notes: vec![],
+                    fixes,
+                    severity: Severity::Warning,
+                    message: ErrorMessage(vec![
+                        msgtext!("This "),
+                        msgcode!("_"),
+                        msgtext!(" case is redundant, as all the cases of "),
+                        msgcode!("{}", type_name),
+                        msgtext!(" are already matched."),
+                    ]),
+                    position: underscore_pos.clone(),
+                });
+            }
+
             return;
         }
     }

--- a/src/test_files/check/match_redundant_wildcard.gdn
+++ b/src/test_files/check/match_redundant_wildcard.gdn
@@ -1,0 +1,29 @@
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+public fun describe(c: Color): String {
+  // The `_` case is redundant because every variant is matched.
+  match c {
+    Red => "red"
+    Green => "green"
+    Blue => "blue"
+    _ => "other"
+  }
+}
+
+// args: check
+// expected exit status: 1
+// expected stdout:
+// Warning: This `_` case is redundant, as all the cases of `Color` are already matched.
+// 
+// --| src/test_files/check/match_redundant_wildcard.gdn:13:5
+// 11|     Green => "green"
+// 12|     Blue => "blue"
+// 13|     _ => "other"
+// 14|   } ^
+// 15| }
+
+// expected stderr: 1 issue can be fixed automatically (use `--fix`).

--- a/src/test_files/check_fix/match_redundant_wildcard.gdn
+++ b/src/test_files/check_fix/match_redundant_wildcard.gdn
@@ -1,0 +1,23 @@
+enum Color { Red, Green, Blue }
+
+public fun describe(c: Color): String {
+  match c {
+    Red => "red"
+    Green => "green"
+    Blue => "blue"
+    _ => "other"
+  }
+}
+
+// args: check --fix --stdout
+// expected stdout:
+// enum Color { Red, Green, Blue }
+// 
+// public fun describe(c: Color): String {
+//   match c {
+//     Red => "red"
+//     Green => "green"
+//     Blue => "blue"
+//   }
+// }
+


### PR DESCRIPTION
Detect when a match expression has a `_` case that can never be reached because all enum variants are already matched explicitly. This produces a warning with an autofix to remove the redundant case.

The check tracks the position and block of the `_` case separately from other cases, allowing us to identify when `variants_remaining` is empty after processing all explicit patterns. When this occurs, we emit a diagnostic with an autofix that removes the `_` case and its leading separator.

https://claude.ai/code/session_014RPrPGCFrZESSBzf3sVHGL