### PR TITLE
Implement nREPL stdin for read_line()

### DIFF
--- a/src/cli_session.rs
+++ b/src/cli_session.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
 use crate::eval::{
     eval, load_toplevel_items_with_stubs, push_test_stackframe, EvalError, ExceptionInfo,
-    ExpressionState, Session, StdoutStderrMode,
+    ExpressionState, Session, StdinMode, StdoutStderrMode,
 };
 use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::{parse_toplevel_items, ParseError};
@@ -104,6 +104,7 @@ pub(crate) fn repl(interrupted: Arc<AtomicBool>, trace_exprs: bool) {
     let mut session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs,
         pretty_print_json: false,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7,8 +7,9 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Instant;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use normalize_path::NormalizePath as _;
 use ordered_float::OrderedFloat;
@@ -246,12 +247,49 @@ pub(crate) enum StdoutStderrMode {
     DoNotWrite,
 }
 
+/// How `read_line()` obtains a line of input during evaluation.
+pub(crate) enum StdinMode {
+    /// Read a line from the process's standard input.
+    ReadFromStdin,
+    /// Request a line of input from the connected nREPL client and
+    /// block until it replies. Used by the nREPL server so that
+    /// `read_line()` does not read the server's own stdin.
+    NRepl(NReplStdin),
+}
+
+impl std::fmt::Debug for StdinMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StdinMode::ReadFromStdin => f.write_str("ReadFromStdin"),
+            StdinMode::NRepl(_) => f.write_str("NRepl(..)"),
+        }
+    }
+}
+
+/// Channels used to request a line of input from an nREPL client.
+///
+/// When `read_line()` runs it calls `request_input`, which tells the
+/// server to send a `need-input` status to the client, then blocks on
+/// `input_rx` until the client sends a line back via the `stdin` op.
+pub(crate) struct NReplStdin {
+    /// Called when an eval blocks on input. The server flushes any
+    /// buffered output and sends a `need-input` status to the client.
+    pub(crate) request_input: Box<dyn Fn() + Send>,
+    /// Lines sent by the client via the `stdin` op. `None` means the
+    /// client signalled end-of-input. Shared with the session worker,
+    /// which owns it for the lifetime of the session; only the worker
+    /// thread ever locks it.
+    pub(crate) input_rx: Arc<Mutex<Receiver<Option<String>>>>,
+}
+
 #[derive(Debug)]
 pub(crate) struct Session {
     pub(crate) interrupted: Arc<AtomicBool>,
     /// Whether `print()` should write to stdout directly, or if we
     /// should write a JSON message to stdout summarising the print.
     pub(crate) stdout_stderr_mode: StdoutStderrMode,
+    /// How `read_line()` obtains input.
+    pub(crate) stdin_mode: StdinMode,
     pub(crate) start_time: Instant,
     pub(crate) trace_exprs: bool,
     /// Whether JSON should be pretty-printed. This applies to any
@@ -2590,6 +2628,71 @@ fn as_int_str_tuple(i: i64, s: &str) -> Value {
     })
 }
 
