### PR TITLE
Add bitwise AND and OR operators for Int values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 **Goal: Offer actions when runtime errors occur.**
 **Goal: Fix precedence of `2 + 1 * 3.**
 
+## Language
+
+Added `&` and `|` operators for bitwise AND and OR on `Int` values.
+
 ## Standard Library
 
 `__shell::run()` now returns `(Int, String, String)`, always providing

--- a/src/checks/type_checker.rs
+++ b/src/checks/type_checker.rs
@@ -1750,7 +1750,9 @@ impl TypeCheckVisitor<'_> {
             | BinaryOperatorKind::Multiply
             | BinaryOperatorKind::Divide
             | BinaryOperatorKind::Modulo
-            | BinaryOperatorKind::Exponent => {
+            | BinaryOperatorKind::Exponent
+            | BinaryOperatorKind::BitwiseAnd
+            | BinaryOperatorKind::BitwiseOr => {
                 self.infer_int_binop(lhs, rhs, op, type_bindings, expected_return_ty)
             }
             BinaryOperatorKind::AddFloat

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2309,6 +2309,8 @@ fn eval_int_binop(
                 }
             }
         }
+        BinaryOperatorKind::BitwiseAnd => Value::new(Value_::Int(lhs_num & rhs_num)),
+        BinaryOperatorKind::BitwiseOr => Value::new(Value_::Int(lhs_num | rhs_num)),
         BinaryOperatorKind::LessThan => Value::bool(lhs_num < rhs_num),
         BinaryOperatorKind::GreaterThan => Value::bool(lhs_num > rhs_num),
         BinaryOperatorKind::LessThanOrEqual => Value::bool(lhs_num <= rhs_num),
@@ -6785,6 +6787,8 @@ fn eval_expr(
                     | BinaryOperatorKind::Divide
                     | BinaryOperatorKind::Modulo
                     | BinaryOperatorKind::Exponent
+                    | BinaryOperatorKind::BitwiseAnd
+                    | BinaryOperatorKind::BitwiseOr
                     | BinaryOperatorKind::LessThan
                     | BinaryOperatorKind::LessThanOrEqual
                     | BinaryOperatorKind::GreaterThan

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1441,6 +1441,8 @@ fn token_as_binary_op(token: &Token<'_>) -> Option<BinaryOperatorSymbol> {
         "!=" => Some(BinaryOperatorKind::NotEqual),
         "&&" => Some(BinaryOperatorKind::And),
         "||" => Some(BinaryOperatorKind::Or),
+        "&" => Some(BinaryOperatorKind::BitwiseAnd),
+        "|" => Some(BinaryOperatorKind::BitwiseOr),
         "<" => Some(BinaryOperatorKind::LessThan),
         "<=" => Some(BinaryOperatorKind::LessThanOrEqual),
         ">" => Some(BinaryOperatorKind::GreaterThan),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -266,6 +266,8 @@ pub(crate) enum BinaryOperatorKind {
     GreaterThanOrEqual,
     And,
     Or,
+    BitwiseAnd,
+    BitwiseOr,
     StringConcat,
 }
 
@@ -290,6 +292,8 @@ impl Display for BinaryOperatorKind {
             BinaryOperatorKind::GreaterThanOrEqual => ">=",
             BinaryOperatorKind::And => "&&",
             BinaryOperatorKind::Or => "||",
+            BinaryOperatorKind::BitwiseAnd => "&",
+            BinaryOperatorKind::BitwiseOr => "|",
             BinaryOperatorKind::StringConcat => "^",
         };
         write!(f, "{s}")

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -27,7 +27,7 @@ const TWO_CHAR_TOKENS: &[&str] = &["=>", "::"];
 /// Single character binary operators. Note that some of these
 /// operators can occur in other syntactic positions, specifically `<`
 /// and `>` can be used in type annotations.
-const ONE_CHAR_OPERATORS: &[char] = &['+', '-', '*', '/', '%', '^', '=', '<', '>'];
+const ONE_CHAR_OPERATORS: &[char] = &['+', '-', '*', '/', '%', '^', '=', '<', '>', '&', '|'];
 
 // Lexemes that aren't infix operators.
 const ONE_CHAR_TOKENS: &[char] = &['(', ')', '{', '}', ',', '[', ']', '.', ':'];

--- a/src/test_files/runtime/bitwise.gdn
+++ b/src/test_files/runtime/bitwise.gdn
@@ -1,0 +1,13 @@
+{
+  dbg(12 & 10)
+  dbg(12 | 10)
+  dbg(6 & 3)
+  dbg(6 | 1)
+}
+
+// args: run
+// expected stderr:
+// [src/test_files/runtime/bitwise.gdn:2:3] 12 & 10 //-> 8
+// [src/test_files/runtime/bitwise.gdn:3:3] 12 | 10 //-> 14
+// [src/test_files/runtime/bitwise.gdn:4:3] 6 & 3 //-> 2
+// [src/test_files/runtime/bitwise.gdn:5:3] 6 | 1 //-> 7


### PR DESCRIPTION
Adds support for `&` (bitwise AND) and `|` (bitwise OR) operators on `Int` values. These operators are now recognized by the lexer and parser, type-checked alongside other integer binary operations, and evaluated correctly.

- Added `BitwiseAnd` and `BitwiseOr` to `BinaryOperatorKind` enum
- Updated lexer to recognize `&` and `|` as single-character operators
- Updated parser to map `&` and `|` tokens to the new operator kinds
- Updated type checker to handle bitwise operators like other integer binary operations
- Implemented evaluation logic for both operators in `eval_int_binop`
- Added test file demonstrating bitwise operations with expected output

https://claude.ai/code/session_017zv1kBFbBg3BAYUfDP5Mq9