### PR TITLE
Add nREPL ns-path op

### DIFF
--- a/src/nrepl.rs
+++ b/src/nrepl.rs
@@ -3,7 +3,8 @@
 //! Speaks the bencode wire format (via `serde_bencode`) and supports
 //! a small subset of the standard nREPL operations: `clone`,
 //! `describe`, `eval`, `load-file`, `completions`, `lookup`,
-//! `interrupt`, `close` and `ls-sessions`.
+//! `interrupt`, `close`, `ls-sessions` and the cider-nrepl `ns-path`
+//! op (used by `cider-find-ns`).
 //!
 //! Each session runs on its own worker thread so that `interrupt`
 //! requests can be handled while an `eval` is still in progress.
@@ -625,6 +626,40 @@ fn handle_lookup(
     vec![Value::Dict(msg)]
 }
 
+/// Build the `ns-path` response for a given namespace name. This is
+/// the cider-nrepl op used by `cider-find-ns` to jump to a
+/// namespace's source file. Garden identifies namespaces by their
+/// file path, so we look for a loaded namespace whose file stem
+/// matches `ns_name`.
+fn handle_ns_path(
+    env: &Env,
+    ns_name: &str,
+    base_msg: &HashMap<Vec<u8>, Value>,
+    temp_built_in_files: Option<&TempBuiltInFiles>,
+) -> Vec<Value> {
+    let mut msg = base_msg.clone();
+
+    let found = env.namespaces.values().find(|ns| {
+        ns.borrow()
+            .abs_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .is_some_and(|s| s == ns_name)
+    });
+
+    if let Some(ns) = found {
+        let ns_borrow = ns.borrow();
+        let abs_path = ns_borrow.abs_path.as_ref();
+        let file_path = temp_built_in_files
+            .and_then(|b| b.resolve(abs_path))
+            .unwrap_or_else(|| to_project_relative(abs_path, &env.project_root));
+        msg.insert(b"path".to_vec(), bstr(file_path.display().to_string()));
+    }
+
+    msg.insert(b"status".to_vec(), Value::List(vec![bstr("done")]));
+    vec![Value::Dict(msg)]
+}
+
 fn format_eval_error(e: &EvalError, env: &Env) -> (String, Option<&'static str>) {
     match e {
         EvalError::Exception(ExceptionInfo { position, message }) => (
@@ -683,6 +718,10 @@ enum SessionRequest {
     },
     Lookup {
         sym: String,
+        base_msg: HashMap<Vec<u8>, Value>,
+    },
+    NsPath {
+        ns: String,
         base_msg: HashMap<Vec<u8>, Value>,
     },
 }
@@ -902,6 +941,9 @@ fn session_worker(
             SessionRequest::Lookup { sym, base_msg } => {
                 handle_lookup(&env, &sym, &base_msg, temp_built_in_files.as_ref().as_ref())
             }
+            SessionRequest::NsPath { ns, base_msg } => {
+                handle_ns_path(&env, &ns, &base_msg, temp_built_in_files.as_ref().as_ref())
+            }
         };
         for r in responses {
             if response_tx.send(r).is_err() {
@@ -1081,6 +1123,24 @@ const SUPPORTED_OPS: &[(&str, OpDescriptor)] = &[
             returns: &[(
                 "info",
                 "A map of information about the symbol, including its name, namespace, file, line, column, arglists-str and doc.",
+            )],
+        },
+    ),
+    (
+        "ns-path",
+        OpDescriptor {
+            doc: "Return the file path of the source file that defines the given namespace. Used by cider-find-ns.",
+            requires: &[
+                ("ns", "The namespace whose source path should be returned."),
+                (
+                    "session",
+                    "The ID of the session in which the namespace should be looked up.",
+                ),
+            ],
+            optional: &[],
+            returns: &[(
+                "path",
+                "The path of the source file defining the namespace, if known.",
             )],
         },
     ),
@@ -1268,6 +1328,17 @@ fn handle_message(conn: &mut Connection, request: &HashMap<Vec<u8>, Value>) {
                 .to_owned();
             dispatch_to_session(conn, session_id, base, |base_msg| SessionRequest::Lookup {
                 sym,
+                base_msg,
+            });
+        }
+        "ns-path" => {
+            let session_id = dict_get(request, "session").and_then(as_str);
+            let ns = dict_get(request, "ns")
+                .and_then(as_str)
+                .unwrap_or("")
+                .to_owned();
+            dispatch_to_session(conn, session_id, base, |base_msg| SessionRequest::NsPath {
+                ns,
                 base_msg,
             });
         }

--- a/src/test_files/nrepl/describe_non_verbose.jsonl
+++ b/src/test_files/nrepl/describe_non_verbose.jsonl
@@ -13,7 +13,8 @@
 //     "interrupt": {},
 //     "load-file": {},
 //     "lookup": {},
-//     "ls-sessions": {}
+//     "ls-sessions": {},
+//     "ns-path": {}
 //   },
 //   "status": [
 //     "done"

--- a/src/test_files/nrepl/describe_verbose.jsonl
+++ b/src/test_files/nrepl/describe_verbose.jsonl
@@ -101,6 +101,17 @@
 //       "returns": {
 //         "sessions": "A list of all available session IDs."
 //       }
+//     },
+//     "ns-path": {
+//       "doc": "Return the file path of the source file that defines the given namespace. Used by cider-find-ns.",
+//       "optional": {},
+//       "requires": {
+//         "ns": "The namespace whose source path should be returned.",
+//         "session": "The ID of the session in which the namespace should be looked up."
+//       },
+//       "returns": {
+//         "path": "The path of the source file defining the namespace, if known."
+//       }
 //     }
 //   },
 //   "status": [

--- a/src/test_files/nrepl/ns_path_loaded_file.jsonl
+++ b/src/test_files/nrepl/ns_path_loaded_file.jsonl
@@ -1,0 +1,38 @@
+{ "op": "clone" }
+{ "op": "load-file", "session": "garden-1", "file": "fun helper(): Int { 1 }", "file-path": "/tmp/myns.gdn" }
+{ "op": "ns-path", "session": "garden-1", "ns": "myns" }
+{ "op": "ns-path", "session": "garden-1", "ns": "no_such_namespace" }
+
+// args: reftest-nrepl
+// expected stdout:
+// {
+//   "new-session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "eval-msec": "<eval-msec>",
+//   "ns": "myns",
+//   "session": "garden-1",
+//   "value": "()"
+// }
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "path": "/tmp/myns.gdn",
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }
+// {
+//   "session": "garden-1",
+//   "status": [
+//     "done"
+//   ]
+// }


### PR DESCRIPTION
Implements the cider-nrepl `ns-path` op in the nREPL server, so `cider-find-ns` works without loading additional middleware. The handler looks up a loaded namespace by its file stem and returns the source file path, resolving built-in files to their on-disk temp copies the same way `lookup` does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01THB3Hhdn8Qksy6XNWW9yEi)_