+/// Strip a single trailing newline (`\n` or `\r\n`) from `line`.
+fn strip_trailing_newline(mut line: String) -> String {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+    line
+}
+
+/// Implementation of `read_line()` that reads from the process's
+/// standard input.
+fn read_line_from_stdin() -> Value {
+    let mut line = String::new();
+    match std::io::stdin().read_line(&mut line) {
+        Ok(_) => Value::ok(Value::new(Value_::String(strip_trailing_newline(line)))),
+        Err(e) => Value::err(Value::new(Value_::String(format!("{e}")))),
+    }
+}
+
+/// Implementation of `read_line()` for an nREPL session. Asks the
+/// connected client for input and blocks until it replies, while
+/// still honouring interrupts so a blocked eval can be cancelled.
+fn read_line_from_nrepl(
+    nrepl_stdin: &NReplStdin,
+    session: &Session,
+    receiver_value: &Value,
+) -> Result<Value, (RestoreValues, EvalError)> {
+    // Tell the client we are waiting for a line of input.
+    (nrepl_stdin.request_input)();
+
+    loop {
+        // Poll rather than block forever so an `interrupt` (or the
+        // client disconnecting) can wake us up.
+        if session.interrupted.load(Ordering::SeqCst) {
+            session.interrupted.store(false, Ordering::SeqCst);
+            return Err((
+                RestoreValues(vec![receiver_value.clone()]),
+                EvalError::Interrupted,
+            ));
+        }
+
+        let recv_result = nrepl_stdin
+            .input_rx
+            .lock()
+            .expect("nREPL stdin receiver poisoned")
+            .recv_timeout(Duration::from_millis(50));
+        match recv_result {
+            Ok(Some(line)) => {
+                return Ok(Value::ok(Value::new(Value_::String(
+                    strip_trailing_newline(line),
+                ))));
+            }
+            Ok(None) | Err(RecvTimeoutError::Disconnected) => {
+                // The client signalled end-of-input, or the connection
+                // closed. Report EOF as an empty line, matching what
+                // `read_line` returns on stdin EOF.
+                return Ok(Value::ok(Value::new(Value_::String(String::new()))));
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+        }
+    }
+}
+
 fn eval_built_in_call(
     env: &mut Env,
     kind: BuiltInFunctionKind,
@@ -2840,21 +2943,10 @@ fn eval_built_in_call(
                 arg_values,
             )?;
 
-            let mut line = String::new();
-            let v = match std::io::stdin().read_line(&mut line) {
-                Ok(_) => {
-                    // Remove trailing newline if present
-                    if line.ends_with('\n') {
-                        line.pop();
-                        if line.ends_with('\r') {
-                            line.pop();
-                        }
-                    }
-                    Value::ok(Value::new(Value_::String(line)))
-                }
-                Err(e) => {
-                    let s = Value::new(Value_::String(format!("{e}")));
-                    Value::err(s)
+            let v = match &session.stdin_mode {
+                StdinMode::ReadFromStdin => read_line_from_stdin(),
+                StdinMode::NRepl(nrepl_stdin) => {
+                    read_line_from_nrepl(nrepl_stdin, session, receiver_value)?
                 }
             };
 
@@ -7883,6 +7975,7 @@ mod tests {
         let session = Session {
             interrupted,
             stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+            stdin_mode: StdinMode::ReadFromStdin,
             start_time: Instant::now(),
             trace_exprs: false,
             pretty_print_json: true,
@@ -8392,6 +8485,7 @@ mod tests {
         let session = Session {
             interrupted,
             stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+            stdin_mode: StdinMode::ReadFromStdin,
             start_time: Instant::now(),
             trace_exprs: false,
             pretty_print_json: true,

--- a/src/json_session.rs
+++ b/src/json_session.rs
@@ -20,7 +20,7 @@ use crate::env::Env;
 use crate::eval::{
     eval, eval_tests_until_error, eval_toplevel_exprs_then_stop, eval_up_to,
     load_toplevel_items_with_stubs, push_test_stackframe, EvalError, EvalUpToErr, ExceptionInfo,
-    ExpressionState, Session, StdoutJsonFormat, StdoutStderrMode,
+    ExpressionState, Session, StdinMode, StdoutJsonFormat, StdoutStderrMode,
 };
 use crate::namespaces::NamespaceInfo;
 use crate::parser::ast::IdGenerator;
@@ -890,6 +890,7 @@ pub(crate) fn json_session(interrupted: Arc<AtomicBool>) {
     let session = Session {
         interrupted: Arc::clone(&interrupted),
         stdout_stderr_mode: StdoutStderrMode::WriteJson(StdoutJsonFormat::ReplSession),
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs: false,
         pretty_print_json,

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,8 @@ use test_runner::{run_sandboxed_tests_in_file, run_tests_in_files};
 use crate::diagnostics::{format_diagnostic, format_exception_with_stack, Severity};
 use crate::env::Env;
 use crate::eval::{
-    eval_toplevel_items, load_toplevel_items, EvalError, ExceptionInfo, Session, StdoutJsonFormat,
+    eval_toplevel_items, load_toplevel_items, EvalError, ExceptionInfo, Session, StdinMode,
+    StdoutJsonFormat,
 };
 use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::diagnostics::ErrorMessage;
@@ -470,6 +471,7 @@ fn main() {
             let session = Session {
                 interrupted: Arc::clone(&interrupted),
                 stdout_stderr_mode: StdoutStderrMode::WriteJson(StdoutJsonFormat::ReplSession),
+                stdin_mode: StdinMode::ReadFromStdin,
                 start_time: Instant::now(),
                 trace_exprs,
                 pretty_print_json: true,
@@ -746,6 +748,7 @@ fn reftest_eval_up_to(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs,
         pretty_print_json: true,
@@ -939,6 +942,7 @@ fn run_file(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs,
         pretty_print_json: false,

--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -30,7 +30,7 @@ use crate::diagnostics::format_exception_with_stack;
 use crate::env::Env;
 use crate::eval::{
     eval_toplevel_exprs_then_stop, load_toplevel_items_with_stubs, EvalError, ExceptionInfo,
-    Session, StdoutStderrMode,
+    NReplStdin, Session, StdinMode, StdoutStderrMode,
 };
 use crate::namespaces::NamespaceInfo;
 use crate::parser::ast::{IdGenerator, SymbolName};
@@ -691,6 +691,10 @@ enum SessionRequest {
 struct SessionState {
     request_tx: Sender<SessionRequest>,
     interrupted: Arc<AtomicBool>,
+    /// Lines of input from the client, delivered to a `read_line()`
+    /// call blocked in the session's worker. `None` signals
+    /// end-of-input.
+    input_tx: Sender<Option<String>>,
 }
 
 /// State held for one client connection. Each connection may host
@@ -731,6 +735,7 @@ impl Connection {
     fn new_session(&mut self) -> String {
         let id = next_session_id(&mut self.next_id);
         let (request_tx, request_rx) = mpsc::channel();
+        let (input_tx, input_rx) = mpsc::channel::<Option<String>>();
         let interrupted = Arc::new(AtomicBool::new(false));
 
         self.interrupt_flags
@@ -751,6 +756,7 @@ impl Connection {
                     response_tx,
                     worker_interrupted,
                     temp_built_in_files,
+                    input_rx,
                 )
             })
             .expect("Could not spawn nREPL session worker");
@@ -760,6 +766,7 @@ impl Connection {
             SessionState {
                 request_tx,
                 interrupted,
+                input_tx,
             },
         );
         id
@@ -836,6 +843,62 @@ fn sigint_watchdog(
     }
 }
 
+/// Build the `Session` used while evaluating code for an nREPL
+/// request. Output is captured into `stdout_buf`/`stderr_buf` and
+/// `read_line()` requests input from the client.
+fn nrepl_session(
+    interrupted: &Arc<AtomicBool>,
+    stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
+    response_tx: &Sender<Value>,
+    base_msg: &HashMap<Vec<u8>, Value>,
+    input_rx: &Arc<Mutex<Receiver<Option<String>>>>,
+) -> Session {
+    // Captured by the `request_input` closure so a blocked
+    // `read_line()` can flush pending output and ask the client for a
+    // line.
+    let input_response_tx = response_tx.clone();
+    let input_base_msg = base_msg.clone();
+    let input_stdout_buf = Arc::clone(stdout_buf);
+    let input_stderr_buf = Arc::clone(stderr_buf);
+
+    let request_input = Box::new(move || {
+        // Flush any buffered output (e.g. a prompt printed just before
+        // the read) so the user sees it before being asked for input.
+        flush_output_buffer(
+            &input_stdout_buf,
+            b"out",
+            &input_response_tx,
+            &input_base_msg,
+        );
+        flush_output_buffer(
+            &input_stderr_buf,
+            b"err",
+            &input_response_tx,
+            &input_base_msg,
+        );
+
+        let mut msg = input_base_msg.clone();
+        msg.insert(b"status".to_vec(), Value::List(vec![bstr("need-input")]));
+        let _ = input_response_tx.send(Value::Dict(msg));
+    });
+
+    Session {
+        interrupted: Arc::clone(interrupted),
+        stdout_stderr_mode: StdoutStderrMode::WriteToNReplBuffers {
+            stdout_buf: Arc::clone(stdout_buf),
+            stderr_buf: Arc::clone(stderr_buf),
+        },
+        stdin_mode: StdinMode::NRepl(NReplStdin {
+            request_input,
+            input_rx: Arc::clone(input_rx),
+        }),
+        start_time: Instant::now(),
+        trace_exprs: false,
+        pretty_print_json: false,
+    }
+}
+
 /// Worker thread that owns the `Env` for a session and handles each
 /// session-bound op sequentially.
 fn session_worker(
@@ -843,59 +906,76 @@ fn session_worker(
     response_tx: Sender<Value>,
     interrupted: Arc<AtomicBool>,
     temp_built_in_files: Arc<Option<TempBuiltInFiles>>,
+    input_rx: Receiver<Option<String>>,
 ) {
     let id_gen = IdGenerator::default();
     let vfs = Vfs::default();
     let mut env = Env::new(id_gen, vfs);
 
+    // The receiver lives for the whole session; each `read_line()`
+    // shares it via the per-eval `Session`. Only this worker thread
+    // ever locks it.
+    let input_rx = Arc::new(Mutex::new(input_rx));
+
     while let Ok(req) = request_rx.recv() {
         // Clear any stray interrupt set while the session was idle.
         interrupted.store(false, Ordering::SeqCst);
-
-        let stdout_buf = Arc::new(Mutex::new(String::new()));
-        let stderr_buf = Arc::new(Mutex::new(String::new()));
-        let session = Session {
-            interrupted: Arc::clone(&interrupted),
-            stdout_stderr_mode: StdoutStderrMode::WriteToNReplBuffers {
-                stdout_buf: Arc::clone(&stdout_buf),
-                stderr_buf: Arc::clone(&stderr_buf),
-            },
-            start_time: Instant::now(),
-            trace_exprs: false,
-            pretty_print_json: false,
-        };
 
         let responses = match req {
             SessionRequest::Eval {
                 code,
                 base_msg,
                 print_opts,
-            } => handle_eval(
-                &code,
-                &mut env,
-                &session,
-                &stdout_buf,
-                &stderr_buf,
-                &response_tx,
-                &base_msg,
-                &print_opts,
-            ),
+            } => {
+                let stdout_buf = Arc::new(Mutex::new(String::new()));
+                let stderr_buf = Arc::new(Mutex::new(String::new()));
+                let session = nrepl_session(
+                    &interrupted,
+                    &stdout_buf,
+                    &stderr_buf,
+                    &response_tx,
+                    &base_msg,
+                    &input_rx,
+                );
+                handle_eval(
+                    &code,
+                    &mut env,
+                    &session,
+                    &stdout_buf,
+                    &stderr_buf,
+                    &response_tx,
+                    &base_msg,
+                    &print_opts,
+                )
+            }
             SessionRequest::LoadFile {
                 code,
                 file_path,
                 base_msg,
                 print_opts,
-            } => handle_load_file(
-                &code,
-                file_path.as_deref(),
-                &mut env,
-                &session,
-                &stdout_buf,
-                &stderr_buf,
-                &response_tx,
-                &base_msg,
-                &print_opts,
-            ),
+            } => {
+                let stdout_buf = Arc::new(Mutex::new(String::new()));
+                let stderr_buf = Arc::new(Mutex::new(String::new()));
+                let session = nrepl_session(
+                    &interrupted,
+                    &stdout_buf,
+                    &stderr_buf,
+                    &response_tx,
+                    &base_msg,
+                    &input_rx,
+                );
+                handle_load_file(
+                    &code,
+                    file_path.as_deref(),
+                    &mut env,
+                    &session,
+                    &stdout_buf,
+                    &stderr_buf,
+                    &response_tx,
+                    &base_msg,
+                    &print_opts,
+                )
+            }
             SessionRequest::Completions { prefix, base_msg } => {
                 handle_completions(&env, &prefix, &base_msg)
             }
@@ -1067,6 +1147,21 @@ const SUPPORTED_OPS: &[(&str, OpDescriptor)] = &[
         },
     ),
     (
+        "stdin",
+        OpDescriptor {
+            doc: "Send a line of standard input to a session whose eval is blocked reading input.",
+            requires: &[
+                ("stdin", "The input to send. An empty string signals end-of-input."),
+                (
+                    "session",
+                    "The ID of the session to send the input to.",
+                ),
+            ],
+            optional: &[],
+            returns: &[],
+        },
+    ),
+    (
         "lookup",
         OpDescriptor {
             doc: "Lookup symbol info.",
@@ -1101,6 +1196,15 @@ fn op_descriptor_to_value(d: &OpDescriptor) -> Value {
         (b"optional".to_vec(), to_dict(d.optional)),
         (b"returns".to_vec(), to_dict(d.returns)),
     ])
+}
+
+/// Whether a response dict carries a terminal `status` containing
+/// `done`.
+fn status_contains_done(d: &HashMap<Vec<u8>, Value>) -> bool {
+    match dict_get(d, "status") {
+        Some(Value::List(items)) => items.iter().any(|item| as_str(item) == Some("done")),
+        _ => false,
+    }
 }
 
 fn truthy(v: &Value) -> bool {
@@ -1216,6 +1320,31 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) {
             match session_id.and_then(|s| conn.sessions.get(s)) {
                 Some(s) => {
                     s.interrupted.store(true, Ordering::SeqCst);
+                    let mut msg = base;
+                    msg.insert(b"status".to_vec(), Value::List(vec![bstr("done")]));
+                    conn.send(Value::Dict(msg));
+                }
+                None => {
+                    let mut msg = base;
+                    msg.insert(
+                        b"status".to_vec(),
+                        Value::List(vec![bstr("done"), bstr("error"), bstr("unknown-session")]),
+                    );
+                    conn.send(Value::Dict(msg));
+                }
+            }
+        }
+        "stdin" => {
+            let session_id = dict_get(request, "session").and_then(as_str);
+            // An empty `stdin` string signals end-of-input; any other
+            // value is a line of input for a blocked `read_line()`.
+            let input = match dict_get(request, "stdin").and_then(as_str) {
+                Some(s) if !s.is_empty() => Some(s.to_owned()),
+                _ => None,
+            };
+            match session_id.and_then(|s| conn.sessions.get(s)) {
+                Some(s) => {
+                    let _ = s.input_tx.send(input);
                     let mut msg = base;
                     msg.insert(b"status".to_vec(), Value::List(vec![bstr("done")]));
                     conn.send(Value::Dict(msg));
@@ -1514,21 +1643,19 @@ pub(crate) fn reftest_nrepl(src: &str) {
     }
 
     // Each request produces exactly one terminal response — a
-    // message carrying a `status` field. Drain the channel until
-    // we've seen one per request so the fixture captures
-    // asynchronous worker responses too.
+    // message whose `status` field contains `done`. Drain the channel
+    // until we've seen one per request so the fixture captures
+    // asynchronous worker responses too. Non-terminal status messages
+    // (e.g. `need-input`) are captured but do not count.
     let mut responses = Vec::new();
     let mut status_seen = 0;
     while status_seen < request_count {
         let Ok(response) = rx.recv_timeout(Duration::from_secs(5)) else {
             break;
         };
-        let has_status = matches!(
-            &response,
-            Value::Dict(d) if d.contains_key(b"status".as_slice())
-        );
+        let is_done = matches!(&response, Value::Dict(d) if status_contains_done(d));
         responses.push(response);
-        if has_status {
+        if is_done {
             status_seen += 1;
         }
     }

--- a/src/run_code_blocks.rs
+++ b/src/run_code_blocks.rs
@@ -10,7 +10,9 @@ use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
 
 use crate::diagnostics::{format_diagnostic, format_exception_with_stack, Diagnostic};
 use crate::env::Env;
-use crate::eval::{eval_toplevel_items, load_toplevel_items, EvalError, Session, StdoutStderrMode};
+use crate::eval::{
+    eval_toplevel_items, load_toplevel_items, EvalError, Session, StdinMode, StdoutStderrMode,
+};
 use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::position::Position;
 use crate::parser::vfs::{to_abs_path, to_project_relative, Vfs};
@@ -234,6 +236,7 @@ fn eval_code_block(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::DoNotWrite,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs: false,
         pretty_print_json: false,

--- a/src/sandboxed_playground.rs
+++ b/src/sandboxed_playground.rs
@@ -9,7 +9,8 @@ use serde::Serialize;
 
 use crate::env::Env;
 use crate::eval::{
-    eval_toplevel_items, EvalError, ExceptionInfo, Session, StdoutJsonFormat, StdoutStderrMode,
+    eval_toplevel_items, EvalError, ExceptionInfo, Session, StdinMode, StdoutJsonFormat,
+    StdoutStderrMode,
 };
 use crate::parser::ast::IdGenerator;
 use crate::parser::parse_toplevel_items;
@@ -53,6 +54,7 @@ pub(crate) fn run_sandboxed_playground(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::WriteJson(StdoutJsonFormat::Playground),
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs,
         pretty_print_json: false,

--- a/src/test_files/nrepl/describe_non_verbose.jsonl
+++ b/src/test_files/nrepl/describe_non_verbose.jsonl
@@ -13,7 +13,8 @@
 //     "interrupt": {},
 //     "load-file": {},
 //     "lookup": {},
-//     "ls-sessions": {}
+//     "ls-sessions": {},
+//     "stdin": {}
 //   },
 //   "status": [
 //     "done"

--- a/src/test_files/nrepl/describe_verbose.jsonl
+++ b/src/test_files/nrepl/describe_verbose.jsonl
@@ -101,6 +101,15 @@
 //       "returns": {
 //         "sessions": "A list of all available session IDs."
 //       }
+//     },
+//     "stdin": {
+//       "doc": "Send a line of standard input to a session whose eval is blocked reading input.",
+//       "optional": {},
+//       "requires": {
+//         "session": "The ID of the session to send the input to.",
+//         "stdin": "The input to send. An empty string signals end-of-input."
+//       },
+//       "returns": {}
 //     }
 //   },
 //   "status": [

--- a/src/test_files/nrepl/eval_read_line.jsonl
+++ b/src/test_files/nrepl/eval_read_line.jsonl
@@ -1,0 +1,42 @@
+{ "op": "clone" }
+{ "op": "eval", "id": "e1", "session": "garden-1", "code": "read_line()" }
+// sleep 200
+{ "op": "stdin", "id": "s1", "session": "garden-1", "stdin": "Wilfred\n" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "new-session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "id": "e1",
+//   "session": "garden-1",
+//   "status": [
+//     "need-input"
+//   ]
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "id": "e1",
+//   "ns": "__user",
+//   "session": "garden-1",
+//   "value": "Ok(\"Wilfred\")"
+// }
+// {
+//   "id": "e1",
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "id": "s1",
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+

--- a/src/test_files/nrepl/interrupt_read_line.jsonl
+++ b/src/test_files/nrepl/interrupt_read_line.jsonl
@@ -1,0 +1,42 @@
+{ "op": "clone" }
+{ "op": "eval", "id": "e1", "session": "garden-1", "code": "read_line()" }
+// sleep 200
+{ "op": "interrupt", "id": "i1", "session": "garden-1" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "new-session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "id": "e1",
+//   "session": "garden-1",
+//   "status": [
+//     "need-input"
+//   ]
+// }
+// {
+//   "err": "Interrupted.\n",
+//   "id": "e1",
+//   "session": "garden-1"
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "id": "e1",
+//   "session": "garden-1",
+//   "status": [
+//     "done",
+//     "interrupted"
+//   ]
+// }
+// {
+//   "id": "i1",
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -14,7 +14,8 @@ use crate::parser::ast::{IdGenerator, ToplevelItem};
 use crate::parser::parse_toplevel_items;
 use crate::parser::vfs::Vfs;
 use crate::{
-    load_toplevel_items, parse_toplevel_items_or_die, Env, EvalError, Session, StdoutStderrMode,
+    load_toplevel_items, parse_toplevel_items_or_die, Env, EvalError, Session, StdinMode,
+    StdoutStderrMode,
 };
 
 #[derive(Serialize, Debug)]
@@ -50,6 +51,7 @@ fn sandboxed_tests_summary(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::DoNotWrite,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs: false,
         pretty_print_json: false,
@@ -295,6 +297,7 @@ pub(crate) fn run_tests_in_files(
     let session = Session {
         interrupted,
         stdout_stderr_mode: StdoutStderrMode::WriteDirectly,
+        stdin_mode: StdinMode::ReadFromStdin,
         start_time: Instant::now(),
         trace_exprs: false,
         pretty_print_json: false,


### PR DESCRIPTION
`read_line()` inside an nREPL eval read the server's own stdin and blocked the worker thread on an uninterruptible syscall. It now uses the standard nREPL `need-input`/`stdin` mechanism: the worker sends a `need-input` status, blocks on a per-session input channel fed by the new `stdin` op, and polls the interrupt flag so a blocked read can be cancelled. Other session types still read from process stdin.

An empty `stdin` string is treated as end-of-input. Adds reftests for reading a line and for interrupting a blocked read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBae5CUhrY1U2TSwByoEKg)_